### PR TITLE
7903128: Overhaul jextract README

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ The `jextract` tool includes several customization options. Users can select in 
 
 | Option                                                       | Meaning                                                      |
 | :----------------------------------------------------------- | ------------------------------------------------------------ |
-| `--header-class-name <String>`                               | specify the name the main header class                       |
+| `--header-class-name <String>`                               | specify the name of the main header class                       |
 | `-t, --target-package <String>`                              | specify target package for the generated bindings            |
 | `-I <String>`                                                | specify include files path for the clang parser              |
 | `-l <String>`                                                | specify a library that will be loaded by the generated bindings |

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ### Getting started
 
-`jextract` depends on the [C libclang API](https://clang.llvm.org/doxygen/group__CINDEX.html). To build the jextract sources, the easiest option is to download LLVM binaries for your platform, which can be found [here](https://releases.llvm.org/download.html) (a version <= 9 is required). Both the `jextract` tool and the bindings it generates depend heavily on the [Foreign Function & Memory API](https://openjdk.java.net/jeps/419), so a suitable [jdk 18 distribution](https://jdk.java.net/18/) is also required.
+`jextract` depends on the [C libclang API](https://clang.llvm.org/doxygen/group__CINDEX.html). To build the jextract sources, the easiest option is to download LLVM binaries for your platform, which can be found [here](https://releases.llvm.org/download.html) (a version >= 9 is required). Both the `jextract` tool and the bindings it generates depend heavily on the [Foreign Function & Memory API](https://openjdk.java.net/jeps/419), so a suitable [jdk 18 distribution](https://jdk.java.net/18/) is also required.
 
 `jextract` can be built using `gradle`, as follows (on Windows, `gradlew.bat` should be used instead):
 

--- a/README.md
+++ b/README.md
@@ -116,14 +116,14 @@ The `jextract` tool includes several customization options. Users can select in 
 
 | Option                                                       | Meaning                                                      |
 | :----------------------------------------------------------- | ------------------------------------------------------------ |
-| `--header-class-name` <String>                               | specify the name the main header class                       |
-| `-t, --target-package` <String>                              | specify target package for the generated bindings            |
-| `-I` <String>                                                | specify include files path for the clang parser              |
-| `-l` <String>                                                | specify a library that will be loaded by the generated bindings |
-| `-d` <String>                                                | specify where to place generated files                       |
+| `--header-class-name <String>`                               | specify the name the main header class                       |
+| `-t, --target-package <String>`                              | specify target package for the generated bindings            |
+| `-I <String>`                                                | specify include files path for the clang parser              |
+| `-l <String>`                                                | specify a library that will be loaded by the generated bindings |
+| `-d <String>`                                                | specify where to place generated files                       |
 | `--source`                                                   | generate java sources instead of classfiles                  |
-| `--dump-includes` <String>                                   | dump included symbols into specified file (see below)        |
-| `--include-[function,macro,struct,union,typedef,var]` <String> | Include a symbol of the given name and kind in the generated bindings (see below). When one of these options is specified, any symbols that is not matched by any specified filters is omitted from the generated bindings. |
+| `--dump-includes <String>`                                   | dump included symbols into specified file (see below)        |
+| `--include-[function,macro,struct,union,typedef,var]<String>` | Include a symbol of the given name and kind in the generated bindings (see below). When one of these options is specified, any symbols that is not matched by any specified filters is omitted from the generated bindings. |
 
 #### Filtering symbols
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ The `jextract` tool includes several customization options. Users can select in 
 | `-d <String>`                                                | specify where to place generated files                       |
 | `--source`                                                   | generate java sources instead of classfiles                  |
 | `--dump-includes <String>`                                   | dump included symbols into specified file (see below)        |
-| `--include-[function,macro,struct,union,typedef,var]<String>` | Include a symbol of the given name and kind in the generated bindings (see below). When one of these options is specified, any symbols that is not matched by any specified filters is omitted from the generated bindings. |
+| `--include-[function,macro,struct,union,typedef,var]<String>` | Include a symbol of the given name and kind in the generated bindings (see below). When one of these options is specified, any symbol that is not matched by any specified filters is omitted from the generated bindings. |
 
 #### Filtering symbols
 

--- a/README.md
+++ b/README.md
@@ -22,24 +22,9 @@ build/jextract
     └── runtime
         ├── bin
         ├── conf
-        │   ├── jextract
-        │   ├── sdp
-        │   └── security
-        │       └── policy
-        │           ├── limited
-        │           └── unlimited
         ├── include
-        │   └── linux
         ├── legal
-        │   ├── java.base
-        │   ├── java.compiler
-        │   ├── java.prefs
-        │   ├── java.xml
-        │   ├── jdk.compiler
-        │   └── jdk.incubator.foreign
         └── lib
-            ├── security
-            └── server
 ```
 
 To run the `jextract` tool, simply run the `jextract` command in the `bin` folder:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ### Getting started
 
-`jextract` depends on the [C libclang API](https://clang.llvm.org/doxygen/group__CINDEX.html). To build the jextract sources, the easiest option is to download LLVM binaries for your platform, which can be found [here](https://releases.llvm.org/download.html). Both the `jextract` tool and the bindings it generates depend heavily on the [Foreign Function & Memory API](https://openjdk.java.net/jeps/419), so a suitable [jdk 18 distribution](https://jdk.java.net/18/) is also required.
+`jextract` depends on the [C libclang API](https://clang.llvm.org/doxygen/group__CINDEX.html). To build the jextract sources, the easiest option is to download LLVM binaries for your platform, which can be found [here](https://releases.llvm.org/download.html) (a version <= 9 is required). Both the `jextract` tool and the bindings it generates depend heavily on the [Foreign Function & Memory API](https://openjdk.java.net/jeps/419), so a suitable [jdk 18 distribution](https://jdk.java.net/18/) is also required.
 
 `jextract` can be built using `gradle`, as follows (on Windows, `gradlew.bat` should be used instead):
 
@@ -12,7 +12,7 @@
 $ sh ./gradlew -Pjdk18_home=<jdk18_home_dir> -Plibclang_home=<libclang_dir> clean verify
 ```
 
-After building, there should be a new `jextract` folder under `build` (the contents of this folder might vary depending on the platform):
+After building, there should be a new `jextract` folder under `build` (the contents and the name of this folder might vary slightly depending on the platform):
 
 ```
 build/jextract
@@ -27,7 +27,7 @@ build/jextract
         └── lib
 ```
 
-To run the `jextract` tool, simply run the `jextract` command in the `bin` folder:
+To run the `jextract` tool, simply run the `jextract` command in the `bin` folder (again, the exact location of the binary might vary slightly depending on the platform):
 
 ```sh
 build/jextract/bin/jextract 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ In other words, the `jextract` tool has generated all the required supporting co
 The `jextract` tool includes several customization options. Users can select in which package the generated code should be emitted, and what the name of the main extracted class should be. A complete list of all the supported options is given below:
 
 | Option                                                       | Meaning                                                      |
-| ------------------------------------------------------------ | ------------------------------------------------------------ |
+| :----------------------------------------------------------- | ------------------------------------------------------------ |
 | `--header-class-name` <String>                               | specify the name the main header class                       |
 | `-t, --target-package` <String>                              | specify target package for the generated bindings            |
 | `-I` <String>                                                | specify include files path for the clang parser              |
@@ -123,7 +123,7 @@ The `jextract` tool includes several customization options. Users can select in 
 | `-d` <String>                                                | specify where to place generated files                       |
 | `--source`                                                   | generate java sources instead of classfiles                  |
 | `--dump-includes` <String>                                   | dump included symbols into specified file (see below)        |
-| `--include-function` <String><br />`--include-macro` <String><br />`--include-struct` <String><br />`--include-union` <String><br />`--include-typedef` <String><br />`--include-var` <String> | Include a symbol of the given name and kind in the generated bindings (see below).<br />When one of these options is specified, any symbols that is not matched by any specified filters is omitted from the generated bindings. |
+| `--include-[function,macro,struct,union,typedef,var]` <String> | Include a symbol of the given name and kind in the generated bindings (see below). When one of these options is specified, any symbols that is not matched by any specified filters is omitted from the generated bindings. |
 
 #### Filtering symbols
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Jextract
 
-`jextract` is a tool which mechanically generates Java bindings from a native library headers. This tools leverages the [clang C API](https://clang.llvm.org/doxygen/group__CINDEX.html) in order to parse the headers associated to a given native library, and the generated Java bindings builds upon the [Foreign Function & Memory API](https://openjdk.java.net/jeps/419). The `jextract` tool was originally developed in the context of [Project Panama](https://openjdk.java.net/projects/panama/) (and then made available in the Project Panama [Early Access binaries](https://jdk.java.net/panama/)).
+`jextract` is a tool which mechanically generates Java bindings from a native library headers. This tools leverages the [clang C API](https://clang.llvm.org/doxygen/group__CINDEX.html) in order to parse the headers associated with a given native library, and the generated Java bindings build upon the [Foreign Function & Memory API](https://openjdk.java.net/jeps/419). The `jextract` tool was originally developed in the context of [Project Panama](https://openjdk.java.net/projects/panama/) (and then made available in the Project Panama [Early Access binaries](https://jdk.java.net/panama/)).
 
 ### Getting started
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 ## Jextract
 
-`jextract` is a tool that mechanically generates Java bindings from a native library headers. We would like to include this tool, originally developed in the context of [Project Panama](https://openjdk.java.net/projects/panama/) (and available in the Project Panama [Early Access binaries](https://jdk.java.net/panama/)) in the set of tools that are part of the code-tools project.
+`jextract` is a tool which mechanically generates Java bindings from a native library headers. This tools leverages the [clang C API](https://clang.llvm.org/doxygen/group__CINDEX.html) in order to parse the headers associated to a given native library, and the generated Java bindings builds upon the [Foreign Function & Memory API](https://openjdk.java.net/jeps/419). The `jextract` tool was originally developed in the context of [Project Panama](https://openjdk.java.net/projects/panama/) (and then made available in the Project Panama [Early Access binaries](https://jdk.java.net/panama/)).
 
 ### Getting started
 
-The jextract tool depends on the [C libclang API](https://clang.llvm.org/doxygen/group__CINDEX.html). To build the jextract sources, the easiest option is to download LLVM binaries for your platform, which can be found [here](https://releases.llvm.org/download.html). Both the jextract tool and the bindings it generates depend heavily on the [Foreign Function & Memory API](https://openjdk.java.net/jeps/419), so a suitable [jdk 18 distribution](https://jdk.java.net/18/) is also required.
+`jextract` depends on the [C libclang API](https://clang.llvm.org/doxygen/group__CINDEX.html). To build the jextract sources, the easiest option is to download LLVM binaries for your platform, which can be found [here](https://releases.llvm.org/download.html). Both the `jextract` tool and the bindings it generates depend heavily on the [Foreign Function & Memory API](https://openjdk.java.net/jeps/419), so a suitable [jdk 18 distribution](https://jdk.java.net/18/) is also required.
 
-The jextract tool can be built using `gradle`, as follows (on Windows, `gradlew.bat` should be used instead):
+`jextract` can be built using `gradle`, as follows (on Windows, `gradlew.bat` should be used instead):
 
 ```sh
 $ sh ./gradlew -Pjdk18_home=<jdk18_home_dir> -Plibclang_home=<libclang_dir> clean verify
@@ -42,7 +42,7 @@ build/jextract
             └── server
 ```
 
-To run jextract, simply run the `jextract` command in the `bin` folder:
+To run the `jextract` tool, simply run the `jextract` command in the `bin` folder:
 
 ```sh
 build/jextract/bin/jextract 
@@ -58,7 +58,7 @@ $ sh ./gradlew -Pjdk18_home=<jdk18_home_dir> -Plibclang_home=<libclang_dir> jtre
 
 ### Using jextract
 
-`jextract` is a tool that leverages the [clang C API](https://clang.llvm.org/doxygen/group__CINDEX.html) in order to parse the headers associated to a given native library and generate the Java glue code that is required to interact with said library. To understand how `jextract` works, consider the following C header file:
+To understand how `jextract` works, consider the following C header file:
 
 ```c
 //point.h
@@ -127,7 +127,7 @@ In other words, the `jextract` tool has generated all the required supporting co
 
 #### Filtering symbols
 
-The `jextract` tool includes several customization options. Users can select what in which package the generated code should be emitted, and what the name of the main extracted class should be. To allow for symbol filtering, jextract can generate a *dump* of all the symbols encountered in an header file; this dump can be manipulated, and then used as an argument file (using the `@argfile` syntax also available in other JDK tools) to e.g. generate bindings only for a *subset* of symbols seen by `jextract`. For instance, if we run `jextract` with as follows:
+The `jextract` tool includes several customization options. Users can select what in which package the generated code should be emitted, and what the name of the main extracted class should be. To allow for symbol filtering, `jextract` can generate a *dump* of all the symbols encountered in an header file; this dump can be manipulated, and then used as an argument file (using the `@argfile` syntax also available in other JDK tools) to e.g. generate bindings only for a *subset* of symbols seen by `jextract`. For instance, if we run `jextract` with as follows:
 
 ```
 jextract --dump-includes=includes.txt point.h
@@ -142,7 +142,7 @@ We obtain the following file (`includes.txt`):
 --include-function distance # header: point.h
 ```
 
-This file can be passed back to jextract, as follows:
+This file can be passed back to `jextract`, as follows:
 
 ```
 jextract -t org.jextract --source @includes.txt point.h

--- a/README.md
+++ b/README.md
@@ -110,9 +110,24 @@ public static double distance ( MemorySegment x0) {
 
 In other words, the `jextract` tool has generated all the required supporting code (`MemoryLayout`, `MethodHandle` and `FunctionDescriptor`) that is needed to call the underlying `distance` native function. For more examples on how to use the `jextract` tool with real-world libraries, please refer to the [samples folder](samples) (building/running particular sample may require specific third-party software installation).
 
+#### Command line options
+
+The `jextract` tool includes several customization options. Users can select in which package the generated code should be emitted, and what the name of the main extracted class should be. A complete list of all the supported options is given below:
+
+| Option                                                       | Meaning                                                      |
+| ------------------------------------------------------------ | ------------------------------------------------------------ |
+| `--header-class-name` <String>                               | specify the name the main header class                       |
+| `-t, --target-package` <String>                              | specify target package for the generated bindings            |
+| `-I` <String>                                                | specify include files path for the clang parser              |
+| `-l` <String>                                                | specify a library that will be loaded by the generated bindings |
+| `-d` <String>                                                | specify where to place generated files                       |
+| `--source`                                                   | generate java sources instead of classfiles                  |
+| `--dump-includes` <String>                                   | dump included symbols into specified file (see below)        |
+| `--include-function` <String><br />`--include-macro` <String><br />`--include-struct` <String><br />`--include-union` <String><br />`--include-typedef` <String><br />`--include-var` <String> | Include a symbol of the given name and kind in the generated bindings (see below).<br />When one of these options is specified, any symbols that is not matched by any specified filters is omitted from the generated bindings. |
+
 #### Filtering symbols
 
-The `jextract` tool includes several customization options. Users can select in which package the generated code should be emitted, and what the name of the main extracted class should be. To allow for symbol filtering, `jextract` can generate a *dump* of all the symbols encountered in an header file; this dump can be manipulated, and then used as an argument file (using the `@argfile` syntax also available in other JDK tools) to e.g. generate bindings only for a *subset* of symbols seen by `jextract`. For instance, if we run `jextract` with as follows:
+To allow for symbol filtering, `jextract` can generate a *dump* of all the symbols encountered in an header file; this dump can be manipulated, and then used as an argument file (using the `@argfile` syntax also available in other JDK tools) to e.g. generate bindings only for a *subset* of symbols seen by `jextract`. For instance, if we run `jextract` with as follows:
 
 ```
 jextract --dump-includes=includes.txt point.h

--- a/README.md
+++ b/README.md
@@ -1,67 +1,64 @@
-## jextract
+## Jextract
 
 `jextract` is a tool that mechanically generates Java bindings from a native library headers. We would like to include this tool, originally developed in the context of [Project Panama](https://openjdk.java.net/projects/panama/) (and available in the Project Panama [Early Access binaries](https://jdk.java.net/panama/)) in the set of tools that are part of the code-tools project.
 
-The Java SE 18 API defines an [incubating API](https://openjdk.java.net/jeps/419) to:
+### Getting started
 
-* manipulate foreign memory, that is memory which resides *outside* the Java heap; and
+The jextract tool depends on the [C libclang API](https://clang.llvm.org/doxygen/group__CINDEX.html). To build the jextract sources, the easiest option is to download LLVM binaries for your platform, which can be found [here](https://releases.llvm.org/download.html). Both the jextract tool and the bindings it generates depend heavily on the [Foreign Function & Memory API](https://openjdk.java.net/jeps/419), so a suitable [jdk 18 distribution](https://jdk.java.net/18/) is also required.
 
-* invoke foreign functions, that is functions whose implementation is not defined in Java.
+The jextract tool can be built using `gradle`, as follows (on Windows, `gradlew.bat` should be used instead):
 
-To allocate and access off-heap memory, clients can use the `MemorySegment` API. Memory segments can be associated with optional *layouts* (e.g `MemoryLayout`) which describe the contents of a given memory region and can be used to derive access expression e.g. into a struct field:
-
-```java
-// struct Point2d {
-//     double x;
-//     double y;
-// }
-MemoryLayout POINT_2D = MemoryLayout.structLayout(
-        ValueLayout.JAVA_DOUBLE.withName("x"),
-        ValueLayout.JAVA_DOUBLE.withName("y"),
-);
-
-VarHandle xHandle = POINT_2D.varHandle(PathElement.groupElement("x")); // var handle to access Point2d::x
-VarHandle yHandle = POINT_2D.varHandle(PathElement.groupElement("y")); // var handle to access Point2d::x
-
-MemorySegment segment = MemorySegment.allocateNative(POINT_2D, ReosurceScope.newImplicitScope());
-xHandle.set(segment, 3d);
-yHandle.set(segment, 4d);
+```sh
+$ sh ./gradlew -Pjdk18_home=<jdk18_home_dir> -Plibclang_home=<libclang_dir> clean verify
 ```
 
-Furthermore, clients can use the `CLinker` API to create a so called *downcall* method handle, that is, a method handle which targets a native function, directly:
+After building, there should be a new `jextract` folder under `build` (the contents of this folder might vary depending on the platform):
 
-```java
-// double distance(struct Point2d);
-MethodHandle distance = CLinker.systemCLinker().downcallHandle(
-                                    LibraryLookup.loaderLookup().lookup("distance").get()
-                                    FunctionDescriptor.of(ValueLayout.JAVA_DOUBLE, POINT_2D);
-distance.invoke(segment);
+```
+build/jextract
+├── bin
+└── lib
+    ├── app
+    └── runtime
+        ├── bin
+        ├── conf
+        │   ├── jextract
+        │   ├── sdp
+        │   └── security
+        │       └── policy
+        │           ├── limited
+        │           └── unlimited
+        ├── include
+        │   └── linux
+        ├── legal
+        │   ├── java.base
+        │   ├── java.compiler
+        │   ├── java.prefs
+        │   ├── java.xml
+        │   ├── jdk.compiler
+        │   └── jdk.incubator.foreign
+        └── lib
+            ├── security
+            └── server
 ```
 
-While the new APIs allow clients to manipulate off-heap memory and call native functions using only Java code (unlike JNI), handwriting the above code can be tedious and error-prone, especially when working with big libraries. For instance, inferring the layout of a struct is not an easy task, given that different platforms might have different size and alignment requirements, resulting in different padding bits inserted in the struct layout.
+To run jextract, simply run the `jextract` command in the `bin` folder:
 
-Indeed, when working with big libraries, it would be far more convenient to rely on some tool which:
+```sh
+build/jextract/bin/jextract 
+WARNING: Using incubator modules: jdk.incubator.foreign
+Expected a header file
+```
 
-* is able to parse the contents of the header file of a given native library;
-* identify the set of functions, structs and constant symbols that need to be generated;
-* for each of the symbols identified in the previous step, emit a Java binding using the Java 18 API.
+The repository also contains a comprehensive set of tests, written using the [jtreg](https://openjdk.java.net/jtreg/) test framework, which can be run as follows (again, on Windows, `gradlew.bat` should be used instead):
 
-In other word, to work with a given native library, a developer would have to point the tool to the header file(s) of said library; the tool will then generate a set of Java sources that the developer can check-in into the source code repository, and then update when required (e.g. when the native library is updated), by re-running the tool.
+```sh
+$ sh ./gradlew -Pjdk18_home=<jdk18_home_dir> -Plibclang_home=<libclang_dir> jtreg
+```
 
-### Description
+### Using jextract
 
-`jextract` is a tool that leverages the [clang C API](https://clang.llvm.org/doxygen/group__CINDEX.html) in order to parse the headers associated to a given native library and generate the Java glue code that is required to interact with said library. More specifically, jextract generates the following code:
-
-* for each native function, a downcall method handle constant is created and a small static method which wraps the downcall method handle invocation (`invokeExact`) is also generated;
-* for each global variable, some static accessor methods are generated, which can be used to get, set or retrieve the address of the global variable;
-* for each struct/union type, a `MemoryLayout` constant is generated, which describes the platform-specific layout of the struct/union. Moreover, for each struct/union, some static accessor methods for all fields in the struct/union are also generated. These accessors can be used to get, set or retrieve the address of a field in a given struct.
-* for each function pointer type mentioned in function signatures, global variables or struct/union field types, a new functional interface is emitted, together with a static factory method, which allows clients to create a function pointer (of type `MemoryAddress`) using a simple Java lambda expression, or a method reference;
-* for each constant defined using the  `#define`  directive, a numeric constant (of a suitable Java primitive type) or pointer constant (of type `MemoryAddress`) is generated;
-* for each enum constant, a numeric constant (of a suitable Java primitive type) is generated;
-* each `typedef` is visited recursively. If the entity being defined is a struct/union, then the struct/union is processed accordingly (see above). If the entity being defined is a function pointer, then the function pointer is processed accordingly (see above). If the `typedef` refers to a primitive type, an additional `MemoryLayout` constant is generated;
-* finally, a starter set of `MemoryLayout` constants (for each basic C type) is also generated.
-
-To understand how `jextract` works, consider the following C header file:
+`jextract` is a tool that leverages the [clang C API](https://clang.llvm.org/doxygen/group__CINDEX.html) in order to parse the headers associated to a given native library and generate the Java glue code that is required to interact with said library. To understand how `jextract` works, consider the following C header file:
 
 ```c
 //point.h
@@ -126,7 +123,9 @@ public static double distance ( MemorySegment x0) {
 }
 ```
 
-In other words, the `jextract` tool has generated all the required supporting code (`MemoryLayout`, `MethodHandle` and `FunctionDescriptor`) that is needed to call the underlying `distance` native function.
+In other words, the `jextract` tool has generated all the required supporting code (`MemoryLayout`, `MethodHandle` and `FunctionDescriptor`) that is needed to call the underlying `distance` native function. For more examples on how to use the `jextract` tool with real-world libraries, please refer to the [samples folder](samples) (building/running particular sample may require specific third-party software installation).
+
+#### Filtering symbols
 
 The `jextract` tool includes several customization options. Users can select what in which package the generated code should be emitted, and what the name of the main extracted class should be. To allow for symbol filtering, jextract can generate a *dump* of all the symbols encountered in an header file; this dump can be manipulated, and then used as an argument file (using the `@argfile` syntax also available in other JDK tools) to e.g. generate bindings only for a *subset* of symbols seen by `jextract`. For instance, if we run `jextract` with as follows:
 
@@ -151,42 +150,3 @@ jextract -t org.jextract --source @includes.txt point.h
 
 It is easy to see how this mechanism allows developers to look into the set of symbols seen by `jextract` while parsing, and then process the generated include file, so as to prevent code generation for otherwise unused symbols.
 
-For more examples on how to use the `jextract` tool with real-world libraries, please refer to this [document](https://github.com/openjdk/panama-foreign/blob/d8c0fe5918cb1c6c744eb26797ea4fa04142c237/doc/panama_jextract.md).
-
-
-### Building jextract tool
-
-jextract depends on clang+LLVM binaries. Please download and install clang+LLVM binaries for your platform.
-You can find the prebuilt binaries from [https://releases.llvm.org/download.html](https://releases.llvm.org/download.html). The path of the clang+LLVM installation is provided using the `libclang_home` variable.
-
-Gradle tool needs jdk 17 or below to run. JAVA_HOME should be set to
-jdk 17 or below. Or PATH should contain java from jdk 17 or below. jdk18 build is
-needed to build jextract which is passed from command with -Pjdk18_home option.
-
-You can download jdk18 early access build from [https://jdk.java.net/18/](https://jdk.java.net/18/)
-
-For Windows, please use gradlew.bat.
-
-```sh
-
-$ sh ./gradlew -Pjdk18_home=<jdk18_home_dir> -Plibclang_home=<libclang_dir> clean verify
-
-```
-
-### Testing jextract tool
-
-jextract tests are written for jtreg test framework. Please download and install jtreg binaries.
-The path of the jtreg installation is provided using the `jtreg_home` variable.
-
-For Windows, please use gradlew.bat.
-
-```sh
-
-$ sh ./gradlew -Pjdk18_home=<jdk18_home_dir> -Plibclang_home=<libclang_dir> -Pjtreg_home=<jtreg_dir> clean jtreg
-
-```
-
-### jextract samples
-
-jextract samples can be found "samples" top-level directory. Building/running particular sample may require
-specific third-party software installation.

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ In other words, the `jextract` tool has generated all the required supporting co
 
 #### Filtering symbols
 
-The `jextract` tool includes several customization options. Users can select what in which package the generated code should be emitted, and what the name of the main extracted class should be. To allow for symbol filtering, `jextract` can generate a *dump* of all the symbols encountered in an header file; this dump can be manipulated, and then used as an argument file (using the `@argfile` syntax also available in other JDK tools) to e.g. generate bindings only for a *subset* of symbols seen by `jextract`. For instance, if we run `jextract` with as follows:
+The `jextract` tool includes several customization options. Users can select in which package the generated code should be emitted, and what the name of the main extracted class should be. To allow for symbol filtering, `jextract` can generate a *dump* of all the symbols encountered in an header file; this dump can be manipulated, and then used as an argument file (using the `@argfile` syntax also available in other JDK tools) to e.g. generate bindings only for a *subset* of symbols seen by `jextract`. For instance, if we run `jextract` with as follows:
 
 ```
 jextract --dump-includes=includes.txt point.h


### PR DESCRIPTION
I've improved the README file, by putting the expanding the build section, and putting it more front and center.
I have also streamlined the remaining contents a little, and removed the parts that were describing the foreign API (not really needed here).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [CODETOOLS-7903128](https://bugs.openjdk.java.net/browse/CODETOOLS-7903128): Overhaul jextract README


### Reviewers
 * [Athijegannathan Sundararajan](https://openjdk.java.net/census#sundar) (@sundararajana - no project role) ⚠️ Review applies to b2b97d165dda58054bfa4ffb633773f7a1040272
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - no project role) ⚠️ Review applies to a64355175f1a8820f004fca3b2adbd79d788a8fa


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jextract pull/3/head:pull/3` \
`$ git checkout pull/3`

Update a local copy of the PR: \
`$ git checkout pull/3` \
`$ git pull https://git.openjdk.java.net/jextract pull/3/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3`

View PR using the GUI difftool: \
`$ git pr show -t 3`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jextract/pull/3.diff">https://git.openjdk.java.net/jextract/pull/3.diff</a>

</details>
