### PR TITLE
7903129: jextract does not handle @argfile

### DIFF
--- a/src/main/java/org/openjdk/jextract/JextractTool.java
+++ b/src/main/java/org/openjdk/jextract/JextractTool.java
@@ -26,6 +26,7 @@
 package org.openjdk.jextract;
 
 import org.openjdk.jextract.impl.ClangException;
+import org.openjdk.jextract.impl.CommandLine;
 import org.openjdk.jextract.impl.IncludeHelper;
 import org.openjdk.jextract.impl.OutputFactory;
 import org.openjdk.jextract.impl.Parser;
@@ -44,6 +45,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.text.MessageFormat;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.ResourceBundle;
@@ -172,6 +174,16 @@ public final class JextractTool {
     }
 
     private int run(String[] args) {
+        try {
+            args = CommandLine.parse(Arrays.asList(args)).toArray(new String[0]);
+        } catch (IOException ioexp) {
+            err.println(format("argfile.read.error", ioexp));
+            if (JextractTool.DEBUG) {
+                ioexp.printStackTrace(err);
+            }
+            return OPTION_ERROR;
+        }
+
         OptionParser parser = new OptionParser(false);
         parser.accepts("C", format("help.C")).withRequiredArg();
         parser.accepts("I", format("help.I")).withRequiredArg();

--- a/src/main/resources/org/openjdk/jextract/impl/resources/Messages.properties
+++ b/src/main/resources/org/openjdk/jextract/impl/resources/Messages.properties
@@ -22,6 +22,7 @@
 #
 
 # error message
+argfile.read.error=reading @argfile failed: {0}
 cannot.read.header.file=cannot read header file: {0}
 not.a.file=not a file: {0}
 l.option.value.invalid=option value for -l option should be a name or an absolute path

--- a/test/java/org/openjdk/jextract/test/toolprovider/JextractToolProviderTest.java
+++ b/test/java/org/openjdk/jextract/test/toolprovider/JextractToolProviderTest.java
@@ -39,6 +39,14 @@ public class JextractToolProviderTest extends JextractToolRunner {
         run("-?").checkSuccess();
     }
 
+    // error for non-existent args file
+    @Test
+    public void testNonExistentArgsFile() {
+        run("@non_existent_args")
+            .checkFailure(OPTION_ERROR)
+            .checkContainsOutput("reading @argfile failed");
+    }
+
     // error for non-existent header file
     @Test
     public void testNonExistentHeader() {
@@ -90,6 +98,20 @@ public class JextractToolProviderTest extends JextractToolRunner {
             assertNotNull(findMethod(cls, "func", int.class));
             // check a method for "int printf(MemoryAddress, Object[])"
             assertNotNull(findMethod(cls, "printf", Addressable.class, Object[].class));
+        } finally {
+            TestUtils.deleteDir(helloOutput);
+        }
+    }
+
+    @Test
+    public void testArgsFile() {
+        Path helloOutput = getOutputFilePath("hellogen");
+        run("-d", helloOutput.toString(),
+            "@" + getInputFilePath("helloargs").toString(),
+            getInputFilePath("hello.h").toString()).checkSuccess();
+        try(TestUtils.Loader loader = TestUtils.classLoader(helloOutput)) {
+            Class<?> cls = loader.loadClass("com.acme.hello_h");
+            assertNotNull(cls);
         } finally {
             TestUtils.deleteDir(helloOutput);
         }

--- a/test/java/org/openjdk/jextract/test/toolprovider/helloargs
+++ b/test/java/org/openjdk/jextract/test/toolprovider/helloargs
@@ -1,0 +1,1 @@
+-t com.acme


### PR DESCRIPTION
Missed CommandLine.parse call in JextractTool.run method.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [CODETOOLS-7903129](https://bugs.openjdk.java.net/browse/CODETOOLS-7903129): jextract does not handle @argfile


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jextract pull/4/head:pull/4` \
`$ git checkout pull/4`

Update a local copy of the PR: \
`$ git checkout pull/4` \
`$ git pull https://git.openjdk.java.net/jextract pull/4/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4`

View PR using the GUI difftool: \
`$ git pr show -t 4`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jextract/pull/4.diff">https://git.openjdk.java.net/jextract/pull/4.diff</a>

</details>
