### PR TITLE
7903132: Replace casts with type test pattern

### DIFF
--- a/src/main/java/org/openjdk/jextract/clang/Cursor.java
+++ b/src/main/java/org/openjdk/jextract/clang/Cursor.java
@@ -237,10 +237,8 @@ public final class Cursor {
         if (this == other) {
             return true;
         }
-        if (!(other instanceof Cursor otherCursor)) {
-            return false;
-        }
-        return (Index_h.clang_equalCursors(cursor, otherCursor.cursor) != 0);
+        return other instanceof Cursor otherCursor &&
+                (Index_h.clang_equalCursors(cursor, otherCursor.cursor) != 0);
     }
 
     @Override

--- a/src/main/java/org/openjdk/jextract/clang/Cursor.java
+++ b/src/main/java/org/openjdk/jextract/clang/Cursor.java
@@ -237,10 +237,10 @@ public final class Cursor {
         if (this == other) {
             return true;
         }
-        if (!(other instanceof Cursor)) {
+        if (!(other instanceof Cursor otherCursor)) {
             return false;
         }
-        return (Index_h.clang_equalCursors(cursor, ((Cursor)other).cursor) != 0);
+        return (Index_h.clang_equalCursors(cursor, otherCursor.cursor) != 0);
     }
 
     @Override

--- a/src/main/java/org/openjdk/jextract/clang/SourceLocation.java
+++ b/src/main/java/org/openjdk/jextract/clang/SourceLocation.java
@@ -91,10 +91,9 @@ public class SourceLocation {
         if (this == other) {
             return true;
         }
-        if (!(other instanceof SourceLocation)) {
+        if (!(other instanceof SourceLocation sloc)) {
             return false;
         }
-        SourceLocation sloc = (SourceLocation)other;
         return Objects.equals(getFileLocation(), sloc.getFileLocation());
     }
 
@@ -142,10 +141,9 @@ public class SourceLocation {
             if (this == other) {
                 return true;
             }
-            if (!(other instanceof Location)) {
+            if (!(other instanceof Location loc)) {
                 return false;
             }
-            Location loc = (Location)other;
             return Objects.equals(path, loc.path) &&
                 line == loc.line && column == loc.column &&
                 offset == loc.offset;

--- a/src/main/java/org/openjdk/jextract/clang/SourceLocation.java
+++ b/src/main/java/org/openjdk/jextract/clang/SourceLocation.java
@@ -91,10 +91,8 @@ public class SourceLocation {
         if (this == other) {
             return true;
         }
-        if (!(other instanceof SourceLocation sloc)) {
-            return false;
-        }
-        return Objects.equals(getFileLocation(), sloc.getFileLocation());
+        return other instanceof SourceLocation sloc &&
+                Objects.equals(getFileLocation(), sloc.getFileLocation());
     }
 
     @Override
@@ -141,10 +139,8 @@ public class SourceLocation {
             if (this == other) {
                 return true;
             }
-            if (!(other instanceof Location loc)) {
-                return false;
-            }
-            return Objects.equals(path, loc.path) &&
+            return other instanceof Location loc &&
+                Objects.equals(path, loc.path) &&
                 line == loc.line && column == loc.column &&
                 offset == loc.offset;
         }

--- a/src/main/java/org/openjdk/jextract/clang/Type.java
+++ b/src/main/java/org/openjdk/jextract/clang/Type.java
@@ -188,10 +188,7 @@ public final class Type {
         if (this == other) {
             return true;
         }
-        if (!(other instanceof Type type)) {
-            return false;
-        }
-        return equalType(type);
+        return other instanceof Type type && equalType(type);
     }
 
     @Override

--- a/src/main/java/org/openjdk/jextract/clang/Type.java
+++ b/src/main/java/org/openjdk/jextract/clang/Type.java
@@ -188,10 +188,10 @@ public final class Type {
         if (this == other) {
             return true;
         }
-        if (!(other instanceof Type)) {
+        if (!(other instanceof Type type)) {
             return false;
         }
-        return equalType((Type) other);
+        return equalType(type);
     }
 
     @Override

--- a/src/main/java/org/openjdk/jextract/impl/ClassSourceBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/ClassSourceBuilder.java
@@ -56,7 +56,8 @@ abstract class ClassSourceBuilder extends JavaSourceBuilder {
 
     ClassSourceBuilder(JavaSourceBuilder enclosing, Kind kind, String name) {
         this.enclosing = enclosing;
-        this.align = (enclosing instanceof ClassSourceBuilder enclosing) ? enclosing.align : 0;
+        this.align = (enclosing instanceof ClassSourceBuilder classSourceBuilder)
+                ? classSourceBuilder.align : 0;
         this.kind = kind;
         this.desc = ClassDesc.of(enclosing.packageName(), enclosing.uniqueNestedClassName(name));
     }

--- a/src/main/java/org/openjdk/jextract/impl/ClassSourceBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/ClassSourceBuilder.java
@@ -56,8 +56,7 @@ abstract class ClassSourceBuilder extends JavaSourceBuilder {
 
     ClassSourceBuilder(JavaSourceBuilder enclosing, Kind kind, String name) {
         this.enclosing = enclosing;
-        this.align = (enclosing instanceof ClassSourceBuilder) ?
-            ((ClassSourceBuilder) enclosing).align : 0;
+        this.align = (enclosing instanceof ClassSourceBuilder enclosing) ? enclosing.align : 0;
         this.kind = kind;
         this.desc = ClassDesc.of(enclosing.packageName(), enclosing.uniqueNestedClassName(name));
     }
@@ -222,8 +221,8 @@ abstract class ClassSourceBuilder extends JavaSourceBuilder {
 
     ToplevelBuilder toplevel() {
         JavaSourceBuilder encl = enclosing;
-        while (encl instanceof ClassSourceBuilder) {
-            encl = ((ClassSourceBuilder) encl).enclosing;
+        while (encl instanceof ClassSourceBuilder classSourceBuilder) {
+            encl = classSourceBuilder.enclosing;
         }
         return (ToplevelBuilder)encl;
     }

--- a/src/main/java/org/openjdk/jextract/impl/DeclarationImpl.java
+++ b/src/main/java/org/openjdk/jextract/impl/DeclarationImpl.java
@@ -89,8 +89,7 @@ public abstract class DeclarationImpl implements Declaration {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof Declaration)) return false;
-        Declaration decl = (Declaration) o;
+        if (!(o instanceof Declaration decl)) return false;
         return name().equals(decl.name());
     }
 
@@ -130,9 +129,7 @@ public abstract class DeclarationImpl implements Declaration {
         @Override
         public boolean equals(Object o) {
             if (this == o) return true;
-            if (!(o instanceof Declaration.Typedef)) return false;
-
-            Declaration.Typedef other = (Declaration.Typedef) o;
+            if (!(o instanceof Declaration.Typedef other)) return false;
             return name().equals(other.name()) &&
                     type.equals(other.type());
         }
@@ -197,9 +194,7 @@ public abstract class DeclarationImpl implements Declaration {
         @Override
         public boolean equals(Object o) {
             if (this == o) return true;
-            if (!(o instanceof Declaration.Variable)) return false;
-
-            Declaration.Variable variable = (Declaration.Variable) o;
+            if (!(o instanceof Declaration.Variable variable)) return false;
             if (!super.equals(o)) return false;
             return kind == variable.kind() &&
                     type.equals(variable.type());
@@ -254,10 +249,8 @@ public abstract class DeclarationImpl implements Declaration {
         @Override
         public boolean equals(Object o) {
             if (this == o) return true;
-            if (!(o instanceof Declaration.Function)) return false;
+            if (!(o instanceof Declaration.Function function)) return false;
             if (!super.equals(o)) return false;
-
-            Declaration.Function function = (Declaration.Function) o;
             return type.equals(function.type());
         }
 
@@ -322,9 +315,8 @@ public abstract class DeclarationImpl implements Declaration {
         @Override
         public boolean equals(Object o) {
             if (this == o) return true;
-            if (!(o instanceof Declaration.Scoped)) return false;
+            if (!(o instanceof Declaration.Scoped scoped)) return false;
             if (!super.equals(o)) return false;
-            Declaration.Scoped scoped = (Declaration.Scoped) o;
             return kind == scoped.kind() &&
                     declarations.equals(scoped.members());
         }
@@ -378,9 +370,8 @@ public abstract class DeclarationImpl implements Declaration {
         @Override
         public boolean equals(Object o) {
             if (this == o) return true;
-            if (!(o instanceof Declaration.Constant)) return false;
+            if (!(o instanceof Declaration.Constant constant)) return false;
             if (!super.equals(o)) return false;
-            Declaration.Constant constant = (Declaration.Constant) o;
             return value.equals(constant.value()) &&
                     type.equals(constant.type());
         }

--- a/src/main/java/org/openjdk/jextract/impl/DeclarationImpl.java
+++ b/src/main/java/org/openjdk/jextract/impl/DeclarationImpl.java
@@ -88,9 +88,10 @@ public abstract class DeclarationImpl implements Declaration {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof Declaration decl)) return false;
-        return name().equals(decl.name());
+        if (this == o) {
+            return true;
+        }
+        return o instanceof Declaration decl && name().equals(decl.name());
     }
 
     @Override
@@ -129,8 +130,8 @@ public abstract class DeclarationImpl implements Declaration {
         @Override
         public boolean equals(Object o) {
             if (this == o) return true;
-            if (!(o instanceof Declaration.Typedef other)) return false;
-            return name().equals(other.name()) &&
+            return o instanceof Declaration.Typedef other &&
+                    name().equals(other.name()) &&
                     type.equals(other.type());
         }
 

--- a/src/main/java/org/openjdk/jextract/impl/MacroParserImpl.java
+++ b/src/main/java/org/openjdk/jextract/impl/MacroParserImpl.java
@@ -79,10 +79,10 @@ class MacroParserImpl {
      * back to use clang evaluation support.
      */
     Optional<Declaration.Constant> parseConstant(Position pos, String name, String[] tokens) {
-        if (!(pos instanceof TreeMaker.CursorPosition)) {
+        if (!(pos instanceof TreeMaker.CursorPosition cursorPosition)) {
             return Optional.empty();
         } else {
-            Cursor cursor = ((TreeMaker.CursorPosition)pos).cursor();
+            Cursor cursor = cursorPosition.cursor();
             if (cursor.isMacroFunctionLike()) {
                 return Optional.empty();
             } else if (tokens.length == 2) {

--- a/src/main/java/org/openjdk/jextract/impl/OutputFactory.java
+++ b/src/main/java/org/openjdk/jextract/impl/OutputFactory.java
@@ -282,14 +282,14 @@ public class OutputFactory implements Declaration.Visitor<Void, Declaration> {
     }
 
     Type.Function getAsFunctionPointer(Type type) {
-        if (type instanceof Type.Function) {
+        if (type instanceof Type.Function function) {
             /*
              * // pointer to function declared as function like this
              *
              * typedef void CB(int);
              * void func(CB cb);
              */
-            return (Type.Function) type;
+            return function;
         } else if (Utils.isPointerType(type)) {
             return getAsFunctionPointer(((Type.Delegated)type).type());
         } else {
@@ -303,8 +303,8 @@ public class OutputFactory implements Declaration.Visitor<Void, Declaration> {
             return null;
         }
         Type type = tree.type();
-        if (type instanceof Type.Declared) {
-            Declaration.Scoped s = ((Type.Declared) type).tree();
+        if (type instanceof Type.Declared declared) {
+            Declaration.Scoped s = declared.tree();
             if (!s.name().equals(tree.name())) {
                 switch (s.kind()) {
                     case STRUCT, UNION -> {
@@ -366,9 +366,9 @@ public class OutputFactory implements Declaration.Visitor<Void, Declaration> {
 
         Type type = tree.type();
 
-        if (type instanceof Type.Declared) {
+        if (type instanceof Type.Declared declared) {
             // declared type - visit declaration recursively
-            ((Type.Declared) type).tree().accept(this, tree);
+            declared.tree().accept(this, tree);
         }
         MemoryLayout layout = tree.layout().orElse(Type.layoutFor(type).orElse(null));
         if (layout == null) {
@@ -459,11 +459,10 @@ public class OutputFactory implements Declaration.Visitor<Void, Declaration> {
     }
 
     protected static MemoryLayout layoutFor(Declaration decl) {
-        if (decl instanceof Declaration.Typedef) {
-            Declaration.Typedef alias = (Declaration.Typedef) decl;
+        if (decl instanceof Declaration.Typedef alias) {
             return Type.layoutFor(alias.type()).orElseThrow();
-        } else if (decl instanceof Declaration.Scoped) {
-            return ((Declaration.Scoped) decl).layout().orElseThrow();
+        } else if (decl instanceof Declaration.Scoped scoped) {
+            return scoped.layout().orElseThrow();
         } else {
             throw new IllegalArgumentException("Unexpected parent declaration");
         }

--- a/src/main/java/org/openjdk/jextract/impl/ToplevelBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/ToplevelBuilder.java
@@ -110,9 +110,9 @@ class ToplevelBuilder extends JavaSourceBuilder {
 
     @Override
     public void addTypedef(String name, String superClass, Type type) {
-        if (type instanceof Type.Primitive) {
+        if (type instanceof Type.Primitive primitive) {
             // primitive
-            nextHeader().emitPrimitiveTypedef((Type.Primitive)type, name);
+            nextHeader().emitPrimitiveTypedef(primitive, name);
         } else if (((TypeImpl)type).isPointer()) {
             // pointer typedef
             nextHeader().emitPointerTypedef(name);

--- a/src/main/java/org/openjdk/jextract/impl/TreeMaker.java
+++ b/src/main/java/org/openjdk/jextract/impl/TreeMaker.java
@@ -231,11 +231,13 @@ class TreeMaker {
     }
 
     private static boolean isEnum(Declaration d) {
-        return d instanceof Declaration.Scoped && ((Declaration.Scoped)d).kind() == Declaration.Scoped.Kind.ENUM;
+        return d instanceof Declaration.Scoped scoped &&
+                scoped.kind() == Declaration.Scoped.Kind.ENUM;
     }
 
     private static boolean isBitfield(Declaration d) {
-        return d instanceof Declaration.Scoped && ((Declaration.Scoped)d).kind() == Declaration.Scoped.Kind.BITFIELDS;
+        return d instanceof Declaration.Scoped scoped &&
+                scoped.kind() == Declaration.Scoped.Kind.BITFIELDS;
     }
 
     private static boolean isAnonymousStruct(Declaration declaration) {
@@ -252,8 +254,8 @@ class TreeMaker {
     private Declaration.Typedef createTypedef(Cursor c) {
         Type cursorType = toType(c);
         Type canonicalType = canonicalType(cursorType);
-        if (canonicalType instanceof Type.Declared) {
-            Declaration.Scoped s = ((Type.Declared) canonicalType).tree();
+        if (canonicalType instanceof Type.Declared declaredCanonicalType) {
+            Declaration.Scoped s = declaredCanonicalType.tree();
             if (s.name().equals(c.spelling())) {
                 // typedef record with the same name, no need to present twice
                 return null;
@@ -261,8 +263,8 @@ class TreeMaker {
         }
         Type.Function funcType = null;
         boolean isFuncPtrType = false;
-        if (canonicalType instanceof Type.Function) {
-            funcType = (Type.Function)canonicalType;
+        if (canonicalType instanceof Type.Function canonicalFunctionType) {
+            funcType = canonicalFunctionType;
         } else if (Utils.isPointerType(canonicalType)) {
             Type pointeeType = null;
             try {
@@ -270,8 +272,8 @@ class TreeMaker {
             } catch (NullPointerException npe) {
                 // exception thrown for unresolved pointee type. Ignore if we hit that case.
             }
-            if (pointeeType instanceof Type.Function) {
-                funcType = (Type.Function)pointeeType;
+            if (pointeeType instanceof Type.Function pointeeFunctionType) {
+                funcType = pointeeFunctionType;
                 isFuncPtrType = true;
             }
         }

--- a/src/main/java/org/openjdk/jextract/impl/TypeImpl.java
+++ b/src/main/java/org/openjdk/jextract/impl/TypeImpl.java
@@ -89,10 +89,9 @@ public abstract class TypeImpl implements Type {
         @Override
         public boolean equals(Object o) {
             if (this == o) return true;
-            if (!(o instanceof Type.Primitive)) {
-                return (o instanceof Delegated) && equals(this, (Delegated)o);
+            if (!(o instanceof Type.Primitive primitive)) {
+                return (o instanceof Delegated delegated) && equals(this, delegated);
             }
-            Type.Primitive primitive = (Type.Primitive) o;
             return kind == primitive.kind();
         }
 
@@ -129,12 +128,11 @@ public abstract class TypeImpl implements Type {
         @Override
         public boolean equals(Object o) {
             if (this == o) return true;
-            if (!(o instanceof Type.Delegated)) {
-                return (o instanceof Type) && equals((Type)o, this);
+            if (!(o instanceof Type.Delegated delegated)) {
+                return (o instanceof Type type) && equals(type, this);
             }
-            Type.Delegated that = (Type.Delegated) o;
-            return kind == that.kind() &&
-                    name.equals(that.name());
+            return kind == delegated.kind() &&
+                    name.equals(delegated.name());
         }
 
         @Override
@@ -167,11 +165,10 @@ public abstract class TypeImpl implements Type {
         @Override
         public boolean equals(Object o) {
             if (this == o) return true;
-            if (!(o instanceof Type.Delegated)) return false;
+            if (!(o instanceof Type.Delegated qualified)) return false;
             if (!super.equals(o)) {
-                return (o instanceof Delegated) && equals(this, (Delegated) o);
+                return (o instanceof Delegated delegated) && equals(this, delegated);
             }
-            Type.Delegated qualified = (Type.Delegated) o;
             return Objects.equals(type, qualified.type());
         }
 
@@ -223,10 +220,9 @@ public abstract class TypeImpl implements Type {
         @Override
         public boolean equals(Object o) {
             if (this == o) return true;
-            if (!(o instanceof Type.Declared)) {
-                return (o instanceof Delegated) && equals(this, (Delegated) o);
+            if (!(o instanceof Type.Declared declared)) {
+                return (o instanceof Delegated delegated) && equals(this, delegated);
             }
-            Type.Declared declared = (Type.Declared) o;
             return declaration.equals(declared.tree());
         }
 
@@ -289,10 +285,9 @@ public abstract class TypeImpl implements Type {
         @Override
         public boolean equals(Object o) {
             if (this == o) return true;
-            if (!(o instanceof Type.Function)) {
-                return (o instanceof Delegated) && equals(this, (Delegated) o);
+            if (!(o instanceof Type.Function function)) {
+                return (o instanceof Delegated delegated) && equals(this, delegated);
             }
-            Type.Function function = (Type.Function) o;
             return varargs == function.varargs() &&
                     argtypes.equals(function.argumentTypes()) &&
                     restype.equals(function.returnType());
@@ -348,10 +343,9 @@ public abstract class TypeImpl implements Type {
         @Override
         public boolean equals(Object o) {
             if (this == o) return true;
-            if (!(o instanceof Type.Array)) {
-                return (o instanceof Delegated) && equals(this, (Delegated) o);
+            if (!(o instanceof Type.Array array)) {
+                return (o instanceof Delegated delegated) && equals(this, delegated);
             }
-            Type.Array array = (Type.Array) o;
             return kind == array.kind() &&
                     elemType.equals(array.elementType());
         }
@@ -399,11 +393,9 @@ public abstract class TypeImpl implements Type {
     }
 
     private static boolean isVoidType(org.openjdk.jextract.Type type) {
-        if (type instanceof org.openjdk.jextract.Type.Primitive) {
-            org.openjdk.jextract.Type.Primitive pt = (org.openjdk.jextract.Type.Primitive)type;
+        if (type instanceof org.openjdk.jextract.Type.Primitive pt) {
             return pt.kind() == org.openjdk.jextract.Type.Primitive.Kind.Void;
-        } else if (type instanceof org.openjdk.jextract.Type.Delegated) {
-            org.openjdk.jextract.Type.Delegated dt = (org.openjdk.jextract.Type.Delegated)type;
+        } else if (type instanceof org.openjdk.jextract.Type.Delegated dt) {
             return dt.kind() == org.openjdk.jextract.Type.Delegated.Kind.TYPEDEF? isVoidType(dt.type()) : false;
         }
         return false;

--- a/src/main/java/org/openjdk/jextract/impl/TypeMaker.java
+++ b/src/main/java/org/openjdk/jextract/impl/TypeMaker.java
@@ -247,8 +247,8 @@ class TypeMaker {
 
         @Override
         public Type visitDelegated(Type.Delegated t, Void aVoid) {
-            if (t.kind() == Delegated.Kind.TYPEDEF && t.type() instanceof Type.Array) {
-                return visitArray((Type.Array)t.type(), aVoid);
+            if (t.kind() == Delegated.Kind.TYPEDEF && t.type() instanceof Type.Array array) {
+                return visitArray(array, aVoid);
             }
             return visitType(t, aVoid);
         }

--- a/src/main/java/org/openjdk/jextract/impl/UnsupportedLayouts.java
+++ b/src/main/java/org/openjdk/jextract/impl/UnsupportedLayouts.java
@@ -86,8 +86,8 @@ public final class UnsupportedLayouts {
         @Override
         public String visitDeclared(Type.Declared t, Void unused) {
             for (Declaration d : t.tree().members()) {
-                if (d instanceof Declaration.Variable) {
-                    String unsupported = firstUnsupportedType(((Declaration.Variable) d).type());
+                if (d instanceof Declaration.Variable variable) {
+                    String unsupported = firstUnsupportedType(variable.type());
                     if (unsupported != null) {
                         return unsupported;
                     }

--- a/src/main/java/org/openjdk/jextract/impl/Utils.java
+++ b/src/main/java/org/openjdk/jextract/impl/Utils.java
@@ -324,8 +324,7 @@ class Utils {
     }
 
     static boolean isPointerType(org.openjdk.jextract.Type type) {
-        if (type instanceof Delegated) {
-            Delegated delegated = (Delegated) type;
+        if (type instanceof Delegated delegated) {
             return delegated.kind() == Delegated.Kind.POINTER;
         } else {
             return false;


### PR DESCRIPTION
Replaces a handful of casts following type tests with the equivalent pattern syntax.

I cannot create a matching issue, as I do not have an account on the bug tracker.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [CODETOOLS-7903132](https://bugs.openjdk.java.net/browse/CODETOOLS-7903132): Replace casts with type test pattern


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - Committer)
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jextract pull/5/head:pull/5` \
`$ git checkout pull/5`

Update a local copy of the PR: \
`$ git checkout pull/5` \
`$ git pull https://git.openjdk.java.net/jextract pull/5/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5`

View PR using the GUI difftool: \
`$ git pr show -t 5`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jextract/pull/5.diff">https://git.openjdk.java.net/jextract/pull/5.diff</a>

</details>
