### PR TITLE
7903134: Improve error reporting in jextract gradle build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .gradle
 **/build/
+.idea

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 `jextract` can be built using `gradle`, as follows (on Windows, `gradlew.bat` should be used instead):
 
 ```sh
-$ sh ./gradlew -Pjdk18_home=<jdk18_home_dir> -Plibclang_home=<libclang_dir> clean verify
+$ sh ./gradlew -Pjdk18_home=<jdk18_home_dir> -Pllvm_home=<libclang_dir> clean verify
 ```
 
 After building, there should be a new `jextract` folder under `build` (the contents and the name of this folder might vary slightly depending on the platform):
@@ -38,7 +38,7 @@ Expected a header file
 The repository also contains a comprehensive set of tests, written using the [jtreg](https://openjdk.java.net/jtreg/) test framework, which can be run as follows (again, on Windows, `gradlew.bat` should be used instead):
 
 ```sh
-$ sh ./gradlew -Pjdk18_home=<jdk18_home_dir> -Plibclang_home=<libclang_dir> jtreg
+$ sh ./gradlew -Pjdk18_home=<jdk18_home_dir> -Pllvm_home=<libclang_dir> jtreg
 ```
 
 ### Using jextract

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,6 @@
 import org.apache.tools.ant.taskdefs.condition.Os
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 plugins {
     id "java"
@@ -10,8 +12,21 @@ plugins {
 
 version = '1.0'
 
+def static checkPath(String p) {
+    if (!Files.exists(Path.of(p))) {
+        throw new IllegalArgumentException("Error: the path ${p} does not exist");
+    }
+}
+
 def libclang_home = project.property("libclang_home")
-def clang_version = new File("${libclang_home}/lib/clang/").list()[0]
+checkPath(libclang_home)
+checkPath("${libclang_home}/lib/clang")
+def clang_versions = new File("${libclang_home}/lib/clang/").list();
+if (clang_versions.length == 0) {
+    throw new IllegalArgumentException("Could not detect clang version." +
+            " Make sure a ${libclang_home}/lib/clang/<VERSION> directory exists")
+}
+def clang_version = clang_versions[0]
 
 def jextract_path
 if (Os.isFamily(Os.FAMILY_WINDOWS)) {
@@ -23,8 +38,10 @@ if (Os.isFamily(Os.FAMILY_WINDOWS)) {
 }
 
 def clang_include_dir = "${libclang_home}/lib/clang/${clang_version}/include"
+checkPath(clang_include_dir)
 def os_lib_dir = Os.isFamily(Os.FAMILY_WINDOWS)? "bin" : "lib"
 def libclang_dir = "${libclang_home}/${os_lib_dir}"
+checkPath(libclang_dir)
 
 repositories {
     mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -18,13 +18,13 @@ def static checkPath(String p) {
     }
 }
 
-def libclang_home = project.property("libclang_home")
-checkPath(libclang_home)
-checkPath("${libclang_home}/lib/clang")
-def clang_versions = new File("${libclang_home}/lib/clang/").list();
+def llvm_home = project.property("llvm_home")
+checkPath(llvm_home)
+checkPath("${llvm_home}/lib/clang")
+def clang_versions = new File("${llvm_home}/lib/clang/").list();
 if (clang_versions.length == 0) {
     throw new IllegalArgumentException("Could not detect clang version." +
-            " Make sure a ${libclang_home}/lib/clang/<VERSION> directory exists")
+            " Make sure a ${llvm_home}/lib/clang/<VERSION> directory exists")
 }
 def clang_version = clang_versions[0]
 
@@ -37,10 +37,10 @@ if (Os.isFamily(Os.FAMILY_WINDOWS)) {
     jextract_path = "$buildDir/jextract/bin/jextract"
 }
 
-def clang_include_dir = "${libclang_home}/lib/clang/${clang_version}/include"
+def clang_include_dir = "${llvm_home}/lib/clang/${clang_version}/include"
 checkPath(clang_include_dir)
 def os_lib_dir = Os.isFamily(Os.FAMILY_WINDOWS)? "bin" : "lib"
-def libclang_dir = "${libclang_home}/${os_lib_dir}"
+def libclang_dir = "${llvm_home}/${os_lib_dir}"
 checkPath(libclang_dir)
 
 repositories {


### PR DESCRIPTION
Improve error reporting around missing LLVM paths in jextract gradle build.

This patch tries to detect missing paths and throw a descriptive error, instead of a more cryptic one.

I've also added the `.idea` folder to the `.gitignore` file.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [CODETOOLS-7903134](https://bugs.openjdk.java.net/browse/CODETOOLS-7903134): Improve error reporting in jextract gradle build


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jextract pull/8/head:pull/8` \
`$ git checkout pull/8`

Update a local copy of the PR: \
`$ git checkout pull/8` \
`$ git pull https://git.openjdk.java.net/jextract pull/8/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8`

View PR using the GUI difftool: \
`$ git pr show -t 8`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jextract/pull/8.diff">https://git.openjdk.java.net/jextract/pull/8.diff</a>

</details>
