### PR TITLE
7903136: Don't require jdk18_home to be set in jextract gradle build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .gradle
 **/build/
 .idea
+deps

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 `jextract` depends on the [C libclang API](https://clang.llvm.org/doxygen/group__CINDEX.html). To build the jextract sources, the easiest option is to download LLVM binaries for your platform, which can be found [here](https://releases.llvm.org/download.html) (a version >= 9 is required). Both the `jextract` tool and the bindings it generates depend heavily on the [Foreign Function & Memory API](https://openjdk.java.net/jeps/419), so a suitable [jdk 18 distribution](https://jdk.java.net/18/) is also required.
 
-The jdk used to build jextract is specified with `-Pjdk=/path/to/jdk`. If that option is omitted, a build JDK will be downloaded automatically.
+The JDK used to build jextract can be specified with `-Pjdk=/path/to/jdk`. If that option is omitted, a build JDK will be downloaded automatically.
 
 `jextract` can be built using `gradle`, as follows (on Windows, `gradlew.bat` should be used instead):
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 `jextract` depends on the [C libclang API](https://clang.llvm.org/doxygen/group__CINDEX.html). To build the jextract sources, the easiest option is to download LLVM binaries for your platform, which can be found [here](https://releases.llvm.org/download.html) (a version >= 9 is required). Both the `jextract` tool and the bindings it generates depend heavily on the [Foreign Function & Memory API](https://openjdk.java.net/jeps/419), so a suitable [jdk 18 distribution](https://jdk.java.net/18/) is also required.
 
-By default, the build will use the JDK used to run gradle. An alternative JDK can be specified with `-Pjdk=/path/to/jdk`.
+The jdk used to build jextract is specified with `-Pjdk=/path/to/jdk`. If that option is omitted, a build JDK will be downloaded automatically.
 
 `jextract` can be built using `gradle`, as follows (on Windows, `gradlew.bat` should be used instead):
 

--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@
 
 `jextract` depends on the [C libclang API](https://clang.llvm.org/doxygen/group__CINDEX.html). To build the jextract sources, the easiest option is to download LLVM binaries for your platform, which can be found [here](https://releases.llvm.org/download.html) (a version >= 9 is required). Both the `jextract` tool and the bindings it generates depend heavily on the [Foreign Function & Memory API](https://openjdk.java.net/jeps/419), so a suitable [jdk 18 distribution](https://jdk.java.net/18/) is also required.
 
-`jextract` can be built using `gradle`, as follows (on Windows, `gradlew.bat` should be used instead):
-
 Before starting, please make sure `JAVA_HOME` points and jdk 18:
 
 ```sh
 $ echo $JAVA_HOME
 /path/to/jdk18
 ```
+
+`jextract` can be built using `gradle`, as follows (on Windows, `gradlew.bat` should be used instead):
 
 ```sh
 $ sh ./gradlew -Pllvm_home=<libclang_dir> clean verify

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Expected a header file
 The repository also contains a comprehensive set of tests, written using the [jtreg](https://openjdk.java.net/jtreg/) test framework, which can be run as follows (again, on Windows, `gradlew.bat` should be used instead):
 
 ```sh
-$ sh ./gradlew -Pllvm_home=<libclang_dir> jtreg
+$ sh ./gradlew -Pllvm_home=<libclang_dir> -Pjtreg_home=<jtreg_dir> jtreg
 ```
 
 ### Using jextract

--- a/README.md
+++ b/README.md
@@ -8,8 +8,15 @@
 
 `jextract` can be built using `gradle`, as follows (on Windows, `gradlew.bat` should be used instead):
 
+Before starting, please make sure `JAVA_HOME` points and jdk 18:
+
 ```sh
-$ sh ./gradlew -Pjdk18_home=<jdk18_home_dir> -Pllvm_home=<libclang_dir> clean verify
+$ echo $JAVA_HOME
+/path/to/jdk18
+```
+
+```sh
+$ sh ./gradlew -Pllvm_home=<libclang_dir> clean verify
 ```
 
 After building, there should be a new `jextract` folder under `build` (the contents and the name of this folder might vary slightly depending on the platform):
@@ -38,7 +45,7 @@ Expected a header file
 The repository also contains a comprehensive set of tests, written using the [jtreg](https://openjdk.java.net/jtreg/) test framework, which can be run as follows (again, on Windows, `gradlew.bat` should be used instead):
 
 ```sh
-$ sh ./gradlew -Pjdk18_home=<jdk18_home_dir> -Pllvm_home=<libclang_dir> jtreg
+$ sh ./gradlew -Pllvm_home=<libclang_dir> jtreg
 ```
 
 ### Using jextract

--- a/README.md
+++ b/README.md
@@ -6,12 +6,7 @@
 
 `jextract` depends on the [C libclang API](https://clang.llvm.org/doxygen/group__CINDEX.html). To build the jextract sources, the easiest option is to download LLVM binaries for your platform, which can be found [here](https://releases.llvm.org/download.html) (a version >= 9 is required). Both the `jextract` tool and the bindings it generates depend heavily on the [Foreign Function & Memory API](https://openjdk.java.net/jeps/419), so a suitable [jdk 18 distribution](https://jdk.java.net/18/) is also required.
 
-Before starting, please make sure `JAVA_HOME` points and jdk 18:
-
-```sh
-$ echo $JAVA_HOME
-/path/to/jdk18
-```
+By default, the build will use the JDK used to run gradle. An alternative JDK can be specified with `-Pjdk=/path/to/jdk`.
 
 `jextract` can be built using `gradle`, as follows (on Windows, `gradlew.bat` should be used instead):
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ $ echo $JAVA_HOME
 `jextract` can be built using `gradle`, as follows (on Windows, `gradlew.bat` should be used instead):
 
 ```sh
-$ sh ./gradlew -Pllvm_home=<libclang_dir> clean verify
+$ sh ./gradlew -Pllvm_home=<llvm_dir> clean verify
 ```
 
 After building, there should be a new `jextract` folder under `build` (the contents and the name of this folder might vary slightly depending on the platform):
@@ -45,7 +45,7 @@ Expected a header file
 The repository also contains a comprehensive set of tests, written using the [jtreg](https://openjdk.java.net/jtreg/) test framework, which can be run as follows (again, on Windows, `gradlew.bat` should be used instead):
 
 ```sh
-$ sh ./gradlew -Pllvm_home=<libclang_dir> -Pjtreg_home=<jtreg_dir> jtreg
+$ sh ./gradlew -Pllvm_home=<llvm_dir> -Pjtreg_home=<jtreg_dir> jtreg
 ```
 
 ### Using jextract

--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ def static checkJDKRelease(String java_home, String expectedVersion) {
     }
 }
 
-def java_home = System.getenv("JAVA_HOME");
+def java_home = System.getProperty("java.home");
 checkJDKRelease(java_home, "18");
 
 def llvm_home = project.property("llvm_home")

--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,7 @@ def static Runtime.Version getJDKVersion(String jdkHome) {
 def static checkJDKRelease(String jdkHome, Runtime.Version expectedVersion) {
     Runtime.Version foundVersion = getJDKVersion(jdkHome);
     if (foundVersion.compareToIgnoreOptional(expectedVersion) < 0) {
-        throw new IllegalArgumentException("Incorrect java version. " +
+        throw new IllegalArgumentException("Incorrect build JDK version. " +
             "Expected at least '${expectedVersion}', but found '${foundVersion}'");
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 import org.apache.tools.ant.taskdefs.condition.Os
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Properties;
 
 plugins {
     id "java"
@@ -13,10 +14,37 @@ plugins {
 version = '1.0'
 
 def static checkPath(String p) {
-    if (!Files.exists(Path.of(p))) {
+    checkPath(Path.of(p));
+}
+
+def static checkPath(Path p) {
+    if (!Files.exists(p)) {
         throw new IllegalArgumentException("Error: the path ${p} does not exist");
     }
 }
+
+def static checkJDKRelease(String java_home, String expectedVersion) {
+    Path releaseFile = Path.of(java_home).resolve("release");
+    checkPath(releaseFile);
+
+    Properties props = new Properties();
+    try (InputStream input = Files.newInputStream(releaseFile)) {
+        props.load(input);
+    }
+
+    String foundVersion = props.getProperty("JAVA_VERSION");
+    if (foundVersion == null) {
+        throw new IllegalArgumentException("Could not determine java version from ${releaseFile}");
+    }
+
+    expectedVersion = "\"${expectedVersion}\""; // version in release file is quoted
+    if (!foundVersion.equals(expectedVersion)) {
+        throw new IllegalArgumentException("Incorrect java version. Expected ${expectedVersion}, but found ${foundVersion}");
+    }
+}
+
+def java_home = System.getenv("JAVA_HOME");
+checkJDKRelease(java_home, "18");
 
 def llvm_home = project.property("llvm_home")
 checkPath(llvm_home)
@@ -56,7 +84,7 @@ compileJava {
     options.compilerArgs << "--add-modules=jdk.incubator.foreign"
     options.compilerArgs << "-Xlint:all"
     options.fork = true
-    options.forkOptions.executable = "${jdk18_home}/bin/javac"
+    options.forkOptions.executable = "${java_home}/bin/javac"
 }
 
 jar {
@@ -65,9 +93,6 @@ jar {
 }
 
 moditect {
-    // moditect uses java.home to find JDK tools
-    System.setProperty("java.home", "$jdk18_home")
-
     // inject module-info.class for org.openjdk.jextract module
     addMainModuleInfo {
         dependsOn build
@@ -165,7 +190,7 @@ task createRuntimeImageForTest(type: org.moditect.gradleplugin.image.CreateRunti
 
     onlyIf { !new File("$buildDir/jextract-jdk-test-image").exists() }
     outputDirectory = file("$buildDir/jextract-jdk-test-image")
-    modulePath = [file("$buildDir/modules"),file("$jdk18_home/jmods")]
+    modulePath = [file("$buildDir/modules"),file("$java_home/jmods")]
     modules = ['ALL-MODULE-PATH']
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -55,10 +55,6 @@ def static checkJDKRelease(String jdkHome, Runtime.Version expectedVersion) {
     }
 }
 
-def satisfiesJDKVersion(String jdkHome, Runtime.Version expectedVersion) {
-    return getJDKVersion(jdkHome).compareToIgnoreOptional(ext.minimalJDKVersion) >= 0;
-}
-
 def String downloadJDK() {
     String jdkUrl = "https://download.java.net/java/GA/jdk18/43f95e8614114aeaa8e8a5fcf20a682d/36/GPL/openjdk-18_";
     String archiveExt;
@@ -95,9 +91,6 @@ if (project.hasProperty("jdk")) {
     println("using JDK from 'jdk' project property");
     jdkHome = project.property("jdk");
     checkJDKRelease(jdkHome, minimalJDKVersion);
-} else if (satisfiesJDKVersion(System.getProperty("java.home"), minimalJDKVersion)) {
-    println("using JDK from 'java.home' system property");
-    jdkHome = System.getProperty("java.home");
 } else {
     println("downloading JDK to build with");
     jdkHome = downloadJDK();

--- a/build.gradle
+++ b/build.gradle
@@ -9,9 +9,13 @@ plugins {
     id "org.moditect.gradleplugin" version "1.0.0-rc3"
     // jpackage plugin for packging jextract native app
     id "org.panteleyev.jpackageplugin" version "1.3.1"
+    // for downloading files
+    id "de.undercouch.download" version "5.0.2"
 }
 
 version = '1.0'
+project.ext.minimalJDKVersion = Runtime.Version.parse("18");
+project.ext.depsDir = "deps"
 
 def static checkPath(String p) {
     checkPath(Path.of(p));
@@ -23,8 +27,8 @@ def static checkPath(Path p) {
     }
 }
 
-def static checkJDKRelease(String java_home, int expectedVersion) {
-    Path releaseFile = Path.of(java_home).resolve("release");
+def static Runtime.Version getJDKVersion(String jdkHome) {
+    Path releaseFile = Path.of(jdkHome).resolve("release");
     checkPath(releaseFile);
 
     Properties props = new Properties();
@@ -32,22 +36,73 @@ def static checkJDKRelease(String java_home, int expectedVersion) {
         props.load(input);
     }
 
-    String foundVersion = props.getProperty("JAVA_VERSION");
-    if (foundVersion == null) {
+    String foundVersionStr = props.getProperty("JAVA_VERSION");
+    if (foundVersionStr == null) {
         throw new IllegalArgumentException("Could not determine java version from ${releaseFile}");
     }
 
-    foundVersion = foundVersion.substring(1, foundVersion.length() - 1); // version in release file is quoted
-    int foundVersionInt = Integer.parseInt(foundVersion);
+    foundVersionStr = foundVersionStr.substring(1, foundVersionStr.length() - 1); // version in release file is quoted
+    Runtime.Version foundVersion = Runtime.Version.parse(foundVersionStr);
 
-    if (foundVersionInt < expectedVersion) {
+    return foundVersion;
+}
+
+def static checkJDKRelease(String jdkHome, Runtime.Version expectedVersion) {
+    Runtime.Version foundVersion = getJDKVersion(jdkHome);
+    if (foundVersion.compareToIgnoreOptional(expectedVersion) < 0) {
         throw new IllegalArgumentException("Incorrect java version. " +
             "Expected at least '${expectedVersion}', but found '${foundVersion}'");
     }
 }
 
-def java_home = project.hasProperty("jdk") ? project.property("jdk") : System.getProperty("java.home");
-checkJDKRelease(java_home, 18);
+def satisfiesJDKVersion(String jdkHome, Runtime.Version expectedVersion) {
+    return getJDKVersion(jdkHome).compareToIgnoreOptional(ext.minimalJDKVersion) >= 0;
+}
+
+def String downloadJDK() {
+    String jdkUrl = "https://download.java.net/java/GA/jdk18/43f95e8614114aeaa8e8a5fcf20a682d/36/GPL/openjdk-18_";
+    String archiveExt;
+    if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+        jdkUrl += "windows-x64_bin.zip";
+        archiveExt = ".zip";
+    } else if (Os.isFamily(Os.FAMILY_MAC)) {
+        jdkUrl += "macos-x64_bin.tar.gz"
+        archiveExt = ".tar.gz";
+    } else {
+        jdkUrl += "linux-x64_bin.tar.gz"
+        archiveExt = ".tar.gz";
+    }
+
+    String jdkZipPath = ext.depsDir + "/jdk" + archiveExt;
+	download.run {
+		src jdkUrl
+		dest jdkZipPath
+		overwrite false // don't overwrite if it already exists
+	}
+
+    // extract
+    FileTree source = Os.isFamily(Os.FAMILY_WINDOWS) ? zipTree(jdkZipPath) : tarTree(jdkZipPath);
+	copy {
+		from source
+		into ext.depsDir
+	}
+
+    return ext.depsDir + "/jdk-18";
+}
+
+String jdkHome;
+if (project.hasProperty("jdk")) {
+    println("using JDK from 'jdk' project property");
+    jdkHome = project.property("jdk");
+    checkJDKRelease(jdkHome, minimalJDKVersion);
+} else if (satisfiesJDKVersion(System.getProperty("java.home"), minimalJDKVersion)) {
+    println("using JDK from 'java.home' system property");
+    jdkHome = System.getProperty("java.home");
+} else {
+    println("downloading JDK to build with");
+    jdkHome = downloadJDK();
+}
+println("build JDK path is: " + jdkHome);
 
 def llvm_home = project.property("llvm_home")
 checkPath(llvm_home)
@@ -87,7 +142,7 @@ compileJava {
     options.compilerArgs << "--add-modules=jdk.incubator.foreign"
     options.compilerArgs << "-Xlint:all"
     options.fork = true
-    options.forkOptions.executable = "${java_home}/bin/javac"
+    options.forkOptions.executable = "${jdkHome}/bin/javac"
 }
 
 jar {
@@ -97,7 +152,7 @@ jar {
 
 moditect {
     // moditect uses java.home to find JDK tools
-    System.setProperty("java.home", "$java_home")
+    System.setProperty("java.home", "$jdkHome")
 
     // inject module-info.class for org.openjdk.jextract module
     addMainModuleInfo {
@@ -196,7 +251,7 @@ task createRuntimeImageForTest(type: org.moditect.gradleplugin.image.CreateRunti
 
     onlyIf { !new File("$buildDir/jextract-jdk-test-image").exists() }
     outputDirectory = file("$buildDir/jextract-jdk-test-image")
-    modulePath = [file("$buildDir/modules"),file("$java_home/jmods")]
+    modulePath = [file("$buildDir/modules"),file("$jdkHome/jmods")]
     modules = ['ALL-MODULE-PATH']
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -70,18 +70,18 @@ def String downloadJDK() {
     }
 
     String jdkZipPath = ext.depsDir + "/jdk" + archiveExt;
-	download.run {
-		src jdkUrl
-		dest jdkZipPath
-		overwrite false // don't overwrite if it already exists
-	}
+    download.run {
+        src jdkUrl
+        dest jdkZipPath
+        overwrite false // don't overwrite if it already exists
+    }
 
     // extract
     FileTree source = Os.isFamily(Os.FAMILY_WINDOWS) ? zipTree(jdkZipPath) : tarTree(jdkZipPath);
-	copy {
-		from source
-		into ext.depsDir
-	}
+    copy {
+        from source
+        into ext.depsDir
+    }
 
     return ext.depsDir + "/jdk-18";
 }

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ def static checkPath(Path p) {
     }
 }
 
-def static checkJDKRelease(String java_home, String expectedVersion) {
+def static checkJDKRelease(String java_home, int expectedVersion) {
     Path releaseFile = Path.of(java_home).resolve("release");
     checkPath(releaseFile);
 
@@ -37,14 +37,17 @@ def static checkJDKRelease(String java_home, String expectedVersion) {
         throw new IllegalArgumentException("Could not determine java version from ${releaseFile}");
     }
 
-    expectedVersion = "\"${expectedVersion}\""; // version in release file is quoted
-    if (!foundVersion.equals(expectedVersion)) {
-        throw new IllegalArgumentException("Incorrect java version. Expected ${expectedVersion}, but found ${foundVersion}");
+    foundVersion = foundVersion.substring(1, foundVersion.length() - 1); // version in release file is quoted
+    int foundVersionInt = Integer.parseInt(foundVersion);
+
+    if (foundVersionInt < expectedVersion) {
+        throw new IllegalArgumentException("Incorrect java version. " +
+            "Expected at least '${expectedVersion}', but found '${foundVersion}'");
     }
 }
 
-def java_home = System.getProperty("java.home");
-checkJDKRelease(java_home, "18");
+def java_home = project.hasProperty("jdk") ? project.property("jdk") : System.getProperty("java.home");
+checkJDKRelease(java_home, 18);
 
 def llvm_home = project.property("llvm_home")
 checkPath(llvm_home)
@@ -93,6 +96,9 @@ jar {
 }
 
 moditect {
+    // moditect uses java.home to find JDK tools
+    System.setProperty("java.home", "$java_home")
+
     // inject module-info.class for org.openjdk.jextract module
     addMainModuleInfo {
         dependsOn build


### PR DESCRIPTION
Drop the requirement to set `jdk18_home` in the gradle build, and rely instead on `JAVA_HOME` being set to JDK 18.

I've also updated the build instructions. The `-Pjtreg_home` flag seems to have been dropped by accident from the test command. I've re-added it. Also renamed `libclang_dir` -> `llvm_dir` which was missed in an earlier change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [CODETOOLS-7903136](https://bugs.openjdk.java.net/browse/CODETOOLS-7903136): Don't require jdk18_home to be set in jextract gradle build


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jextract pull/9/head:pull/9` \
`$ git checkout pull/9`

Update a local copy of the PR: \
`$ git checkout pull/9` \
`$ git pull https://git.openjdk.java.net/jextract pull/9/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9`

View PR using the GUI difftool: \
`$ git pr show -t 9`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jextract/pull/9.diff">https://git.openjdk.java.net/jextract/pull/9.diff</a>

</details>
