### PR TITLE
Update Readme with macOs specifics

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,18 +12,19 @@
 $ sh ./gradlew -Pjdk18_home=<jdk18_home_dir> -Pllvm_home=<libclang_dir> clean verify
 ```
 
-<details><summary>Using a local installation of LLVM</summary>
 
-While the recommanded way is to use a [release from the LLVM project](https://releases.llvm.org/download.html),
-extract it then make `llvm_home` point to this directory, it may be possible to use a local installation instead.
-
-E.g. on macOs the `llvm_home` can also be set as one of these locations :
-
-* `/Library/Developer/CommandLineTools/usr/` if using Command Line Tools
-* `/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/` if using XCode
-* `$(brew --prefix llvm)` if using the [LLVM install from Homebrew](https://formulae.brew.sh/formula/llvm#default)
-
-</details>
+> <details><summary><strong>Using a local installation of LLVM</strong></summary>
+> 
+> While the recommanded way is to use a [release from the LLVM project](https://releases.llvm.org/download.html),
+> extract it then make `llvm_home` point to this directory, it may be possible to use a local installation instead.
+>
+> E.g. on macOs the `llvm_home` can also be set as one of these locations :
+> 
+> * `/Library/Developer/CommandLineTools/usr/` if using Command Line Tools
+> * `/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/` if using XCode
+> * `$(brew --prefix llvm)` if using the [LLVM install from Homebrew](https://formulae.brew.sh/formula/llvm#default)
+> 
+> </details>
 
 After building, there should be a new `jextract` folder under `build` (the contents and the name of this folder might vary slightly depending on the platform, e.g. on macOs the folder is `jextract.app`) :
 

--- a/README.md
+++ b/README.md
@@ -12,11 +12,18 @@
 $ sh ./gradlew -Pjdk18_home=<jdk18_home_dir> -Pllvm_home=<libclang_dir> clean verify
 ```
 
-On macOs the `libclang_dir` the usual locations are:
+<details><summary>Using a local installation of LLVM</summary>
+
+While the recommanded way is to use a [release from the LLVM project](https://releases.llvm.org/download.html),
+extract it then make `llvm_home` point to this directory, it may be possible to use a local installation instead.
+
+E.g. on macOs the `llvm_home` can also be set as one of these locations :
 
 * `/Library/Developer/CommandLineTools/usr/` if using Command Line Tools
 * `/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/` if using XCode
 * `$(brew --prefix llvm)` if using the [LLVM install from Homebrew](https://formulae.brew.sh/formula/llvm#default)
+
+</details>
 
 After building, there should be a new `jextract` folder under `build` (the contents and the name of this folder might vary slightly depending on the platform, e.g. on macOs the folder is `jextract.app`) :
 
@@ -44,8 +51,10 @@ Expected a header file
 The repository also contains a comprehensive set of tests, written using the [jtreg](https://openjdk.java.net/jtreg/) test framework, which can be run as follows (again, on Windows, `gradlew.bat` should be used instead):
 
 ```sh
-$ sh ./gradlew -Pjdk18_home=<jdk18_home_dir> -Pllvm_home=<libclang_dir> jtreg
+$ sh ./gradlew -Pjdk18_home=<jdk18_home_dir> -Pllvm_home=<libclang_dir> -Pjtreg_home=<jtreg_home> jtreg
 ```
+
+Note however that running `jtreg` task requires `cmake` to be available on the `PATH`.
 
 ### Using jextract
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,13 @@
 $ sh ./gradlew -Pjdk18_home=<jdk18_home_dir> -Pllvm_home=<libclang_dir> clean verify
 ```
 
-After building, there should be a new `jextract` folder under `build` (the contents and the name of this folder might vary slightly depending on the platform):
+On macOs the `libclang_dir` the usual locations are:
+
+* `/Library/Developer/CommandLineTools/usr/` if using Command Line Tools
+* `/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/` if using XCode
+* `$(brew --prefix llvm)` if using the [LLVM install from Homebrew](https://formulae.brew.sh/formula/llvm#default)
+
+After building, there should be a new `jextract` folder under `build` (the contents and the name of this folder might vary slightly depending on the platform, e.g. on macOs the folder is `jextract.app`) :
 
 ```
 build/jextract
@@ -27,7 +33,7 @@ build/jextract
         └── lib
 ```
 
-To run the `jextract` tool, simply run the `jextract` command in the `bin` folder (again, the exact location of the binary might vary slightly depending on the platform):
+To run the `jextract` tool, simply run the `jextract` command in the `bin` folder (again, the exact location of the binary might vary slightly depending on the platform, e.g. on macOs `build/jextract.app/Contents/MacOS/jextract` ):
 
 ```sh
 build/jextract/bin/jextract 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ $ sh ./gradlew -Pjdk18_home=<jdk18_home_dir> -Pllvm_home=<libclang_dir> clean ve
 
 > <details><summary><strong>Using a local installation of LLVM</strong></summary>
 > 
-> While the recommanded way is to use a [release from the LLVM project](https://releases.llvm.org/download.html),
+> While the recommended way is to use a [release from the LLVM project](https://releases.llvm.org/download.html),
 > extract it then make `llvm_home` point to this directory, it may be possible to use a local installation instead.
 >
 > E.g. on macOs the `llvm_home` can also be set as one of these locations :


### PR DESCRIPTION
The macOs libclang location as well as build output differ enough to warrant specific information. In particular the use of the XCode based path to find the libclang is not an easy find. The output also makes use of jpackage with `app-image` type, but the macOs _.app_ layout different enough on macOs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - no project role) ⚠️ Review applies to baf128b7f0443225c000ed9c527ea9b71a461901
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jextract pull/10/head:pull/10` \
`$ git checkout pull/10`

Update a local copy of the PR: \
`$ git checkout pull/10` \
`$ git pull https://git.openjdk.java.net/jextract pull/10/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10`

View PR using the GUI difftool: \
`$ git pr show -t 10`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jextract/pull/10.diff">https://git.openjdk.java.net/jextract/pull/10.diff</a>

</details>
