### PR TITLE
7903148: jextract crashes when C11 keyword _Static_Assert is used in a header

### DIFF
--- a/src/main/java/org/openjdk/jextract/clang/CursorKind.java
+++ b/src/main/java/org/openjdk/jextract/clang/CursorKind.java
@@ -98,7 +98,7 @@ public enum CursorKind {
     InclusionDirective(CXCursor_InclusionDirective()),
     /*
      * Per libclang API docs, clang returns this CursorKind
-     * for both C11 _Static_Assert and C++11 static_assert
+     * for both C11 _Static_assert and C++11 static_assert
      */
     StaticAssert(CXCursor_StaticAssert());
 

--- a/src/main/java/org/openjdk/jextract/clang/CursorKind.java
+++ b/src/main/java/org/openjdk/jextract/clang/CursorKind.java
@@ -95,7 +95,13 @@ public enum CursorKind {
     MacroDefinition(CXCursor_MacroDefinition()),
     MacroExpansion(CXCursor_MacroExpansion()),
     MacroInstantiation(CXCursor_MacroInstantiation()),
-    InclusionDirective(CXCursor_InclusionDirective());
+    InclusionDirective(CXCursor_InclusionDirective()),
+    /*
+     * Per libclang API docs, clang returns this CursorKind
+     * for both C11 _Static_Assert and C++11 static_assert
+     */
+    StaticAssert(CXCursor_StaticAssert());
+
 
     private final int value;
 

--- a/src/main/java/org/openjdk/jextract/impl/TreeMaker.java
+++ b/src/main/java/org/openjdk/jextract/impl/TreeMaker.java
@@ -62,7 +62,15 @@ class TreeMaker {
     public Declaration createTree(Cursor c) {
         Objects.requireNonNull(c);
         CursorLanguage lang = c.language();
-        if (lang != CursorLanguage.C && lang != CursorLanguage.Invalid) {
+        /*
+         * We detect non-C constructs to early exit with error for
+         * unsupported features. But libclang maps both C11's _Static_Assert
+         * and C++11's static_assert to same CursorKind. But the language is
+         * set a C++ always. Because we want to allow C11's _Static_Assert,
+         * we allow that exception here.
+         */
+        if (lang != CursorLanguage.C && lang != CursorLanguage.Invalid &&
+                c.kind() != CursorKind.StaticAssert) {
             throw new RuntimeException("Unsupported language: " + c.language());
         }
         var rv = (DeclarationImpl) createTreeInternal(c);

--- a/src/main/java/org/openjdk/jextract/impl/TreeMaker.java
+++ b/src/main/java/org/openjdk/jextract/impl/TreeMaker.java
@@ -64,7 +64,7 @@ class TreeMaker {
         CursorLanguage lang = c.language();
         /*
          * We detect non-C constructs to early exit with error for
-         * unsupported features. But libclang maps both C11's _Static_Assert
+         * unsupported features. But libclang maps both C11's _Static_assert
          * and C++11's static_assert to same CursorKind. But the language is
          * set a C++ always. Because we want to allow C11's _Static_Assert,
          * we allow that exception here.

--- a/test/java/org/openjdk/jextract/test/toolprovider/Test7903148.java
+++ b/test/java/org/openjdk/jextract/test/toolprovider/Test7903148.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package org.openjdk.jextract.test.toolprovider;
+
+import org.openjdk.jextract.test.TestUtils;
+import org.testng.annotations.Test;
+import java.nio.file.Path;
+import static org.testng.Assert.assertNotNull;
+
+/*
+ * @test
+ * @library /test/lib
+ * @build JextractToolRunner
+ * @bug 7903148
+ * @summary jextract crashes when C11 keyword _Static_Assert is used in a header
+ * @run testng/othervm --enable-native-access=ALL-UNNAMED Test7903148
+ */
+public class Test7903148 extends JextractToolRunner {
+    @Test
+    public void test() {
+        Path output = getOutputFilePath("7903148gen");
+        Path outputH = getInputFilePath("test7903148.h");
+        run("-d", output.toString(), outputH.toString()).checkSuccess();
+        try(TestUtils.Loader loader = TestUtils.classLoader(output)) {
+            assertNotNull(loader.loadClass("test7903148_h"));
+        } finally {
+            TestUtils.deleteDir(output);
+        }
+    }
+}

--- a/test/java/org/openjdk/jextract/test/toolprovider/Test7903148.java
+++ b/test/java/org/openjdk/jextract/test/toolprovider/Test7903148.java
@@ -43,7 +43,9 @@ public class Test7903148 extends JextractToolRunner {
         Path outputH = getInputFilePath("test7903148.h");
         run("-d", output.toString(), outputH.toString()).checkSuccess();
         try(TestUtils.Loader loader = TestUtils.classLoader(output)) {
-            assertNotNull(loader.loadClass("test7903148_h"));
+            Class<?> headerCls = loader.loadClass("test7903148_h");
+            assertNotNull(headerCls);
+            checkMethod(headerCls, "func", int.class, int.class);
         } finally {
             TestUtils.deleteDir(output);
         }

--- a/test/java/org/openjdk/jextract/test/toolprovider/test7903148.h
+++ b/test/java/org/openjdk/jextract/test/toolprovider/test7903148.h
@@ -22,3 +22,5 @@
  */
 
 _Static_assert(1 == 1, "what??");
+
+int func(int x);

--- a/test/java/org/openjdk/jextract/test/toolprovider/test7903148.h
+++ b/test/java/org/openjdk/jextract/test/toolprovider/test7903148.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+_Static_assert(1 == 1, "what??");


### PR DESCRIPTION
Added missing CursorKind enum value.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [CODETOOLS-7903148](https://bugs.openjdk.java.net/browse/CODETOOLS-7903148): jextract crashes when C11 keyword _Static_Assert is used in a header


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jextract pull/15/head:pull/15` \
`$ git checkout pull/15`

Update a local copy of the PR: \
`$ git checkout pull/15` \
`$ git pull https://git.openjdk.java.net/jextract pull/15/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15`

View PR using the GUI difftool: \
`$ git pr show -t 15`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jextract/pull/15.diff">https://git.openjdk.java.net/jextract/pull/15.diff</a>

</details>
