### PR TITLE
Drop unused jtreg test headers

### DIFF
--- a/test/TEST.ROOT
+++ b/test/TEST.ROOT
@@ -1,11 +1,5 @@
-# Test libraries
-lib.dirs = ./lib
-
 # This file identifies root(s) of the test-ng hierarchy.
 TestNG.dirs = ./java
-
-# To help out with foreign memory access Spliterator tests
-modules = jdk.incubator.foreign
 
 groups=TEST.groups
 

--- a/test/java/org/openjdk/jextract/test/api/Test8241650.java
+++ b/test/java/org/openjdk/jextract/test/api/Test8241650.java
@@ -27,12 +27,6 @@ import org.openjdk.jextract.Declaration;
 import org.testng.annotations.Test;
 import static org.testng.Assert.assertTrue;
 
-/*
- * @test
- * @bug 8241650
- * @summary jextract module should be mapped to application class loader
- * @run testng Test8241650
- */
 public class Test8241650 {
     @Test
     public void testClassLoader() {

--- a/test/java/org/openjdk/jextract/test/toolprovider/RepeatedDeclsTest.java
+++ b/test/java/org/openjdk/jextract/test/toolprovider/RepeatedDeclsTest.java
@@ -39,7 +39,7 @@ import static org.testng.Assert.assertTrue;
  * @test
  * @bug 8240300
  * @summary jextract produces non compilable code with repeated declarations
- * @library /test/lib
+ * @library /lib
  * @build JextractToolRunner
  * @run testng/othervm --enable-native-access=ALL-UNNAMED RepeatedDeclsTest
  */

--- a/test/java/org/openjdk/jextract/test/toolprovider/RepeatedDeclsTest.java
+++ b/test/java/org/openjdk/jextract/test/toolprovider/RepeatedDeclsTest.java
@@ -35,14 +35,6 @@ import jdk.incubator.foreign.MemorySegment;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
-/*
- * @test
- * @bug 8240300
- * @summary jextract produces non compilable code with repeated declarations
- * @library /lib
- * @build JextractToolRunner
- * @run testng/othervm --enable-native-access=ALL-UNNAMED RepeatedDeclsTest
- */
 public class RepeatedDeclsTest extends JextractToolRunner {
     @Test
     public void repeatedDecls() throws Throwable {

--- a/test/java/org/openjdk/jextract/test/toolprovider/Test8240181.java
+++ b/test/java/org/openjdk/jextract/test/toolprovider/Test8240181.java
@@ -30,7 +30,7 @@ import org.testng.annotations.Test;
 
 /*
  * @test
- * @library /test/lib
+ * @library /lib
  * @build JextractToolRunner
  * @bug 8240181
  * @run testng/othervm --enable-native-access=ALL-UNNAMED -Duser.language=en Test8240181

--- a/test/java/org/openjdk/jextract/test/toolprovider/Test8240181.java
+++ b/test/java/org/openjdk/jextract/test/toolprovider/Test8240181.java
@@ -28,13 +28,6 @@ import java.nio.file.Path;
 import org.openjdk.jextract.test.TestUtils;
 import org.testng.annotations.Test;
 
-/*
- * @test
- * @library /lib
- * @build JextractToolRunner
- * @bug 8240181
- * @run testng/othervm --enable-native-access=ALL-UNNAMED -Duser.language=en Test8240181
- */
 public class Test8240181 extends JextractToolRunner {
     @Test
     public void testAnonymousEnum() {

--- a/test/java/org/openjdk/jextract/test/toolprovider/Test8240657.java
+++ b/test/java/org/openjdk/jextract/test/toolprovider/Test8240657.java
@@ -31,7 +31,7 @@ import static org.testng.Assert.assertNotNull;
 
 /*
  * @test
- * @library /test/lib
+ * @library /lib
  * @build JextractToolRunner
  * @bug 8240657
  * @summary when Java keywords are used as identifiers in C header, jextract generates non-compilable java code

--- a/test/java/org/openjdk/jextract/test/toolprovider/Test8240657.java
+++ b/test/java/org/openjdk/jextract/test/toolprovider/Test8240657.java
@@ -29,14 +29,6 @@ import org.openjdk.jextract.test.TestUtils;
 import org.testng.annotations.Test;
 import static org.testng.Assert.assertNotNull;
 
-/*
- * @test
- * @library /lib
- * @build JextractToolRunner
- * @bug 8240657
- * @summary when Java keywords are used as identifiers in C header, jextract generates non-compilable java code
- * @run testng/othervm --enable-native-access=ALL-UNNAMED Test8240657
- */
 public class Test8240657 extends JextractToolRunner {
     @Test
     public void testKeywordIdentifiers() {

--- a/test/java/org/openjdk/jextract/test/toolprovider/Test8240752.java
+++ b/test/java/org/openjdk/jextract/test/toolprovider/Test8240752.java
@@ -33,14 +33,6 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
-/*
- * @test
- * @library /lib
- * @build JextractToolRunner
- * @bug 8240752
- * @summary jextract generates non-compilable code for special floating point values
- * @run testng/othervm --enable-native-access=ALL-UNNAMED Test8240752
- */
 public class Test8240752 extends JextractToolRunner {
     private float getFloatConstant(Class<?> cls, String name) {
         Method method = findMethod(cls, name);

--- a/test/java/org/openjdk/jextract/test/toolprovider/Test8240752.java
+++ b/test/java/org/openjdk/jextract/test/toolprovider/Test8240752.java
@@ -35,7 +35,7 @@ import static org.testng.Assert.assertTrue;
 
 /*
  * @test
- * @library /test/lib
+ * @library /lib
  * @build JextractToolRunner
  * @bug 8240752
  * @summary jextract generates non-compilable code for special floating point values

--- a/test/java/org/openjdk/jextract/test/toolprovider/Test8240811.java
+++ b/test/java/org/openjdk/jextract/test/toolprovider/Test8240811.java
@@ -33,14 +33,6 @@ import org.testng.annotations.Test;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
-/*
- * @test
- * @library /lib
- * @build JextractToolRunner
- * @bug 8240811
- * @summary jextract generates non-compilable code for name collision between a struct and a global variable
- * @run testng/othervm --enable-native-access=ALL-UNNAMED Test8240811
- */
 public class Test8240811 extends JextractToolRunner {
     @Test
     public void testNameCollision() {

--- a/test/java/org/openjdk/jextract/test/toolprovider/Test8240811.java
+++ b/test/java/org/openjdk/jextract/test/toolprovider/Test8240811.java
@@ -35,7 +35,7 @@ import static org.testng.Assert.assertTrue;
 
 /*
  * @test
- * @library /test/lib
+ * @library /lib
  * @build JextractToolRunner
  * @bug 8240811
  * @summary jextract generates non-compilable code for name collision between a struct and a global variable

--- a/test/java/org/openjdk/jextract/test/toolprovider/Test8244412.java
+++ b/test/java/org/openjdk/jextract/test/toolprovider/Test8244412.java
@@ -31,7 +31,7 @@ import static org.testng.Assert.assertNotNull;
 
 /*
  * @test
- * @library /test/lib
+ * @library /lib
  * @build JextractToolRunner
  * @bug 8244412
  * @summary jextract should generate static utils class for primitive typedefs

--- a/test/java/org/openjdk/jextract/test/toolprovider/Test8244412.java
+++ b/test/java/org/openjdk/jextract/test/toolprovider/Test8244412.java
@@ -29,14 +29,6 @@ import org.openjdk.jextract.test.TestUtils;
 import org.testng.annotations.Test;
 import static org.testng.Assert.assertNotNull;
 
-/*
- * @test
- * @library /lib
- * @build JextractToolRunner
- * @bug 8244412
- * @summary jextract should generate static utils class for primitive typedefs
- * @run testng/othervm --enable-native-access=ALL-UNNAMED Test8244412
- */
 public class Test8244412 extends JextractToolRunner {
     @Test
     public void testPrimitiveTypedefs() {

--- a/test/java/org/openjdk/jextract/test/toolprovider/Test8245767.java
+++ b/test/java/org/openjdk/jextract/test/toolprovider/Test8245767.java
@@ -34,7 +34,7 @@ import static org.testng.Assert.assertTrue;
 
 /*
  * @test
- * @library /test/lib
+ * @library /lib
  * @build JextractToolRunner
  * @bug 8245767
  * @summary jextract crashes with typedef on a opaque struct or union

--- a/test/java/org/openjdk/jextract/test/toolprovider/Test8245767.java
+++ b/test/java/org/openjdk/jextract/test/toolprovider/Test8245767.java
@@ -32,14 +32,6 @@ import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
-/*
- * @test
- * @library /lib
- * @build JextractToolRunner
- * @bug 8245767
- * @summary jextract crashes with typedef on a opaque struct or union
- * @run testng/othervm --enable-native-access=ALL-UNNAMED Test8245767
- */
 public class Test8245767 extends JextractToolRunner {
     @Test
     public void testTypedefs() {

--- a/test/java/org/openjdk/jextract/test/toolprovider/Test8248415.java
+++ b/test/java/org/openjdk/jextract/test/toolprovider/Test8248415.java
@@ -29,14 +29,6 @@ import jdk.incubator.foreign.MemorySegment;
 import org.openjdk.jextract.test.TestUtils;
 import org.testng.annotations.Test;
 
-/*
- * @test
- * @library /lib
- * @build JextractToolRunner
- * @bug 8248415
- * @summary jextract does not generate getter and setter for pointer typed fields in structs
- * @run testng/othervm --enable-native-access=ALL-UNNAMED Test8248415
- */
 public class Test8248415 extends JextractToolRunner {
 
     @Test

--- a/test/java/org/openjdk/jextract/test/toolprovider/Test8248415.java
+++ b/test/java/org/openjdk/jextract/test/toolprovider/Test8248415.java
@@ -31,7 +31,7 @@ import org.testng.annotations.Test;
 
 /*
  * @test
- * @library /test/lib
+ * @library /lib
  * @build JextractToolRunner
  * @bug 8248415
  * @summary jextract does not generate getter and setter for pointer typed fields in structs

--- a/test/java/org/openjdk/jextract/test/toolprovider/Test8248474.java
+++ b/test/java/org/openjdk/jextract/test/toolprovider/Test8248474.java
@@ -31,7 +31,7 @@ import static org.testng.Assert.assertNotNull;
 
 /*
  * @test
- * @library /test/lib
+ * @library /lib
  * @build JextractToolRunner
  * @bug 8248474
  * @summary jextract uses header file name as part of identifier

--- a/test/java/org/openjdk/jextract/test/toolprovider/Test8248474.java
+++ b/test/java/org/openjdk/jextract/test/toolprovider/Test8248474.java
@@ -29,14 +29,6 @@ import org.openjdk.jextract.test.TestUtils;
 import org.testng.annotations.Test;
 import static org.testng.Assert.assertNotNull;
 
-/*
- * @test
- * @library /lib
- * @build JextractToolRunner
- * @bug 8248474
- * @summary jextract uses header file name as part of identifier
- * @run testng/othervm --enable-native-access=ALL-UNNAMED Test8248474
- */
 public class Test8248474 extends JextractToolRunner {
     @Test
     public void testUnsafeHeaderName() {

--- a/test/java/org/openjdk/jextract/test/toolprovider/Test8249290.java
+++ b/test/java/org/openjdk/jextract/test/toolprovider/Test8249290.java
@@ -31,7 +31,7 @@ import org.testng.annotations.Test;
 
 /*
  * @test
- * @library /test/lib
+ * @library /lib
  * @build JextractToolRunner
  * @bug 8249290
  * @summary jextract does not handle void typedef in function pointer argument

--- a/test/java/org/openjdk/jextract/test/toolprovider/Test8249290.java
+++ b/test/java/org/openjdk/jextract/test/toolprovider/Test8249290.java
@@ -29,14 +29,6 @@ import jdk.incubator.foreign.Addressable;
 import org.openjdk.jextract.test.TestUtils;
 import org.testng.annotations.Test;
 
-/*
- * @test
- * @library /lib
- * @build JextractToolRunner
- * @bug 8249290
- * @summary jextract does not handle void typedef in function pointer argument
- * @run testng/othervm --enable-native-access=ALL-UNNAMED Test8249290
- */
 public class Test8249290 extends JextractToolRunner {
     @Test
     public void testVoidTypedef() {

--- a/test/java/org/openjdk/jextract/test/toolprovider/Test8249300.java
+++ b/test/java/org/openjdk/jextract/test/toolprovider/Test8249300.java
@@ -29,14 +29,6 @@ import jdk.incubator.foreign.Addressable;
 import org.openjdk.jextract.test.TestUtils;
 import org.testng.annotations.Test;
 
-/*
- * @test
- * @library /lib
- * @build JextractToolRunner
- * @bug 8249300
- * @summary jextract does not handle empty parameter list of a function pointer parameters
- * @run testng/othervm --enable-native-access=ALL-UNNAMED Test8249300
- */
 public class Test8249300 extends JextractToolRunner {
     @Test
     public void testVoidTypedef() {

--- a/test/java/org/openjdk/jextract/test/toolprovider/Test8249300.java
+++ b/test/java/org/openjdk/jextract/test/toolprovider/Test8249300.java
@@ -31,7 +31,7 @@ import org.testng.annotations.Test;
 
 /*
  * @test
- * @library /test/lib
+ * @library /lib
  * @build JextractToolRunner
  * @bug 8249300
  * @summary jextract does not handle empty parameter list of a function pointer parameters

--- a/test/java/org/openjdk/jextract/test/toolprovider/Test8251943.java
+++ b/test/java/org/openjdk/jextract/test/toolprovider/Test8251943.java
@@ -31,14 +31,6 @@ import org.testng.annotations.Test;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertNotNull;
 
-/*
- * @test
- * @library /lib
- * @build JextractToolRunner
- * @bug 8251943
- * @summary jextract should not generate MemorySegment typed fields for variables, struct fields if layout size info is not available
- * @run testng/othervm --enable-native-access=ALL-UNNAMED Test8251943
- */
 public class Test8251943 extends JextractToolRunner {
 
     @Test

--- a/test/java/org/openjdk/jextract/test/toolprovider/Test8251943.java
+++ b/test/java/org/openjdk/jextract/test/toolprovider/Test8251943.java
@@ -33,7 +33,7 @@ import static org.testng.Assert.assertNotNull;
 
 /*
  * @test
- * @library /test/lib
+ * @library /lib
  * @build JextractToolRunner
  * @bug 8251943
  * @summary jextract should not generate MemorySegment typed fields for variables, struct fields if layout size info is not available

--- a/test/java/org/openjdk/jextract/test/toolprovider/Test8258223.java
+++ b/test/java/org/openjdk/jextract/test/toolprovider/Test8258223.java
@@ -29,14 +29,6 @@ import org.openjdk.jextract.test.TestUtils;
 import org.testng.annotations.Test;
 import static org.testng.Assert.assertNotNull;
 
-/*
- * @test
- * @library /lib
- * @build JextractToolRunner
- * @bug 8258223
- * @summary jextract throws exception when unsupport type is used in anonymous struct
- * @run testng/othervm --enable-native-access=ALL-UNNAMED Test8258223
- */
 public class Test8258223 extends JextractToolRunner {
     @Test
     public void test() {

--- a/test/java/org/openjdk/jextract/test/toolprovider/Test8258223.java
+++ b/test/java/org/openjdk/jextract/test/toolprovider/Test8258223.java
@@ -31,7 +31,7 @@ import static org.testng.Assert.assertNotNull;
 
 /*
  * @test
- * @library /test/lib
+ * @library /lib
  * @build JextractToolRunner
  * @bug 8258223
  * @summary jextract throws exception when unsupport type is used in anonymous struct

--- a/test/java/org/openjdk/jextract/test/toolprovider/Test8258405.java
+++ b/test/java/org/openjdk/jextract/test/toolprovider/Test8258405.java
@@ -29,14 +29,6 @@ import org.openjdk.jextract.test.TestUtils;
 import org.testng.annotations.Test;
 import static org.testng.Assert.assertNotNull;
 
-/*
- * @test
- * @library /lib
- * @build JextractToolRunner
- * @bug 8258405
- * @summary functional interfaces are not generated for struct fields/global variables with function pointers
- * @run testng/othervm --enable-native-access=ALL-UNNAMED Test8258405
- */
 public class Test8258405 extends JextractToolRunner {
     @Test
     public void test() {

--- a/test/java/org/openjdk/jextract/test/toolprovider/Test8258405.java
+++ b/test/java/org/openjdk/jextract/test/toolprovider/Test8258405.java
@@ -31,7 +31,7 @@ import static org.testng.Assert.assertNotNull;
 
 /*
  * @test
- * @library /test/lib
+ * @library /lib
  * @build JextractToolRunner
  * @bug 8258405
  * @summary functional interfaces are not generated for struct fields/global variables with function pointers

--- a/test/java/org/openjdk/jextract/test/toolprovider/Test8260344.java
+++ b/test/java/org/openjdk/jextract/test/toolprovider/Test8260344.java
@@ -30,7 +30,7 @@ import org.testng.annotations.Test;
 
 /*
  * @test
- * @library /test/lib
+ * @library /lib
  * @build JextractToolRunner
  * @bug 8260344
  * @summary jextract crashes with exception for log.h from libdebian-installer4-dev

--- a/test/java/org/openjdk/jextract/test/toolprovider/Test8260344.java
+++ b/test/java/org/openjdk/jextract/test/toolprovider/Test8260344.java
@@ -28,14 +28,6 @@ import java.nio.file.Path;
 import org.openjdk.jextract.test.TestUtils;
 import org.testng.annotations.Test;
 
-/*
- * @test
- * @library /lib
- * @build JextractToolRunner
- * @bug 8260344
- * @summary jextract crashes with exception for log.h from libdebian-installer4-dev
- * @run testng/othervm --enable-native-access=ALL-UNNAMED -Duser.language=en Test8260344
- */
 public class Test8260344 extends JextractToolRunner {
     @Test
     public void test() {

--- a/test/java/org/openjdk/jextract/test/toolprovider/Test8260705.java
+++ b/test/java/org/openjdk/jextract/test/toolprovider/Test8260705.java
@@ -34,7 +34,7 @@ import static org.testng.Assert.assertTrue;
 
 /*
  * @test
- * @library /test/lib
+ * @library /lib
  * @build JextractToolRunner
  * @bug 8260705
  * @summary jextract crash with libbart's types.h

--- a/test/java/org/openjdk/jextract/test/toolprovider/Test8260705.java
+++ b/test/java/org/openjdk/jextract/test/toolprovider/Test8260705.java
@@ -32,14 +32,6 @@ import org.testng.annotations.Test;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
-/*
- * @test
- * @library /lib
- * @build JextractToolRunner
- * @bug 8260705
- * @summary jextract crash with libbart's types.h
- * @run testng/othervm --enable-native-access=ALL-UNNAMED Test8260705
- */
 public class Test8260705 extends JextractToolRunner {
     @Test
     public void test() {

--- a/test/java/org/openjdk/jextract/test/toolprovider/Test8260717.java
+++ b/test/java/org/openjdk/jextract/test/toolprovider/Test8260717.java
@@ -29,14 +29,6 @@ import jdk.incubator.foreign.MemorySegment;
 import org.openjdk.jextract.test.TestUtils;
 import org.testng.annotations.Test;
 
-/*
- * @test
- * @library /lib
- * @build JextractToolRunner
- * @bug 8260717
- * @summary jextract crashes with 'Crossing storage unit boundaries' for libcoap's block.h
- * @run testng/othervm --enable-native-access=ALL-UNNAMED Test8260717
- */
 public class Test8260717 extends JextractToolRunner {
     @Test
     public void test() {

--- a/test/java/org/openjdk/jextract/test/toolprovider/Test8260717.java
+++ b/test/java/org/openjdk/jextract/test/toolprovider/Test8260717.java
@@ -31,7 +31,7 @@ import org.testng.annotations.Test;
 
 /*
  * @test
- * @library /test/lib
+ * @library /lib
  * @build JextractToolRunner
  * @bug 8260717
  * @summary jextract crashes with 'Crossing storage unit boundaries' for libcoap's block.h

--- a/test/java/org/openjdk/jextract/test/toolprovider/Test8260929.java
+++ b/test/java/org/openjdk/jextract/test/toolprovider/Test8260929.java
@@ -32,7 +32,7 @@ import static org.testng.Assert.assertNotNull;
 
 /*
  * @test
- * @library /test/lib
+ * @library /lib
  * @build JextractToolRunner
  * @bug 8260929
  * @summary jextract crashes with libdnet's rabdef.h

--- a/test/java/org/openjdk/jextract/test/toolprovider/Test8260929.java
+++ b/test/java/org/openjdk/jextract/test/toolprovider/Test8260929.java
@@ -30,14 +30,6 @@ import org.testng.annotations.Test;
 import jdk.incubator.foreign.MemorySegment;
 import static org.testng.Assert.assertNotNull;
 
-/*
- * @test
- * @library /lib
- * @build JextractToolRunner
- * @bug 8260929
- * @summary jextract crashes with libdnet's rabdef.h
- * @run testng/othervm --enable-native-access=ALL-UNNAMED Test8260929
- */
 public class Test8260929 extends JextractToolRunner {
     @Test
     public void test() {

--- a/test/java/org/openjdk/jextract/test/toolprovider/Test8261893.java
+++ b/test/java/org/openjdk/jextract/test/toolprovider/Test8261893.java
@@ -31,7 +31,7 @@ import static org.testng.Assert.assertNotNull;
 
 /*
  * @test
- * @library /test/lib
+ * @library /lib
  * @build JextractToolRunner
  * @bug 8261893
  * @summary jextract generates class names that are restricted type names

--- a/test/java/org/openjdk/jextract/test/toolprovider/Test8261893.java
+++ b/test/java/org/openjdk/jextract/test/toolprovider/Test8261893.java
@@ -29,14 +29,6 @@ import org.openjdk.jextract.test.TestUtils;
 import org.testng.annotations.Test;
 import static org.testng.Assert.assertNotNull;
 
-/*
- * @test
- * @library /lib
- * @build JextractToolRunner
- * @bug 8261893
- * @summary jextract generates class names that are restricted type names
- * @run testng/othervm --enable-native-access=ALL-UNNAMED -Duser.language=en Test8261893
- */
 public class Test8261893 extends JextractToolRunner {
     @Test
     public void test() {

--- a/test/java/org/openjdk/jextract/test/toolprovider/Test8262117.java
+++ b/test/java/org/openjdk/jextract/test/toolprovider/Test8262117.java
@@ -32,14 +32,6 @@ import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
-/*
- * @test
- * @library /lib
- * @build JextractToolRunner
- * @bug 8262117
- * @summary jextract crashes with javac compilation error "class u is already defined"
- * @run testng/othervm --enable-native-access=ALL-UNNAMED Test8262117
- */
 public class Test8262117 extends JextractToolRunner {
     @Test
     public void testNameClash() {

--- a/test/java/org/openjdk/jextract/test/toolprovider/Test8262117.java
+++ b/test/java/org/openjdk/jextract/test/toolprovider/Test8262117.java
@@ -34,7 +34,7 @@ import static org.testng.Assert.assertTrue;
 
 /*
  * @test
- * @library /test/lib
+ * @library /lib
  * @build JextractToolRunner
  * @bug 8262117
  * @summary jextract crashes with javac compilation error "class u is already defined"

--- a/test/java/org/openjdk/jextract/test/toolprovider/Test8262733.java
+++ b/test/java/org/openjdk/jextract/test/toolprovider/Test8262733.java
@@ -30,7 +30,7 @@ import static org.testng.Assert.assertNotNull;
 
 /*
  * @test
- * @library /test/lib
+ * @library /lib
  * @build JextractToolRunner
  * @bug 8262733
  * @summary jextract generates clashing names which results in compilation error with javac

--- a/test/java/org/openjdk/jextract/test/toolprovider/Test8262733.java
+++ b/test/java/org/openjdk/jextract/test/toolprovider/Test8262733.java
@@ -28,14 +28,6 @@ import org.testng.annotations.Test;
 import java.nio.file.Path;
 import static org.testng.Assert.assertNotNull;
 
-/*
- * @test
- * @library /lib
- * @build JextractToolRunner
- * @bug 8262733
- * @summary jextract generates clashing names which results in compilation error with javac
- * @run testng/othervm --enable-native-access=ALL-UNNAMED Test8262733
- */
 public class Test8262733 extends JextractToolRunner {
     @Test
     public void test() {

--- a/test/java/org/openjdk/jextract/test/toolprovider/Test8262825.java
+++ b/test/java/org/openjdk/jextract/test/toolprovider/Test8262825.java
@@ -30,7 +30,7 @@ import static org.testng.Assert.assertNotNull;
 
 /*
  * @test
- * @library /test/lib
+ * @library /lib
  * @build JextractToolRunner
  * @bug 8262825
  * @summary jextract crashes when Java type names like String are used as identifiers in C header

--- a/test/java/org/openjdk/jextract/test/toolprovider/Test8262825.java
+++ b/test/java/org/openjdk/jextract/test/toolprovider/Test8262825.java
@@ -28,14 +28,6 @@ import org.testng.annotations.Test;
 import java.nio.file.Path;
 import static org.testng.Assert.assertNotNull;
 
-/*
- * @test
- * @library /lib
- * @build JextractToolRunner
- * @bug 8262825
- * @summary jextract crashes when Java type names like String are used as identifiers in C header
- * @run testng/othervm --enable-native-access=ALL-UNNAMED Test8262825
- */
 public class Test8262825 extends JextractToolRunner {
     @Test
     public void test() {

--- a/test/java/org/openjdk/jextract/test/toolprovider/Test8262851.java
+++ b/test/java/org/openjdk/jextract/test/toolprovider/Test8262851.java
@@ -30,7 +30,7 @@ import static org.testng.Assert.assertNotNull;
 
 /*
  * @test
- * @library /test/lib
+ * @library /lib
  * @build JextractToolRunner
  * @bug 8262851
  * @summary jextract crashes with "Cannot compute size of a layout which is, or depends on a sequence layout with unspecified size"

--- a/test/java/org/openjdk/jextract/test/toolprovider/Test8262851.java
+++ b/test/java/org/openjdk/jextract/test/toolprovider/Test8262851.java
@@ -28,14 +28,6 @@ import org.testng.annotations.Test;
 import java.nio.file.Path;
 import static org.testng.Assert.assertNotNull;
 
-/*
- * @test
- * @library /lib
- * @build JextractToolRunner
- * @bug 8262851
- * @summary jextract crashes with "Cannot compute size of a layout which is, or depends on a sequence layout with unspecified size"
- * @run testng/othervm --enable-native-access=ALL-UNNAMED Test8262851
- */
 public class Test8262851 extends JextractToolRunner {
     @Test
     public void test() {

--- a/test/java/org/openjdk/jextract/test/toolprovider/TestAttributedPointerTypedef.java
+++ b/test/java/org/openjdk/jextract/test/toolprovider/TestAttributedPointerTypedef.java
@@ -22,12 +22,6 @@
  */
 package org.openjdk.jextract.test.toolprovider;
 
-/*
- * @test
- * @build JextractToolRunner
- * @run testng/othervm --enable-native-access=org.openjdk.jextract TestAttributedPointerTypedef
- */
-
 import org.testng.annotations.Test;
 
 public class TestAttributedPointerTypedef extends JextractToolRunner {

--- a/test/java/org/openjdk/jextract/test/toolprovider/TestClassGeneration.java
+++ b/test/java/org/openjdk/jextract/test/toolprovider/TestClassGeneration.java
@@ -42,7 +42,6 @@ import static jdk.incubator.foreign.MemoryLayout.PathElement.sequenceElement;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 
-//@Ignore // FIXME needs native lib
 public class TestClassGeneration extends JextractToolRunner {
 
     private static final VarHandle VH_bytes = MemoryLayout.sequenceLayout(C_CHAR).varHandle(sequenceElement());

--- a/test/java/org/openjdk/jextract/test/toolprovider/TestFilters.java
+++ b/test/java/org/openjdk/jextract/test/toolprovider/TestFilters.java
@@ -23,13 +23,6 @@
 
 package org.openjdk.jextract.test.toolprovider;
 
-/*
- * @test
- * @library /lib
- * @build JextractToolRunner
- * @run testng/othervm --enable-native-access=ALL-UNNAMED -Duser.language=en TestFilters
- */
-
 import org.openjdk.jextract.test.TestUtils;
 import org.testng.annotations.Test;
 

--- a/test/java/org/openjdk/jextract/test/toolprovider/TestFilters.java
+++ b/test/java/org/openjdk/jextract/test/toolprovider/TestFilters.java
@@ -25,7 +25,7 @@ package org.openjdk.jextract.test.toolprovider;
 
 /*
  * @test
- * @library /test/lib
+ * @library /lib
  * @build JextractToolRunner
  * @run testng/othervm --enable-native-access=ALL-UNNAMED -Duser.language=en TestFilters
  */

--- a/test/java/org/openjdk/jextract/test/toolprovider/TestNested.java
+++ b/test/java/org/openjdk/jextract/test/toolprovider/TestNested.java
@@ -41,7 +41,7 @@ import static org.testng.Assert.fail;
 
 /*
  * @test
- * @library /test/lib
+ * @library /lib
  * @build JextractToolRunner
  * @bug 8244512 8252759
  * @summary test nested structs and unions

--- a/test/java/org/openjdk/jextract/test/toolprovider/TestNested.java
+++ b/test/java/org/openjdk/jextract/test/toolprovider/TestNested.java
@@ -39,14 +39,6 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.fail;
 
-/*
- * @test
- * @library /lib
- * @build JextractToolRunner
- * @bug 8244512 8252759
- * @summary test nested structs and unions
- * @run testng/othervm --enable-native-access=ALL-UNNAMED TestNested
- */
 public class TestNested extends JextractToolRunner {
     @Test
     public void testNestedStructs() {

--- a/test/java/org/openjdk/jextract/test/toolprovider/TestSplit.java
+++ b/test/java/org/openjdk/jextract/test/toolprovider/TestSplit.java
@@ -29,13 +29,15 @@ import org.testng.annotations.Ignore;
 import org.testng.annotations.Test;
 import static org.testng.Assert.*;
 
+// This test is ignored because we cannot set the "-Djextract.decls.per.header" here (as all testng tests are
+// executed in the same VM). Moving the test in a non-testng folder is possible, but this test depends on
+// JextractToolRunner and TestUtils which makes it hard.
 @Ignore
 public class TestSplit extends JextractToolRunner {
     @Test
     public void testSplit() {
         Path splitOutput = getOutputFilePath("split");
         Path splitH = getInputFilePath("split.h");
-        //System.setProperty("-Djextract.decls.per.header", "1");
         run("-d", splitOutput.toString(), splitH.toString()).checkSuccess();
         try(TestUtils.Loader loader = TestUtils.classLoader(splitOutput)) {
             checkPresent(loader, "split_h");

--- a/test/java/org/openjdk/jextract/test/toolprovider/UniondeclTest.java
+++ b/test/java/org/openjdk/jextract/test/toolprovider/UniondeclTest.java
@@ -34,7 +34,7 @@ import static org.testng.Assert.assertTrue;
 
 /*
  * @test
- * @library /test/lib
+ * @library /lib
  * @build JextractToolRunner
  * @run testng/othervm --enable-native-access=ALL-UNNAMED UniondeclTest
  */

--- a/test/java/org/openjdk/jextract/test/toolprovider/UniondeclTest.java
+++ b/test/java/org/openjdk/jextract/test/toolprovider/UniondeclTest.java
@@ -32,12 +32,6 @@ import jdk.incubator.foreign.GroupLayout;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
-/*
- * @test
- * @library /lib
- * @build JextractToolRunner
- * @run testng/othervm --enable-native-access=ALL-UNNAMED UniondeclTest
- */
 public class UniondeclTest extends JextractToolRunner {
     @Test
     public void unionDecl() {


### PR DESCRIPTION
The `@library` tags in jtreg tests are wrong. According to the tag specification here:

https://openjdk.java.net/jtreg/tag-spec.html

If an absolute path is used in combination with `@library`, the path should be interpreted as either relative to the test root (e.g. test/), or relative to an external root path (specified with a property in TEST.ROOT). Since we're not using any property, it follows that the library path should be relative to `test/` - which means `/lib` is the correct choice here, not `/test/lib`.

(I discovered this when using the jtreg plugin [1] to run the jextract tests - these bad `@library` tags were causing a crash in the plugin; of course the plugin should be fixed - but the tags in the tests should be fixed as well).

[1] - https://github.com/openjdk/jtreg/tree/master/plugins/idea

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Athijegannathan Sundararajan](https://openjdk.java.net/census#sundar) (@sundararajana - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jextract pull/16/head:pull/16` \
`$ git checkout pull/16`

Update a local copy of the PR: \
`$ git checkout pull/16` \
`$ git pull https://git.openjdk.java.net/jextract pull/16/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16`

View PR using the GUI difftool: \
`$ git pr show -t 16`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jextract/pull/16.diff">https://git.openjdk.java.net/jextract/pull/16.diff</a>

</details>
