### PR TITLE
7903154: jextract build fails on Windows

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ def jextract_app_dir = "$buildDir/jextract"
 def clang_include_dir = "${llvm_home}/lib/clang/${clang_version}/include"
 checkPath(clang_include_dir)
 def os_lib_dir = Os.isFamily(Os.FAMILY_WINDOWS)? "bin" : "lib"
+def os_script_extension = Os.isFamily(Os.FAMILY_WINDOWS)? ".bat" : ""
 def libclang_dir = "${llvm_home}/${os_lib_dir}"
 checkPath(libclang_dir)
 
@@ -110,7 +111,7 @@ task createJextractImage(type: Exec) {
          "--output=${jextract_app_dir}",
          "--launcher=jextract=org.openjdk.jextract/org.openjdk.jextract.JextractTool",
          "--add-options",
-         "\"--enable-native-access=org.openjdk.jextract\""
+         '"--enable-native-access=org.openjdk.jextract"'
     ]
 }
 
@@ -140,7 +141,7 @@ task jextractapp() {
 task verify(type: Exec) {
     dependsOn jextractapp
 
-    executable = "${jextract_app_dir}/bin/jextract"
+    executable = "${jextract_app_dir}/bin/jextract${os_script_extension}"
     args = [ "test.h", "-d", "$buildDir/integration_test" ]
 }
 


### PR DESCRIPTION
Apart from quote issue for --add-options, @mcimadamore found that the verify target failed as well. "jextract.bat" has to be launched on Windows (instead of "jextract")