### PR TITLE
7903157: jextract crashes when header contains complex long double

### DIFF
--- a/src/main/java/org/openjdk/jextract/impl/UnsupportedLayouts.java
+++ b/src/main/java/org/openjdk/jextract/impl/UnsupportedLayouts.java
@@ -98,13 +98,14 @@ public final class UnsupportedLayouts {
 
         @Override
         public String visitDelegated(Type.Delegated t, Void unused) {
-            return t.kind() == Type.Delegated.Kind.TYPEDEF ?
+            return t.kind() != Type.Delegated.Kind.POINTER ?
                     firstUnsupportedType(t.type()) :
                     null;
             //in principle we should always do this:
             // return firstUnsupportedType(t.type());
-            // but if we do that, we might end up with infinite recursion. Old code did not have that issue
-            // as it was layout-based, but doing so it also missed unsupported pointer types (e.g. *long double)
+            // but if we do that, we might end up with infinite recursion (because of pointer types).
+            // Unsupported pointer types (e.g. *long double) are not detected, but they are not problematic layout-wise
+            // (e.g. they are always 32- or 64-bits, depending on the platform).
         }
 
         @Override


### PR DESCRIPTION
Following the work in JDK-7903146, jextract crashes when encountering an header that contains a `long double complex`. As it turns out, this was a latent issue: the analysis in UnsupportedLayouts did not recursively follow a `DelegatedType`, unless its kind was a `typedef`.

There were reasons as to why the recursion was restricted: following pointers blindly can lead to infinite recursion (A points to B which points back to A). Butpointers are never problematic in terms of layout: the layout of a pointer is always fixed (given a platform), independently of what the pointee actually is.

So, the fix is for the analysis to be applied recursively to the delegated type, unless the type is a pointer type. This correctly detects `long double complex` (but also `atomic long double` etc.).

I could not add a test because our test framework ensures that tests cannot rely on standard headers (by forcing the `-C-nostdinc` flag on clang). This is problematic, because it is not possible to use complex types in C w/o including `<complex.h>`, at least not in a portable fashion (on Windows, MSVC does not support the `_Complex` keyword defined in C99 [1]).

[1] - https://docs.microsoft.com/en-us/cpp/c-runtime-library/complex-math-support?view=msvc-170