### PR TITLE
7903164: cleanup jextract options

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,10 +128,11 @@ The `jextract` tool includes several customization options. Users can select in 
 | `--dump-includes <String>`                                   | dump included symbols into specified file (see below)        |
 | `--include-[function,macro,struct,union,typedef,var]<String>` | Include a symbol of the given name and kind in the generated bindings (see below). When one of these options is specified, any symbol that is not matched by any specified filters is omitted from the generated bindings. |
 
-#### clang compiler extra options
+#### Additional clang options
 
-If you want to pass extra options to clang compiler, you can create a file named _compile_flags.txt_ in the current directory.
-That text file can contain clang compiler options one per each line.
+Users can specify additional clang compiler options, by creating a file named
+`compile_flags.txt` in the current folder, as described [here]
+(https://clang.llvm.org/docs/JSONCompilationDatabase.html#alternatives).
 
 #### Filtering symbols
 

--- a/README.md
+++ b/README.md
@@ -131,8 +131,7 @@ The `jextract` tool includes several customization options. Users can select in 
 #### Additional clang options
 
 Users can specify additional clang compiler options, by creating a file named
-`compile_flags.txt` in the current folder, as described [here]
-(https://clang.llvm.org/docs/JSONCompilationDatabase.html#alternatives).
+`compile_flags.txt` in the current folder, as described [here](https://clang.llvm.org/docs/JSONCompilationDatabase.html#alternatives).
 
 #### Filtering symbols
 

--- a/README.md
+++ b/README.md
@@ -118,14 +118,20 @@ The `jextract` tool includes several customization options. Users can select in 
 
 | Option                                                       | Meaning                                                      |
 | :----------------------------------------------------------- | ------------------------------------------------------------ |
-| `--header-class-name <String>`                               | specify the name of the main header class                       |
-| `-t, --target-package <String>`                              | specify target package for the generated bindings            |
-| `-I <String>`                                                | specify include files path for the clang parser              |
-| `-l <String>`                                                | specify a library that will be loaded by the generated bindings |
-| `-d <String>`                                                | specify where to place generated files                       |
+| `-D <macro>`                                                 | define a C preprocessor macro                                |
+| `--header-class-name <name>`                                 | specify the name of the main header class                    |
+| `-t, --target-package <package>`                             | specify target package for the generated bindings            |
+| `-I <path>`                                                  | specify include files path for the clang parser              |
+| `-l <library>`                                               | specify a library that will be loaded by the generated bindings |
+| `--output <path>`                                            | specify where to place generated files                       |
 | `--source`                                                   | generate java sources instead of classfiles                  |
 | `--dump-includes <String>`                                   | dump included symbols into specified file (see below)        |
 | `--include-[function,macro,struct,union,typedef,var]<String>` | Include a symbol of the given name and kind in the generated bindings (see below). When one of these options is specified, any symbol that is not matched by any specified filters is omitted from the generated bindings. |
+
+#### clang compiler extra options
+
+If you want to pass extra options to clang compiler, you can create a file named _compile_flags.txt_ in the current directory.
+That text file can contain clang compiler options one per each line.
 
 #### Filtering symbols
 

--- a/build.gradle
+++ b/build.gradle
@@ -92,7 +92,7 @@ task verify(type: Exec) {
     dependsOn jextractapp
 
     executable = "${jextract_app_dir}/bin/jextract${os_script_extension}"
-    args = [ "test.h", "-d", "$buildDir/integration_test" ]
+    args = [ "test.h", "--output", "$buildDir/integration_test" ]
 }
 
 // jlink a JDK image with org.openjdk.jextract for testing

--- a/samples/cblas/compile.sh
+++ b/samples/cblas/compile.sh
@@ -1,4 +1,4 @@
-jextract -C "-D FORCE_OPENBLAS_COMPLEX_STRUCT" \
+jextract -D FORCE_OPENBLAS_COMPLEX_STRUCT \
   -I /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include \
   -l openblas -t blas /usr/local/opt/openblas/include/cblas.h
 

--- a/samples/cblas/compilesource.sh
+++ b/samples/cblas/compilesource.sh
@@ -1,4 +1,4 @@
-jextract --source -C "-D FORCE_OPENBLAS_COMPLEX_STRUCT" \
+jextract --source -D FORCE_OPENBLAS_COMPLEX_STRUCT \
   -I /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include \
   -l openblas -t blas /usr/local/opt/openblas/include/cblas.h
 

--- a/samples/libjimage/compilesource.sh
+++ b/samples/libjimage/compilesource.sh
@@ -1,0 +1,1 @@
+javac -d build --add-modules jdk.incubator.foreign org/unix/*.java org/openjdk/*.java

--- a/samples/opengl/compile.sh
+++ b/samples/opengl/compile.sh
@@ -1,4 +1,3 @@
 jextract -t opengl -lGL -l/System/Library/Frameworks/GLUT.framework/Versions/Current/GLUT \
   -I /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/ \
-  -C-F/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks \
   /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/GLUT.framework/Headers/glut.h

--- a/samples/opengl/compile_flags.txt
+++ b/samples/opengl/compile_flags.txt
@@ -1,0 +1,1 @@
+-F/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks

--- a/samples/opengl/compilesource.sh
+++ b/samples/opengl/compilesource.sh
@@ -1,6 +1,5 @@
 jextract --source -t opengl -lGL -l/System/Library/Frameworks/GLUT.framework/Versions/Current/GLUT \
   -I /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/ \
-  -C-F/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks \
   /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/GLUT.framework/Headers/glut.h
 
 javac --add-modules jdk.incubator.foreign opengl/*.java

--- a/src/main/java/org/openjdk/jextract/JextractTool.java
+++ b/src/main/java/org/openjdk/jextract/JextractTool.java
@@ -287,14 +287,14 @@ public final class JextractTool {
                                throw new OptionException(spec.help());
                            }
                            argValue = args[i + 1];
-                           // do not allow argument value to start with '-'
-                           // this will catch issues like "-l-lclang", "-l -t"
-                           if (argValue.charAt(0) == '-') {
-                               throw new OptionException(spec.help());
-                           }
                            i++; // consume value from next command line arg
                        } // else -DFOO like case. argValue already set
 
+                       // do not allow argument value to start with '-'
+                       // this will catch issues like "-l-lclang", "-l -t"
+                       if (argValue.charAt(0) == '-') {
+                           throw new OptionException(spec.help());
+                       }
                        values = options.getOrDefault(spec.name(), new ArrayList<String>());
                        values.add(argValue);
                    } else {

--- a/src/main/resources/org/openjdk/jextract/impl/resources/Messages.properties
+++ b/src/main/resources/org/openjdk/jextract/impl/resources/Messages.properties
@@ -28,19 +28,19 @@ not.a.file=not a file: {0}
 l.option.value.invalid=option value for -l option should be a name or an absolute path: {0}
 
 # help messages for options
-help.C=pass through argument for clang
 help.I=specify include files path
-help.d=specify where to place generated files
 help.include-macro=name of constant macro to include
 help.include-var=name of global variable to include
 help.include-function=name of function to include
 help.include-typedef=name of type definition to include
 help.include-struct=name of struct definition to include
 help.include-union=name of union definition to include
+help.D=define a C preprocessor macro
 help.dump-includes=dump included symbols into specified file
 help.h=print help
 help.header-class-name=name of the header class
 help.l=specify a library
+help.output=specify the directory to place generated files
 help.source=generate java sources
 help.t=target package for specified header files
 help.non.option=header file
@@ -50,17 +50,17 @@ Usage: jextract <options> <header file>                                  \n\
 Option                         Description                               \n\
 ------                         -----------                               \n\
 -?, -h, --help                 print help                                \n\
--C <String>                    pass through argument for clang           \n\
--I <String>                    specify include files path                \n\
--d <String>                    specify where to place generated files    \n\
---dump-includes <String>       dump included symbols into specified file \n\
---header-class-name <String>   name of the header class                  \n\
---include-function <String>    name of function to include               \n\
---include-macro <String>       name of constant macro to include         \n\
---include-struct <String>      name of struct definition to include      \n\
---include-typedef <String>     name of type definition to include        \n\
---include-union <String>       name of union definition to include       \n\
---include-var <String>         name of global variable to include        \n\
--l <String>                    specify a library                         \n\
+-D <macro>                     define a C preprocessor macro             \n\
+-I <path>                      specify include files path                \n\
+--dump-includes <file>         dump included symbols into specified file \n\
+--header-class-name <name>     name of the header class                  \n\
+--include-function <name>      name of function to include               \n\
+--include-macro <name>         name of constant macro to include         \n\
+--include-struct <name>        name of struct definition to include      \n\
+--include-typedef <name>       name of type definition to include        \n\
+--include-union <name>         name of union definition to include       \n\
+--include-var <name>           name of global variable to include        \n\
+-l <library>                   specify a library name or absolute library path   \n\
+--output <path>                specify the directory to place generated files    \n\
 --source                       generate java sources                     \n\
--t, --target-package <String>  target package for specified header files \n
+-t, --target-package <package> target package for specified header files \n

--- a/test/jtreg/TestSplit.java
+++ b/test/jtreg/TestSplit.java
@@ -38,7 +38,7 @@ public class TestSplit extends JextractToolRunner {
     public void testSplit() {
         Path splitOutput = getOutputFilePath("split");
         Path splitH = getInputFilePath("split.h");
-        run("-d", splitOutput.toString(), splitH.toString()).checkSuccess();
+        run("--output", splitOutput.toString(), splitH.toString()).checkSuccess();
         try(TestUtils.Loader loader = TestUtils.classLoader(splitOutput)) {
             checkPresent(loader, "split_h");
             checkPresent(loader, "split_h_1");

--- a/test/lib/JtregJextract.java
+++ b/test/lib/JtregJextract.java
@@ -63,10 +63,10 @@ public class JtregJextract {
         ArrayList<String> jextrOpts = new ArrayList<>();
 
         jextrOpts.clear();
-        jextrOpts.add("-C-nostdinc");
+        // FIXME jextrOpts.add("-C-nostdinc");
         jextrOpts.add("-I");
         jextrOpts.add(inputDir.toAbsolutePath().toString());
-        jextrOpts.add("-d");
+        jextrOpts.add("--output");
         jextrOpts.add(outputDir.toAbsolutePath().toString());
 
         int i = 0;
@@ -86,7 +86,7 @@ public class JtregJextract {
                 continue;
             }
 
-            if ("-d".equals(opt)) {
+            if ("--output".equals(opt)) {
                 i++;
                 continue;
             }

--- a/test/testng/org/openjdk/jextract/test/toolprovider/BadBitfieldTest.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/BadBitfieldTest.java
@@ -54,7 +54,7 @@ import testlib.JextractToolRunner;
 public class BadBitfieldTest extends JextractToolRunner {
     @Test
     public void testBadBitfield() {
-        run("-d", getOutputFilePath("badBitfieldsGen").toString(),
+        run("--output", getOutputFilePath("badBitfieldsGen").toString(),
                 getInputFilePath("badBitfields.h").toString()).checkSuccess();
     }
 }

--- a/test/testng/org/openjdk/jextract/test/toolprovider/ConstantsTest.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/ConstantsTest.java
@@ -50,7 +50,7 @@ public class ConstantsTest extends JextractToolRunner {
     @BeforeTest
     public void setup() {
         dirPath = getOutputFilePath("ConstantsTest_output");
-        run( "-d", dirPath.toString(), getInputFilePath("constants.h").toString()).checkSuccess();
+        run( "--output", dirPath.toString(), getInputFilePath("constants.h").toString()).checkSuccess();
         loader = TestUtils.classLoader(dirPath);
         constants = loader.loadClass("constants_h");
     }

--- a/test/testng/org/openjdk/jextract/test/toolprovider/IncompleteArrayTest.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/IncompleteArrayTest.java
@@ -39,7 +39,7 @@ public class IncompleteArrayTest extends JextractToolRunner {
         Path input = getInputFilePath("incompleteArray.h");
         run(
             "-t", "org.jextract",
-            "-d", output,
+            "--output", output,
             input).checkSuccess();
         try (TestUtils.Loader loader = TestUtils.classLoader(output)) {
             Class<?> cls = loader.loadClass("org.jextract.Foo");

--- a/test/testng/org/openjdk/jextract/test/toolprovider/RepeatedDeclsTest.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/RepeatedDeclsTest.java
@@ -42,7 +42,7 @@ public class RepeatedDeclsTest extends JextractToolRunner {
     public void repeatedDecls() throws Throwable {
         Path repeatedDeclsOutput = getOutputFilePath("repeatedDeclsgen");
         Path repeatedDeclsH = getInputFilePath("repeatedDecls.h");
-        run("-d", repeatedDeclsOutput.toString(), repeatedDeclsH.toString()).checkSuccess();
+        run("--output", repeatedDeclsOutput.toString(), repeatedDeclsH.toString()).checkSuccess();
         try(TestUtils.Loader loader = TestUtils.classLoader(repeatedDeclsOutput)) {
             Class<?> cls = loader.loadClass("repeatedDecls_h");
             // check a method for "void func(int)"

--- a/test/testng/org/openjdk/jextract/test/toolprovider/Test7903148.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/Test7903148.java
@@ -35,7 +35,7 @@ public class Test7903148 extends JextractToolRunner {
     public void test() {
         Path output = getOutputFilePath("7903148gen");
         Path outputH = getInputFilePath("test7903148.h");
-        run("-d", output.toString(), outputH.toString()).checkSuccess();
+        run("--output", output.toString(), outputH.toString()).checkSuccess();
         try(TestUtils.Loader loader = TestUtils.classLoader(output)) {
             Class<?> headerCls = loader.loadClass("test7903148_h");
             assertNotNull(headerCls);

--- a/test/testng/org/openjdk/jextract/test/toolprovider/Test7903158.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/Test7903158.java
@@ -34,7 +34,7 @@ public class Test7903158 extends JextractToolRunner {
     public void test() {
         Path output = getOutputFilePath("7903158gen");
         Path outputH = getInputFilePath("test7903158.h");
-        run("-d", output.toString(), outputH.toString()).checkSuccess();
+        run("--output", output.toString(), outputH.toString()).checkSuccess();
         try(TestUtils.Loader loader = TestUtils.classLoader(output)) {
             assertNotNull(loader.loadClass("test7903158_h"));
             assertNotNull(loader.loadClass("func"));

--- a/test/testng/org/openjdk/jextract/test/toolprovider/Test7903164.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/Test7903164.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package org.openjdk.jextract.test.toolprovider;
+
+import testlib.JextractToolRunner;
+import testlib.TestUtils;
+import org.testng.annotations.Test;
+import java.nio.file.Path;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+
+public class Test7903164 extends JextractToolRunner {
+    @Test
+    public void testWithoutMacro() {
+        Path output = getOutputFilePath("7903164gen_withoutmacro");
+        Path outputH = getInputFilePath("test7903164.h");
+        run("--output", output.toString(), outputH.toString()).checkSuccess();
+        try(TestUtils.Loader loader = TestUtils.classLoader(output)) {
+            assertNotNull(loader.loadClass("test7903164_h"));
+            assertNotNull(loader.loadClass("func"));
+            assertNull(loader.loadClass("func2"));
+        } finally {
+            TestUtils.deleteDir(output);
+        }
+    }
+
+    @Test
+    public void testWithMacro() {
+        Path output = getOutputFilePath("7903164gen_withmacro");
+        Path outputH = getInputFilePath("test7903164.h");
+        run("-D", "FOO", "--output", output.toString(), outputH.toString()).checkSuccess();
+        try(TestUtils.Loader loader = TestUtils.classLoader(output)) {
+            assertNotNull(loader.loadClass("test7903164_h"));
+            assertNotNull(loader.loadClass("func"));
+            assertNotNull(loader.loadClass("func2"));
+        } finally {
+            TestUtils.deleteDir(output);
+        }
+    }
+}

--- a/test/testng/org/openjdk/jextract/test/toolprovider/Test8240181.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/Test8240181.java
@@ -34,7 +34,7 @@ public class Test8240181 extends JextractToolRunner {
     public void testAnonymousEnum() {
         Path anonenumOutput = getOutputFilePath("anonenumgen");
         Path anonenumH = getInputFilePath("anonenum.h");
-        run("-d", anonenumOutput.toString(), anonenumH.toString()).checkSuccess();
+        run("--output", anonenumOutput.toString(), anonenumH.toString()).checkSuccess();
         try(TestUtils.Loader loader = TestUtils.classLoader(anonenumOutput)) {
             Class<?> cls = loader.loadClass("anonenum_h");
             checkIntGetter(cls, "RED", 0xff0000);

--- a/test/testng/org/openjdk/jextract/test/toolprovider/Test8240657.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/Test8240657.java
@@ -36,7 +36,7 @@ public class Test8240657 extends JextractToolRunner {
     public void testKeywordIdentifiers() {
         Path exportsOutput = getOutputFilePath("exportsgen");
         Path exportsH = getInputFilePath("exports.h");
-        run("-d", exportsOutput.toString(), exportsH.toString()).checkSuccess();
+        run("--output", exportsOutput.toString(), exportsH.toString()).checkSuccess();
         try(TestUtils.Loader loader = TestUtils.classLoader(exportsOutput)) {
             Class<?> cls = loader.loadClass("exports_h");
             assertNotNull(cls);

--- a/test/testng/org/openjdk/jextract/test/toolprovider/Test8240752.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/Test8240752.java
@@ -66,7 +66,7 @@ public class Test8240752 extends JextractToolRunner {
     public void testConstants() {
         Path floatConstsOutput = getOutputFilePath("floatconstsgen");
         Path floatConstsH = getInputFilePath("float_constants.h");
-        run("-d", floatConstsOutput.toString(), floatConstsH.toString()).checkSuccess();
+        run("--output", floatConstsOutput.toString(), floatConstsH.toString()).checkSuccess();
         try(TestUtils.Loader loader = TestUtils.classLoader(floatConstsOutput)) {
             Class<?> cls = loader.loadClass("float_constants_h");
             assertNotNull(cls);

--- a/test/testng/org/openjdk/jextract/test/toolprovider/Test8240811.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/Test8240811.java
@@ -40,7 +40,7 @@ public class Test8240811 extends JextractToolRunner {
     public void testNameCollision() {
         Path nameCollisionOutput = getOutputFilePath("name_collision_gen");
         Path nameCollisionH = getInputFilePath("name_collision.h");
-        run("-d", nameCollisionOutput.toString(), nameCollisionH.toString()).checkSuccess();
+        run("--output", nameCollisionOutput.toString(), nameCollisionH.toString()).checkSuccess();
         try(TestUtils.Loader loader = TestUtils.classLoader(nameCollisionOutput)) {
             Class<?> cls = loader.loadClass("name_collision_h");
             assertNotNull(cls);

--- a/test/testng/org/openjdk/jextract/test/toolprovider/Test8244412.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/Test8244412.java
@@ -36,7 +36,7 @@ public class Test8244412 extends JextractToolRunner {
     public void testPrimitiveTypedefs() {
         Path typedefsOutput = getOutputFilePath("typedefsgen");
         Path typedefsH = getInputFilePath("typedefs.h");
-        run("-d", typedefsOutput.toString(), typedefsH.toString()).checkSuccess();
+        run("--output", typedefsOutput.toString(), typedefsH.toString()).checkSuccess();
         try(TestUtils.Loader loader = TestUtils.classLoader(typedefsOutput)) {
             Class<?> headerCls = loader.loadClass("typedefs_h");
             assertNotNull(findField(headerCls, "byte_t"));

--- a/test/testng/org/openjdk/jextract/test/toolprovider/Test8245767.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/Test8245767.java
@@ -39,7 +39,7 @@ public class Test8245767 extends JextractToolRunner {
     public void testTypedefs() {
         Path test8245767Output = getOutputFilePath("test8245767_gen");
         Path test8245767H = getInputFilePath("test8245767.h");
-        run("-d", test8245767Output.toString(), test8245767H.toString()).checkSuccess();
+        run("--output", test8245767Output.toString(), test8245767H.toString()).checkSuccess();
         try(TestUtils.Loader loader = TestUtils.classLoader(test8245767Output)) {
             Class<?> cls = loader.loadClass("test8245767_h");
             assertNotNull(cls);

--- a/test/testng/org/openjdk/jextract/test/toolprovider/Test8248415.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/Test8248415.java
@@ -36,7 +36,7 @@ public class Test8248415 extends JextractToolRunner {
     public void testPointerFields() {
         Path outputPath = getOutputFilePath("output");
         Path headerFile = getInputFilePath("test8248415.h");
-        run("-d", outputPath.toString(), headerFile.toString()).checkSuccess();
+        run("--output", outputPath.toString(), headerFile.toString()).checkSuccess();
         try(TestUtils.Loader loader = TestUtils.classLoader(outputPath)) {
             Class<?> nodeClass = loader.loadClass("Node");
 

--- a/test/testng/org/openjdk/jextract/test/toolprovider/Test8248474.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/Test8248474.java
@@ -36,7 +36,7 @@ public class Test8248474 extends JextractToolRunner {
     public void testUnsafeHeaderName() {
         Path test8248474Output = getOutputFilePath("test8248474_gen");
         Path test8248474H = getInputFilePath("JDK-8248474.h");
-        run("-d", test8248474Output.toString(), test8248474H.toString()).checkSuccess();
+        run("--output", test8248474Output.toString(), test8248474H.toString()).checkSuccess();
         try(TestUtils.Loader loader = TestUtils.classLoader(test8248474Output)) {
             Class<?> cls = loader.loadClass("JDK_8248474_h");
             assertNotNull(cls);

--- a/test/testng/org/openjdk/jextract/test/toolprovider/Test8249290.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/Test8249290.java
@@ -35,7 +35,7 @@ public class Test8249290 extends JextractToolRunner {
     public void testVoidTypedef() {
         Path outputPath = getOutputFilePath("output8249290");
         Path headerFile = getInputFilePath("test8249290.h");
-        run("-d", outputPath.toString(), headerFile.toString()).checkSuccess();
+        run("--output", outputPath.toString(), headerFile.toString()).checkSuccess();
         try(TestUtils.Loader loader = TestUtils.classLoader(outputPath)) {
             Class<?> headerClass = loader.loadClass("test8249290_h");
             checkMethod(headerClass, "func", void.class, Addressable.class);

--- a/test/testng/org/openjdk/jextract/test/toolprovider/Test8249300.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/Test8249300.java
@@ -35,7 +35,7 @@ public class Test8249300 extends JextractToolRunner {
     public void testVoidTypedef() {
         Path outputPath = getOutputFilePath("output8249300");
         Path headerFile = getInputFilePath("test8249300.h");
-        run("-d", outputPath.toString(), headerFile.toString()).checkSuccess();
+        run("--output", outputPath.toString(), headerFile.toString()).checkSuccess();
         try(TestUtils.Loader loader = TestUtils.classLoader(outputPath)) {
             Class<?> headerClass = loader.loadClass("test8249300_h");
             checkMethod(headerClass, "func", void.class, Addressable.class);

--- a/test/testng/org/openjdk/jextract/test/toolprovider/Test8251943.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/Test8251943.java
@@ -39,7 +39,7 @@ public class Test8251943 extends JextractToolRunner {
     public void test() {
         Path outputPath = getOutputFilePath("output");
         Path headerFile = getInputFilePath("test8251943.h");
-        run("-d", outputPath.toString(), headerFile.toString()).checkSuccess();
+        run("--output", outputPath.toString(), headerFile.toString()).checkSuccess();
         try(TestUtils.Loader loader = TestUtils.classLoader(outputPath)) {
             Class<?> headerClass = loader.loadClass("test8251943_h");
             assertNull(findMethod(headerClass, "tzname$SEGMENT"));

--- a/test/testng/org/openjdk/jextract/test/toolprovider/Test8258223.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/Test8258223.java
@@ -36,7 +36,7 @@ public class Test8258223 extends JextractToolRunner {
     public void test() {
         Path test8258223Output = getOutputFilePath("test8258223_gen");
         Path test8258223H = getInputFilePath("test8258223.h");
-        run("-d", test8258223Output.toString(), test8258223H.toString()).checkSuccess();
+        run("--output", test8258223Output.toString(), test8258223H.toString()).checkSuccess();
         try(TestUtils.Loader loader = TestUtils.classLoader(test8258223Output)) {
             Class<?> cls = loader.loadClass("test8258223_h");
             assertNotNull(cls);

--- a/test/testng/org/openjdk/jextract/test/toolprovider/Test8258405.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/Test8258405.java
@@ -36,7 +36,7 @@ public class Test8258405 extends JextractToolRunner {
     public void test() {
         Path test8258405Output = getOutputFilePath("test8258405_gen");
         Path test8258405H = getInputFilePath("test8258405.h");
-        run("-d", test8258405Output.toString(), test8258405H.toString()).checkSuccess();
+        run("--output", test8258405Output.toString(), test8258405H.toString()).checkSuccess();
         try(TestUtils.Loader loader = TestUtils.classLoader(test8258405Output)) {
             Class<?> cls = loader.loadClass("test8258405_h");
             assertNotNull(cls);

--- a/test/testng/org/openjdk/jextract/test/toolprovider/Test8260344.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/Test8260344.java
@@ -35,7 +35,7 @@ public class Test8260344 extends JextractToolRunner {
         Path test8260344Output = getOutputFilePath("test8260344gen");
         try {
             Path test8260344H = getInputFilePath("test8260344.h");
-            run("-d", test8260344Output.toString(), test8260344H.toString()).checkSuccess();
+            run("--output", test8260344Output.toString(), test8260344H.toString()).checkSuccess();
         } finally {
             TestUtils.deleteDir(test8260344Output);
         }

--- a/test/testng/org/openjdk/jextract/test/toolprovider/Test8260705.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/Test8260705.java
@@ -39,7 +39,7 @@ public class Test8260705 extends JextractToolRunner {
     public void test() {
         Path outputPath = getOutputFilePath("output");
         Path headerFile = getInputFilePath("test8260705.h");
-        run("-d", outputPath.toString(), headerFile.toString()).checkSuccess();
+        run("--output", outputPath.toString(), headerFile.toString()).checkSuccess();
         try(TestUtils.Loader loader = TestUtils.classLoader(outputPath)) {
             Class<?> FooClass = loader.loadClass("Foo");
             checkMethod(FooClass, "c$get", byte.class, MemorySegment.class);

--- a/test/testng/org/openjdk/jextract/test/toolprovider/Test8260717.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/Test8260717.java
@@ -35,7 +35,7 @@ public class Test8260717 extends JextractToolRunner {
     public void test() {
         Path outputPath = getOutputFilePath("output");
         Path headerFile = getInputFilePath("test8260717.h");
-        run("-d", outputPath.toString(), headerFile.toString()).checkSuccess();
+        run("--output", outputPath.toString(), headerFile.toString()).checkSuccess();
         try(TestUtils.Loader loader = TestUtils.classLoader(outputPath)) {
             Class<?> FooClass = loader.loadClass("foo_t");
             checkMethod(FooClass, "s$get", short.class, MemorySegment.class);

--- a/test/testng/org/openjdk/jextract/test/toolprovider/Test8260929.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/Test8260929.java
@@ -37,7 +37,7 @@ public class Test8260929 extends JextractToolRunner {
     public void test() {
         Path outputPath = getOutputFilePath("output");
         Path headerFile = getInputFilePath("test8260929.h");
-        run("-d", outputPath.toString(), headerFile.toString()).checkSuccess();
+        run("--output", outputPath.toString(), headerFile.toString()).checkSuccess();
         try(TestUtils.Loader loader = TestUtils.classLoader(outputPath)) {
             assertNotNull(loader.loadClass("rab"));
             Class<?> rab2Class = loader.loadClass("rab2");

--- a/test/testng/org/openjdk/jextract/test/toolprovider/Test8261578.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/Test8261578.java
@@ -36,7 +36,7 @@ public class Test8261578 extends JextractToolRunner {
     public void test1() {
         Path outputPath = getOutputFilePath("output_1");
         Path headerFile = getInputFilePath("test8261578_1.h");
-        run("-d", outputPath.toString(), headerFile.toString()).checkSuccess();
+        run("--output", outputPath.toString(), headerFile.toString()).checkSuccess();
         try(TestUtils.Loader loader = TestUtils.classLoader(outputPath)) {
             Class<?> ndpi_class = loader.loadClass("ndpi_flow_tcp_struct");
             assertNotNull(ndpi_class);
@@ -51,7 +51,7 @@ public class Test8261578 extends JextractToolRunner {
     public void test2() {
         Path outputPath = getOutputFilePath("output_2");
         Path headerFile = getInputFilePath("test8261578_2.h");
-        run("-d", outputPath.toString(), headerFile.toString()).checkSuccess();
+        run("--output", outputPath.toString(), headerFile.toString()).checkSuccess();
         try(TestUtils.Loader loader = TestUtils.classLoader(outputPath)) {
             Class<?> foo_class = loader.loadClass("foo");
             assertNotNull(foo_class);
@@ -70,7 +70,7 @@ public class Test8261578 extends JextractToolRunner {
     public void test3() {
         Path outputPath = getOutputFilePath("output_3");
         Path headerFile = getInputFilePath("test8261578_3.h");
-        run("-d", outputPath.toString(), headerFile.toString()).checkSuccess();
+        run("--output", outputPath.toString(), headerFile.toString()).checkSuccess();
         try(TestUtils.Loader loader = TestUtils.classLoader(outputPath)) {
             Class<?> plugin_class = loader.loadClass("PluginCodec_H323AudioG7231AnnexC");
             assertNotNull(plugin_class);

--- a/test/testng/org/openjdk/jextract/test/toolprovider/Test8261893.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/Test8261893.java
@@ -36,7 +36,7 @@ public class Test8261893 extends JextractToolRunner {
     public void test() {
         Path test8261893Output = getOutputFilePath("test8261893gen");
         Path test8261893H = getInputFilePath("test8261893.h");
-        run("-d", test8261893Output.toString(), test8261893H.toString()).checkSuccess();
+        run("--output", test8261893Output.toString(), test8261893H.toString()).checkSuccess();
         try(TestUtils.Loader loader = TestUtils.classLoader(test8261893Output)) {
             assertNotNull(loader.loadClass("permits_"));
             assertNotNull(loader.loadClass("record_"));

--- a/test/testng/org/openjdk/jextract/test/toolprovider/Test8262117.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/Test8262117.java
@@ -39,7 +39,7 @@ public class Test8262117 extends JextractToolRunner {
     public void testNameClash() {
         Path test8262117Output = getOutputFilePath("test8262117_gen");
         Path test8262117H = getInputFilePath("test8262117.h");
-        run("-d", test8262117Output.toString(), test8262117H.toString()).checkSuccess();
+        run("--output", test8262117Output.toString(), test8262117H.toString()).checkSuccess();
         try(TestUtils.Loader loader = TestUtils.classLoader(test8262117Output)) {
             Class<?> cls = loader.loadClass("test8262117_h");
             assertNotNull(cls);

--- a/test/testng/org/openjdk/jextract/test/toolprovider/Test8262733.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/Test8262733.java
@@ -35,7 +35,7 @@ public class Test8262733 extends JextractToolRunner {
     public void test() {
         Path output = getOutputFilePath("8262733gen");
         Path outputH = getInputFilePath("test8262733.h");
-        run("-d", output.toString(), outputH.toString()).checkSuccess();
+        run("--output", output.toString(), outputH.toString()).checkSuccess();
         try(TestUtils.Loader loader = TestUtils.classLoader(output)) {
             Class<?> cls = loader.loadClass("test8262733_h");
             assertNotNull(cls);

--- a/test/testng/org/openjdk/jextract/test/toolprovider/Test8262825.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/Test8262825.java
@@ -35,7 +35,7 @@ public class Test8262825 extends JextractToolRunner {
     public void test() {
         Path output = getOutputFilePath("8262825gen");
         Path outputH = getInputFilePath("test8262825.h");
-        run("-d", output.toString(), outputH.toString()).checkSuccess();
+        run("--output", output.toString(), outputH.toString()).checkSuccess();
         try(TestUtils.Loader loader = TestUtils.classLoader(output)) {
             Class<?> cls = loader.loadClass("test8262825_h");
             assertNotNull(cls);

--- a/test/testng/org/openjdk/jextract/test/toolprovider/Test8262851.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/Test8262851.java
@@ -35,7 +35,7 @@ public class Test8262851 extends JextractToolRunner {
     public void test() {
         Path output = getOutputFilePath("8262851gen");
         Path outputH = getInputFilePath("test8262851.h");
-        run("-d", output.toString(), outputH.toString()).checkSuccess();
+        run("--output", output.toString(), outputH.toString()).checkSuccess();
         try(TestUtils.Loader loader = TestUtils.classLoader(output)) {
             assertNotNull(loader.loadClass("test8262851_h"));
             assertNotNull(loader.loadClass("Odd"));

--- a/test/testng/org/openjdk/jextract/test/toolprovider/TestAttributedPointerTypedef.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/TestAttributedPointerTypedef.java
@@ -22,13 +22,24 @@
  */
 package org.openjdk.jextract.test.toolprovider;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
 import org.testng.annotations.Test;
 import testlib.JextractToolRunner;
 
 public class TestAttributedPointerTypedef extends JextractToolRunner {
     @Test
-    public void testAttributedPointerTypedef() {
-        run("-C-fms-extensions", "-d", getOutputFilePath("attributedPointerTypedef").toString(),
+    public void testAttributedPointerTypedef() throws IOException {
+        Path compileFlagsTxt = Paths.get(".", "compile_flags.txt");
+        try {
+            Files.write(compileFlagsTxt, List.of("-fms-extensions"));
+            run("--output", getOutputFilePath("attributedPointerTypedef").toString(),
                 getInputFilePath("attributedPointerTypedef.h").toString()).checkSuccess();
+        } finally {
+            Files.delete(compileFlagsTxt);
+        }
     }
 }

--- a/test/testng/org/openjdk/jextract/test/toolprovider/TestClassGeneration.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/TestClassGeneration.java
@@ -209,7 +209,7 @@ public class TestClassGeneration extends JextractToolRunner {
         Path inputHeader = getInputFilePath("examples.h");
         run(
             "-t", "com.acme",
-            "-d", outputDir,
+            "--output", outputDir,
             "-l", "Examples",
             inputHeader
         ).checkSuccess();

--- a/test/testng/org/openjdk/jextract/test/toolprovider/TestFilters.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/TestFilters.java
@@ -43,7 +43,7 @@ public class TestFilters extends JextractToolRunner {
         for (FilterKind expectedKind : FilterKind.values()) {
             Path filterOutput = getOutputFilePath("filters_" + expectedKind);
             Path filterH = getInputFilePath("filters.h");
-            run("-d", filterOutput.toString(), expectedKind.filterOption, expectedKind.symbolName, filterH.toString()).checkSuccess();
+            run("--output", filterOutput.toString(), expectedKind.filterOption, expectedKind.symbolName, filterH.toString()).checkSuccess();
             try (TestUtils.Loader loader = TestUtils.classLoader(filterOutput)) {
                 Class<?> cls = loader.loadClass("filters_h");
                 for (FilterKind kind : FilterKind.values()) {

--- a/test/testng/org/openjdk/jextract/test/toolprovider/TestNested.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/TestNested.java
@@ -45,7 +45,7 @@ public class TestNested extends JextractToolRunner {
     public void testNestedStructs() {
         Path nestedOutput = getOutputFilePath("nestedgen");
         Path nestedH = getInputFilePath("nested.h");
-        run("-d", nestedOutput.toString(), nestedH.toString()).checkSuccess();
+        run("--output", nestedOutput.toString(), nestedH.toString()).checkSuccess();
         try(TestUtils.Loader loader = TestUtils.classLoader(nestedOutput)) {
             checkClass(loader, "Foo",
                 checkField("bar", MemorySegment.class, 0),

--- a/test/testng/org/openjdk/jextract/test/toolprovider/TestTypedefIsFunctionProto.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/TestTypedefIsFunctionProto.java
@@ -33,7 +33,7 @@ public class TestTypedefIsFunctionProto extends JextractToolRunner {
     public void testVoidTypedef() {
         Path outputPath = getOutputFilePath("outputTDIFP");
         Path headerFile = getInputFilePath("funcproto.h");
-        run("-d", outputPath.toString(), headerFile.toString()).checkSuccess();
+        run("--output", outputPath.toString(), headerFile.toString()).checkSuccess();
         // nothing is generated that we can check, so we just check that jextract ran successfully
         TestUtils.deleteDir(outputPath);
     }

--- a/test/testng/org/openjdk/jextract/test/toolprovider/UniondeclTest.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/UniondeclTest.java
@@ -39,7 +39,7 @@ public class UniondeclTest extends JextractToolRunner {
     public void unionDecl() {
         Path uniondeclOutput = getOutputFilePath("uniondecl.h");
         Path uniondeclH = getInputFilePath("uniondecl.h");
-        run("-d", uniondeclOutput.toString(), uniondeclH.toString()).checkSuccess();
+        run("--output", uniondeclOutput.toString(), uniondeclH.toString()).checkSuccess();
         try(TestUtils.Loader loader = TestUtils.classLoader(uniondeclOutput)) {
             Class<?> cls = loader.loadClass("uniondecl_h");
             // check a method for "void func(IntOrFloat*)"

--- a/test/testng/org/openjdk/jextract/test/toolprovider/test7903164.h
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/test7903164.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+typedef void (func)(const void *addr);
+
+#ifdef FOO
+
+typedef void (func2)(int scope);
+
+#endif


### PR DESCRIPTION
* added -D option for preprocessor macros
* renamed -d as --output
* added support for ./compile_flags.txt to pass extra clang options to jextract
* removed -C option

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [CODETOOLS-7903164](https://bugs.openjdk.java.net/browse/CODETOOLS-7903164): cleanup jextract options


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - Committer) ⚠️ Review applies to eded0d1ff9c8569459a5445b451138224d37443a


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jextract pull/23/head:pull/23` \
`$ git checkout pull/23`

Update a local copy of the PR: \
`$ git checkout pull/23` \
`$ git pull https://git.openjdk.java.net/jextract pull/23/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23`

View PR using the GUI difftool: \
`$ git pr show -t 23`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jextract/pull/23.diff">https://git.openjdk.java.net/jextract/pull/23.diff</a>

</details>
