### PR TITLE
7903167: jextract makefiles still use joptsimple and generated module-info.java

### DIFF
--- a/make/Build.gmk
+++ b/make/Build.gmk
@@ -3,7 +3,6 @@ include make/Common.gmk
 $(eval $(call SetupVariable,PANAMA_JAVA_HOME))
 $(eval $(call SetupVariable,LIBCLANG_HOME))
 $(eval $(call SetupVariable,LIBCLANG_VERSION,,NO_CHECK))
-$(eval $(call SetupVariable,JOPT_SIMPLE_JAR))
 
 include make/NativeCompilation.gmk
 
@@ -43,13 +42,13 @@ NATIVE_TEST_SOURCES := $(shell find $(TOPDIR)/test -name "lib*.c")
 
 $(foreach file,$(NATIVE_TEST_SOURCES),$(eval $(call BuildNativeLibrary,$(file),$(JEXTRACT_IMAGE_NATIVE_TEST_DIR),$(BUILD_TEST_SUPPORT_DIR),BUILD_NATIVE_TEST_LIBRARIES)))
 
-$(BUILD_CLASSES_DIR): $(JOPT_SIMPLE_JAR)
+$(BUILD_CLASSES_DIR):
 	$(MKDIR) -p $(BUILD_CLASSES_DIR)/org/openjdk/jextract/impl
 	$(FIXPATH) $(PANAMA_JAVA_HOME)/bin/javac \
 	    --release=18 \
 	    --add-modules=jdk.incubator.foreign \
-	    -cp "$(JOPT_SIMPLE_JAR)" \
 	    -d "$(BUILD_CLASSES_DIR)" \
+	    src/main/java/module-info.java \
 	    src/main/java/org/openjdk/jextract/*.java \
 	    src/main/java/org/openjdk/jextract/impl/*.java \
 	    src/main/java/org/openjdk/jextract/clang/*.java \
@@ -57,41 +56,11 @@ $(BUILD_CLASSES_DIR): $(JOPT_SIMPLE_JAR)
 	$(CP) -r src/main/java/META-INF $(BUILD_CLASSES_DIR)
 	$(CP) -r src/main/resources/org/openjdk/jextract/impl/resources $(BUILD_CLASSES_DIR)/org/openjdk/jextract/impl
 
-$(BUILD_MODULES_DIR): $(BUILD_CLASSES_DIR) $(JOPT_SIMPLE_JAR)
-	$(MKDIR) -p $(BUILD_MODULES_DIR)/jopt.simple
+$(BUILD_MODULES_DIR): $(BUILD_CLASSES_DIR)
 	$(MKDIR) -p $(BUILD_MODULES_DIR)/org.openjdk.jextract
-
-        # Generate module-info.java for jopt.simple module
-	@$(PRINTF) "module jopt.simple {\n \
-	    exports joptsimple;\n \
-	    exports joptsimple.util;\n \
-	}" > $(BUILD_MODULES_DIR)/jopt.simple/module-info.java
-
-        # Generate module-info.java for org.openjdk.jextract module
-	@$(PRINTF) "module org.openjdk.jextract {\n \
-	    requires transitive java.compiler;\n \
-	    requires transitive jdk.incubator.foreign;\n \
-	    requires jopt.simple;\n \
-	    requires java.prefs;\n \
-	    exports org.openjdk.jextract;\n \
-	    provides java.util.spi.ToolProvider with\n \
-	        org.openjdk.jextract.JextractTool.JextractToolProvider;\n \
-	}" > $(BUILD_MODULES_DIR)/org.openjdk.jextract/module-info.java
 
         # Copy org.openjdk.jextract classes to the right place
 	$(CP) -r $(BUILD_CLASSES_DIR)/* $(BUILD_MODULES_DIR)/org.openjdk.jextract
-
-        # Extract jopt-simple in the right place
-	($(CD) $(BUILD_MODULES_DIR)/jopt.simple; $(FIXPATH) $(PANAMA_JAVA_HOME)/bin/jar xf "$(JOPT_SIMPLE_JAR)")
-
-        # Compile the generated module-info.java files
-	$(FIXPATH) $(PANAMA_JAVA_HOME)/bin/javac \
-	    -d "$(BUILD_MODULES_DIR)/jopt.simple" \
-	    "$(BUILD_MODULES_DIR)/jopt.simple/module-info.java"
-	$(FIXPATH) $(PANAMA_JAVA_HOME)/bin/javac \
-	    --module-path "$(BUILD_MODULES_DIR)" \
-	    -d "$(BUILD_MODULES_DIR)/org.openjdk.jextract" \
-	    "$(BUILD_MODULES_DIR)/org.openjdk.jextract/module-info.java"
 
 $(JEXTRACT_IMAGE_DIR): $(BUILD_MODULES_DIR)
         # jlink the modules to create a custom runtime image for jextract


### PR DESCRIPTION
removed jopt dependency in makefiles as well.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [CODETOOLS-7903167](https://bugs.openjdk.java.net/browse/CODETOOLS-7903167): jextract makefiles still use joptsimple and generated module-info.java


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jextract pull/26/head:pull/26` \
`$ git checkout pull/26`

Update a local copy of the PR: \
`$ git checkout pull/26` \
`$ git pull https://git.openjdk.java.net/jextract pull/26/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26`

View PR using the GUI difftool: \
`$ git pr show -t 26`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jextract/pull/26.diff">https://git.openjdk.java.net/jextract/pull/26.diff</a>

</details>
