### PR TITLE
7903173: jextract makefile build, test fails on macOS Monterey

### DIFF
--- a/make/NativeCompilation.gmk
+++ b/make/NativeCompilation.gmk
@@ -75,6 +75,7 @@ else
     ifneq ($(SYSROOT),)
       CFLAGS += -isysroot $(SYSROOT)
     endif
+    LDFLAGS += -L/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib
   else
     ifeq ($(PLATFORM_OS), linux)
       SHARED_LIB_SUFFIX := .so


### PR DESCRIPTION
passing -L /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib via LDFLAGS. With that makefile build and test on macOS Monterey works fine.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [CODETOOLS-7903173](https://bugs.openjdk.java.net/browse/CODETOOLS-7903173): jextract makefile build, test fails on macOS Monterey


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jextract pull/27/head:pull/27` \
`$ git checkout pull/27`

Update a local copy of the PR: \
`$ git checkout pull/27` \
`$ git pull https://git.openjdk.java.net/jextract pull/27/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27`

View PR using the GUI difftool: \
`$ git pr show -t 27`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jextract/pull/27.diff">https://git.openjdk.java.net/jextract/pull/27.diff</a>

</details>
