### PR TITLE
Fix jextract GHA

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches-ignore:
       - master
+      - pr/*
   workflow_dispatch:
 
 jobs:
@@ -39,7 +40,7 @@ jobs:
     - name: 'Build Jextract'
       shell: sh
       run: |
-        sh ./gradlew -Pjdk18_home=$JAVA_HOME -Plibclang_home=./deps/clang+llvm-13.0.0-x86_64-linux-gnu-ubuntu-20.04 clean verify        
+        sh ./gradlew -Pjdk18_home=$JAVA_HOME -Pllvm_home=./deps/clang+llvm-13.0.0-x86_64-linux-gnu-ubuntu-20.04 clean verify        
 
     - name: 'Check out JTReg'
       uses: actions/checkout@v2
@@ -59,4 +60,4 @@ jobs:
     - name: 'Run tests'
       shell: sh
       run: |
-        sh ./gradlew -Pjdk18_home=$JAVA_HOME -Plibclang_home=./deps/clang+llvm-13.0.0-x86_64-linux-gnu-ubuntu-20.04 -Pjtreg_home=./deps/jtreg/build/images/jtreg jtreg
+        sh ./gradlew -Pjdk18_home=$JAVA_HOME -Pllvm_home=./deps/clang+llvm-13.0.0-x86_64-linux-gnu-ubuntu-20.04 -Pjtreg_home=./deps/jtreg/build/images/jtreg jtreg

--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ jar {
 task createJextractImage(type: Exec) {
     dependsOn jar
 
-    onlyIf { !new File("$buildDir/jextract-jdk-image").exists() }
+    onlyIf { !new File("${jextract_app_dir}").exists() }
 
     executable = "${jdk18_home}/bin/jlink"
     args = [


### PR DESCRIPTION
There are a couple of issue with the jextract GHA:
* the action does not ignore pr/* branches, which seems to be the norm in JDK
* the build is still referring to the old variable name `libclang_home` instead of `llvm_home`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jextract pull/28/head:pull/28` \
`$ git checkout pull/28`

Update a local copy of the PR: \
`$ git checkout pull/28` \
`$ git pull https://git.openjdk.java.net/jextract pull/28/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 28`

View PR using the GUI difftool: \
`$ git pr show -t 28`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jextract/pull/28.diff">https://git.openjdk.java.net/jextract/pull/28.diff</a>

</details>
