### PR TITLE
7903175: Workaround CODETOOLS-7903174

### DIFF
--- a/src/main/java/org/openjdk/jextract/clang/LibClang.java
+++ b/src/main/java/org/openjdk/jextract/clang/LibClang.java
@@ -45,8 +45,9 @@ import static org.openjdk.jextract.clang.libclang.Index_h.C_POINTER;
 
 public class LibClang {
     private static final boolean DEBUG = Boolean.getBoolean("libclang.debug");
-    private static final boolean CRASH_RECOVERY = Boolean.getBoolean("libclang.crash_recovery");
     private static final boolean IS_WINDOWS = System.getProperty("os.name").startsWith("Windows");
+    // crash recovery is not an issue on Windows, so enable it there by default to work around a libclang issue with reparseTranslationUnit
+    private static final boolean CRASH_RECOVERY = IS_WINDOWS || Boolean.getBoolean("libclang.crash_recovery");
 
     final static SegmentAllocator IMPLICIT_ALLOCATOR =
             (size, align) -> MemorySegment.allocateNative(size, align, ResourceScope.newImplicitScope());

--- a/src/main/java/org/openjdk/jextract/clang/TranslationUnit.java
+++ b/src/main/java/org/openjdk/jextract/clang/TranslationUnit.java
@@ -46,6 +46,7 @@ import static org.openjdk.jextract.clang.libclang.Index_h.C_POINTER;
 import static org.openjdk.jextract.clang.LibClang.IMPLICIT_ALLOCATOR;
 
 public class TranslationUnit implements AutoCloseable {
+    private static final int MAX_RETRIES = 10;
 
     private MemoryAddress tu;
 
@@ -102,11 +103,15 @@ public class TranslationUnit implements AutoCloseable {
                 start.set(C_POINTER, CONTENTS_OFFSET, allocator.allocateUtf8String(inMemoryFiles[i].contents));
                 start.set(C_INT, LENGTH_OFFSET, inMemoryFiles[i].contents.length());
             }
-            ErrorCode code = ErrorCode.valueOf(Index_h.clang_reparseTranslationUnit(
+            ErrorCode code;
+            int tries = 0;
+            do {
+                code = ErrorCode.valueOf(Index_h.clang_reparseTranslationUnit(
                         tu,
                         inMemoryFiles.length,
                         files == null ? MemoryAddress.NULL : files,
                         Index_h.clang_defaultReparseOptions(tu)));
+            } while(code == ErrorCode.Crashed || (++tries) < MAX_RETRIES); // this call can crash on Windows. Retry in that case.
 
             if (code != ErrorCode.Success) {
                 throw new IllegalStateException("Re-parsing failed: " + code);

--- a/src/main/java/org/openjdk/jextract/clang/TranslationUnit.java
+++ b/src/main/java/org/openjdk/jextract/clang/TranslationUnit.java
@@ -111,7 +111,7 @@ public class TranslationUnit implements AutoCloseable {
                         inMemoryFiles.length,
                         files == null ? MemoryAddress.NULL : files,
                         Index_h.clang_defaultReparseOptions(tu)));
-            } while(code == ErrorCode.Crashed || (++tries) < MAX_RETRIES); // this call can crash on Windows. Retry in that case.
+            } while(code == ErrorCode.Crashed && (++tries) < MAX_RETRIES); // this call can crash on Windows. Retry in that case.
 
             if (code != ErrorCode.Success) {
                 throw new IllegalStateException("Re-parsing failed: " + code);


### PR DESCRIPTION
This implements a workaround for the crash in clang_reparseTranslationUnit.

It enables libclang's crash recovery on Windows, and if there's a crash in reparseTranslationUnit, we simply retry the call. This seems to be enough to workaround the crash for now.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [CODETOOLS-7903175](https://bugs.openjdk.java.net/browse/CODETOOLS-7903175): Workaround CODETOOLS-7903174


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jextract pull/29/head:pull/29` \
`$ git checkout pull/29`

Update a local copy of the PR: \
`$ git checkout pull/29` \
`$ git pull https://git.openjdk.java.net/jextract pull/29/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 29`

View PR using the GUI difftool: \
`$ git pr show -t 29`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jextract/pull/29.diff">https://git.openjdk.java.net/jextract/pull/29.diff</a>

</details>
