### PR TITLE
7903187: jextract should support --version option

### DIFF
--- a/src/main/java/org/openjdk/jextract/JextractTool.java
+++ b/src/main/java/org/openjdk/jextract/JextractTool.java
@@ -25,6 +25,7 @@
 
 package org.openjdk.jextract;
 
+import org.openjdk.jextract.clang.LibClang;
 import org.openjdk.jextract.impl.ClangException;
 import org.openjdk.jextract.impl.CommandLine;
 import org.openjdk.jextract.impl.IncludeHelper;
@@ -353,7 +354,9 @@ public final class JextractTool {
         }
 
         if (optionSet.has("--version")) {
-            err.println(System.getProperty("java.version"));
+            err.printf("%s %s\n", "jextract", System.getProperty("java.version"));
+            err.printf("%s %s\n", "JDK version", System.getProperty("java.runtime.version"));
+            err.printf("%s\n", LibClang.version());
             return SUCCESS;
         }
 

--- a/src/main/java/org/openjdk/jextract/JextractTool.java
+++ b/src/main/java/org/openjdk/jextract/JextractTool.java
@@ -342,6 +342,7 @@ public final class JextractTool {
         parser.accepts("--output", format("help.output"), true);
         parser.accepts("--source", format("help.source"), false);
         parser.accepts("-t", List.of("--target-package"), format("help.t"), true);
+        parser.accepts("--version", format("help.version"), false);
 
         OptionSet optionSet;
         try {
@@ -349,6 +350,11 @@ public final class JextractTool {
         } catch (OptionException oe) {
             printOptionError(oe);
             return OPTION_ERROR;
+        }
+
+        if (optionSet.has("--version")) {
+            err.println(System.getProperty("java.version"));
+            return SUCCESS;
         }
 
         if (optionSet.has("-h")) {

--- a/src/main/resources/org/openjdk/jextract/impl/resources/Messages.properties
+++ b/src/main/resources/org/openjdk/jextract/impl/resources/Messages.properties
@@ -43,6 +43,7 @@ help.l=specify a library
 help.output=specify the directory to place generated files
 help.source=generate java sources
 help.t=target package for specified header files
+help.version=print version information and exit
 help.non.option=header file
 jextract.usage=\
 Usage: jextract <options> <header file>                                  \n\
@@ -63,4 +64,5 @@ Option                         Description                               \n\
 -l <library>                   specify a library name or absolute library path   \n\
 --output <path>                specify the directory to place generated files    \n\
 --source                       generate java sources                     \n\
--t, --target-package <package> target package for specified header files \n
+-t, --target-package <package> target package for specified header files \n\
+--version                      print version information and exit        \n

--- a/test/testng/org/openjdk/jextract/test/toolprovider/JextractToolProviderTest.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/JextractToolProviderTest.java
@@ -44,6 +44,11 @@ public class JextractToolProviderTest extends JextractToolRunner {
         run("-?").checkSuccess();
     }
 
+    @Test
+    public void testVersion() {
+        run("--version").checkSuccess();
+    }
+
     // error for non-existent args file
     @Test
     public void testNonExistentArgsFile() {


### PR DESCRIPTION
added --version option that prints the underlying Java version and exits.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no reviews required)

### Issue
 * [CODETOOLS-7903187](https://bugs.openjdk.java.net/browse/CODETOOLS-7903187): jextract should support --version option


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jextract pull/31/head:pull/31` \
`$ git checkout pull/31`

Update a local copy of the PR: \
`$ git checkout pull/31` \
`$ git pull https://git.openjdk.java.net/jextract pull/31/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31`

View PR using the GUI difftool: \
`$ git pr show -t 31`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jextract/pull/31.diff">https://git.openjdk.java.net/jextract/pull/31.diff</a>

</details>
