### PR TITLE
7903190: jextract runtime helper issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ The `jextract` tool includes several customization options. Users can select in 
 | `--source`                                                   | generate java sources instead of classfiles                  |
 | `--dump-includes <String>`                                   | dump included symbols into specified file (see below)        |
 | `--include-[function,macro,struct,union,typedef,var]<String>` | Include a symbol of the given name and kind in the generated bindings (see below). When one of these options is specified, any symbol that is not matched by any specified filters is omitted from the generated bindings. |
+| '--version`                                                  | print version information and exit                           |
+
 
 #### Additional clang options
 

--- a/src/main/java/org/openjdk/jextract/impl/ConstantBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/ConstantBuilder.java
@@ -140,6 +140,18 @@ public class ConstantBuilder extends ClassSourceBuilder {
             this.kind = kind;
         }
 
+        String className() {
+            return className;
+        }
+
+        String javaName() {
+            return javaName;
+        }
+
+        Kind kind() {
+            return kind;
+        }
+
         List<String> getterNameParts() {
             return List.of(className, javaName, kind.nameSuffix);
         }
@@ -190,7 +202,13 @@ public class ConstantBuilder extends ClassSourceBuilder {
         String fieldName = Constant.Kind.METHOD_HANDLE.fieldName(javaName);
         indent();
         append(memberMods() + "MethodHandle ");
-        append(fieldName + " = RuntimeHelper.downcallHandle(\n");
+        append(fieldName + " = RuntimeHelper.");
+        if (isVarargs) {
+            append("downcallHandleVariadic");
+        } else {
+            append("downcallHandle");
+        }
+        append("(\n");
         incrAlign();
         indent();
         if (!virtual) {
@@ -199,9 +217,6 @@ public class ConstantBuilder extends ClassSourceBuilder {
             indent();
         }
         append(functionDesc.accessExpression());
-        append(", ");
-        // isVariadic
-        append(isVarargs);
         append("\n");
         decrAlign();
         indent();

--- a/src/main/java/org/openjdk/jextract/impl/FunctionalInterfaceBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/FunctionalInterfaceBuilder.java
@@ -95,8 +95,8 @@ public class FunctionalInterfaceBuilder extends ClassSourceBuilder {
             append(MEMBER_MODS + " NativeSymbol allocate(" + className() + " fi, ResourceScope scope) {\n");
             incrAlign();
             indent();
-            append("return RuntimeHelper.upcallStub(" + className() + ".class, fi, " + functionDesc.accessExpression() + ", " +
-                    "\"" + fiType.toMethodDescriptorString() + "\", scope);\n");
+            append("return RuntimeHelper.upcallStub(" + className() + ".class, fi, " +
+                functionDesc.accessExpression() + ", scope);\n");
             decrAlign();
             indent();
             append("}\n");

--- a/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
@@ -130,11 +130,9 @@ abstract class HeaderFileBuilder extends ClassSourceBuilder {
         append(" {\n");
         incrAlign();
         indent();
-        append("var mh$ = RuntimeHelper.requireNonNull(");
-        append(mhConstant.accessExpression());
-        append(", \"");
-        append(nativeName);
-        append("\");\n");
+        append("var mh$ = ");
+        append(mhConstant.kind().fieldName(javaName));
+        append("();\n");
         indent();
         append("try {\n");
         incrAlign();

--- a/src/main/resources/org/openjdk/jextract/impl/resources/RuntimeHelper.java.template
+++ b/src/main/resources/org/openjdk/jextract/impl/resources/RuntimeHelper.java.template
@@ -55,26 +55,25 @@ final class RuntimeHelper {
         return SYMBOL_LOOKUP.lookup(name).map(symbol -> MemorySegment.ofAddress(symbol.address(), layout.byteSize(), ResourceScope.newSharedScope())).orElse(null);
     }
 
-    static final MethodHandle downcallHandle(String name, FunctionDescriptor fdesc, boolean variadic) {
-        return SYMBOL_LOOKUP.lookup(name).map(
-                addr -> {
-                    return variadic ?
-                        VarargsInvoker.make(addr, fdesc) :
-                        LINKER.downcallHandle(addr, fdesc);
-                }).orElse(null);
+    static final MethodHandle downcallHandle(String name, FunctionDescriptor fdesc) {
+        return SYMBOL_LOOKUP.lookup(name).
+                map(addr -> LINKER.downcallHandle(addr, fdesc)).
+                orElse(null);
     }
 
-    static final MethodHandle downcallHandle(FunctionDescriptor fdesc, boolean variadic) {
-        if (variadic) {
-            throw new AssertionError("Cannot get here!");
-        }
+    static final MethodHandle downcallHandle(FunctionDescriptor fdesc) {
         return LINKER.downcallHandle(fdesc);
     }
 
-    static final <Z> NativeSymbol upcallStub(Class<Z> fi, Z z, FunctionDescriptor fdesc, String mtypeDesc, ResourceScope scope) {
+    static final MethodHandle downcallHandleVariadic(String name, FunctionDescriptor fdesc) {
+        return SYMBOL_LOOKUP.lookup(name).
+                map(addr -> VarargsInvoker.make(addr, fdesc)).
+                orElse(null);
+    }
+
+    static final <Z> NativeSymbol upcallStub(Class<Z> fi, Z z, FunctionDescriptor fdesc, ResourceScope scope) {
         try {
-            MethodHandle handle = MH_LOOKUP.findVirtual(fi, "apply",
-                    MethodType.fromMethodDescriptorString(mtypeDesc, LOADER));
+            MethodHandle handle = MH_LOOKUP.findVirtual(fi, "apply", CLinker.upcallType(fdesc));
             handle = handle.bindTo(z);
             return LINKER.upcallStub(handle, fdesc, scope);
         } catch (Throwable ex) {


### PR DESCRIPTION
* using varargs flag during jextract time rather than at runtime
* avoiding redundant null checks in generated code
* avoiding String to MethodType conversion in RuntimeHelper.upcallStub method

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no reviews required)

### Issue
 * [CODETOOLS-7903190](https://bugs.openjdk.java.net/browse/CODETOOLS-7903190): jextract runtime helper issues


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jextract pull/33/head:pull/33` \
`$ git checkout pull/33`

Update a local copy of the PR: \
`$ git checkout pull/33` \
`$ git pull https://git.openjdk.java.net/jextract pull/33/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 33`

View PR using the GUI difftool: \
`$ git pr show -t 33`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jextract/pull/33.diff">https://git.openjdk.java.net/jextract/pull/33.diff</a>

</details>
