### PR TITLE
7903197: add a build step to create jmod file for jextract module

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,8 +6,6 @@ plugins {
     id "java"
 }
 
-version = '1.0'
-
 def static checkPath(String p) {
     if (!Files.exists(Path.of(p))) {
         throw new IllegalArgumentException("Error: the path ${p} does not exist");
@@ -24,6 +22,11 @@ if (clang_versions.length == 0) {
 }
 def clang_version = clang_versions[0]
 
+def jextract_version = "18"
+def jmods_dir = "$buildDir/jmods"
+def jextract_jmod_file = "$jmods_dir/jextract.jmod"
+def jextract_jmod_libs_dir = "$buildDir/jextract_jmod_libs"
+def jextract_jmod_conf_dir = "$buildDir/jextract_jmod_conf";
 def jextract_app_dir = "$buildDir/jextract"
 def clang_include_dir = "${llvm_home}/lib/clang/${clang_version}/include"
 checkPath(clang_include_dir)
@@ -49,8 +52,51 @@ jar {
     archiveVersion = project.version
 }
 
-task createJextractImage(type: Exec) {
+task copyLibClang(type: Copy) {
     dependsOn jar
+
+    def dir_prefix_len = "$buildDir".length()
+    def libs_dir = jextract_jmod_libs_dir.substring(dir_prefix_len)
+    def conf_dir = jextract_jmod_conf_dir.substring(dir_prefix_len)
+
+    into("$buildDir")
+
+    from("${libclang_dir}") {
+        include("*clang.*")
+        include("libLLVM.*")
+        into(libs_dir)
+    }
+
+    from("$clang_include_dir") {
+        include("*.h")
+        into(conf_dir + "/jextract")
+    }
+}
+
+task createJextractJmod(type: Exec) {
+    dependsOn copyLibClang
+
+    // if these inputs or outputs change, gradle will rerun the task
+    inputs.file(jar.archiveFile.get())
+    outputs.file(jextract_jmod_file)
+
+    doFirst {
+        delete(jextract_jmod_file)
+    }
+
+    executable = "${jdk18_home}/bin/jmod"
+    args = [
+          "create",
+          "--module-version=$jextract_version",
+          "--class-path=" + jar.archiveFile.get(),
+          "--libs=$jextract_jmod_libs_dir",
+          "--conf=$jextract_jmod_conf_dir",
+          "${jextract_jmod_file}"
+    ]
+}
+
+task createJextractImage(type: Exec) {
+    dependsOn createJextractJmod
 
     // if these inputs or outputs change, gradle will rerun the task
     inputs.file(jar.archiveFile.get())
@@ -66,7 +112,7 @@ task createJextractImage(type: Exec) {
 
     executable = "${jdk18_home}/bin/jlink"
     args = [
-         "--module-path=$buildDir/libs",
+         "--module-path=$jmods_dir",
          "--add-modules=org.openjdk.jextract,jdk.compiler",
          "--output=${jextract_app_dir}",
          "--launcher=jextract=org.openjdk.jextract/org.openjdk.jextract.JextractTool",
@@ -75,34 +121,12 @@ task createJextractImage(type: Exec) {
     ]
 }
 
-task copyLibClang(type: Copy) {
-    dependsOn createJextractImage
-
-    into("$buildDir")
-
-    from("${libclang_dir}") {
-        include("*clang.*")
-        include("libLLVM.*")
-        into("jextract/${os_lib_dir}")
-    }
-
-    from("$clang_include_dir") {
-        include("*.h")
-        into("jextract/conf/jextract")
-    }
-}
-
-// jextract jdk image
-task jextractapp() {
-    dependsOn copyLibClang
-}
-
 // build the jextract image when the build or assemble task is run
-assemble.dependsOn(jextractapp)
+assemble.dependsOn(createJextractImage)
 
 // very simple integration test for generated jextract
 task verify(type: Exec) {
-    dependsOn jextractapp
+    dependsOn createJextractImage
 
     executable = "${jextract_app_dir}/bin/jextract${os_script_extension}"
     args = [ "test.h", "--output", "$buildDir/integration_test" ]
@@ -124,27 +148,10 @@ task createRuntimeImageForTest(type: Exec) {
 
     executable = "${jdk18_home}/bin/jlink"
     args = [
-         "--module-path=$buildDir/libs" + File.pathSeparator + "$jdk18_home/jmods",
+         "--module-path=$jmods_dir" + File.pathSeparator + "$jdk18_home/jmods",
          "--add-modules=ALL-MODULE-PATH",
          "--output=$out_dir",
     ]
-}
-
-task prepareTestJDK(type: Copy) {
-    dependsOn createRuntimeImageForTest
-
-    into("$buildDir")
-
-    from("${libclang_dir}") {
-        include("*clang.*")
-        include("libLLVM.*")
-        into("jextract-jdk-test-image/${os_lib_dir}")
-    }
-
-    from("$clang_include_dir") {
-        include("*.h")
-        into("jextract-jdk-test-image/conf/jextract")
-    }
 }
 
 task cmakeConfigure(type: Exec) {
@@ -171,7 +178,7 @@ task cmakeBuild(type: Exec) {
 
 // run jtreg tests. Note: needs jtreg_home variable set to point to the jtreg
 task jtreg(type: JavaExec) {
-    dependsOn prepareTestJDK,cmakeBuild
+    dependsOn createRuntimeImageForTest,cmakeBuild
 
     doFirst {
         if (findProperty("jtreg_home") == null) {


### PR DESCRIPTION
jmod file created for jextract module and that is used to build jextract app image as well as test image.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no reviews required)

### Issue
 * [CODETOOLS-7903197](https://bugs.openjdk.java.net/browse/CODETOOLS-7903197): add a build step to create jmod file for jextract module


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jextract pull/34/head:pull/34` \
`$ git checkout pull/34`

Update a local copy of the PR: \
`$ git checkout pull/34` \
`$ git pull https://git.openjdk.java.net/jextract pull/34/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 34`

View PR using the GUI difftool: \
`$ git pr show -t 34`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jextract/pull/34.diff">https://git.openjdk.java.net/jextract/pull/34.diff</a>

</details>
