### PR TITLE
7903198: Refine filtering for enums

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,18 +126,18 @@ In other words, the `jextract` tool has generated all the required supporting co
 
 The `jextract` tool includes several customization options. Users can select in which package the generated code should be emitted, and what the name of the main extracted class should be. A complete list of all the supported options is given below:
 
-| Option                                                       | Meaning                                                      |
-| :----------------------------------------------------------- | ------------------------------------------------------------ |
-| `-D <macro>`                                                 | define a C preprocessor macro                                |
-| `--header-class-name <name>`                                 | specify the name of the main header class                    |
-| `-t, --target-package <package>`                             | specify target package for the generated bindings            |
-| `-I <path>`                                                  | specify include files path for the clang parser              |
-| `-l <library>`                                               | specify a library that will be loaded by the generated bindings |
-| `--output <path>`                                            | specify where to place generated files                       |
-| `--source`                                                   | generate java sources instead of classfiles                  |
-| `--dump-includes <String>`                                   | dump included symbols into specified file (see below)        |
-| `--include-[function,macro,struct,union,typedef,var]<String>` | Include a symbol of the given name and kind in the generated bindings (see below). When one of these options is specified, any symbol that is not matched by any specified filters is omitted from the generated bindings. |
-| `--version`                                                  | print version information and exit                           |
+| Option                                                             | Meaning                                                      |
+|:-------------------------------------------------------------------| ------------------------------------------------------------ |
+| `-D <macro>`                                                       | define a C preprocessor macro                                |
+| `--header-class-name <name>`                                       | specify the name of the main header class                    |
+| `-t, --target-package <package>`                                   | specify target package for the generated bindings            |
+| `-I <path>`                                                        | specify include files path for the clang parser              |
+| `-l <library>`                                                     | specify a library that will be loaded by the generated bindings |
+| `--output <path>`                                                  | specify where to place generated files                       |
+| `--source`                                                         | generate java sources instead of classfiles                  |
+| `--dump-includes <String>`                                         | dump included symbols into specified file (see below)        |
+| `--include-[function,enum,macro,struct,union,typedef,var]<String>` | Include a symbol of the given name and kind in the generated bindings (see below). When one of these options is specified, any symbol that is not matched by any specified filters is omitted from the generated bindings. |
+| `--version`                                                        | print version information and exit                           |
 
 
 #### Additional clang options

--- a/src/main/java/org/openjdk/jextract/impl/IncludeHelper.java
+++ b/src/main/java/org/openjdk/jextract/impl/IncludeHelper.java
@@ -51,7 +51,8 @@ public class IncludeHelper {
         FUNCTION,
         TYPEDEF,
         STRUCT,
-        UNION;
+        UNION,
+        ENUM;
 
         public String optionName() {
             return "include-" + name().toLowerCase();
@@ -77,6 +78,7 @@ public class IncludeHelper {
             return switch (scoped.kind()) {
                 case STRUCT -> IncludeKind.STRUCT;
                 case UNION ->  IncludeKind.UNION;
+                case ENUM -> IncludeKind.ENUM;
                 default -> throw new IllegalStateException("Cannot get here!");
             };
         }

--- a/src/main/java/org/openjdk/jextract/impl/OutputFactory.java
+++ b/src/main/java/org/openjdk/jextract/impl/OutputFactory.java
@@ -170,8 +170,11 @@ public class OutputFactory implements Declaration.Visitor<Void, Declaration> {
 
     @Override
     public Void visitConstant(Declaration.Constant constant, Declaration parent) {
-        if (!constants.add(constant.name()) || !includeHelper.isIncluded(constant)) {
-            //skip
+        boolean isEnumConstant = parent instanceof Declaration.Scoped scoped &&
+                scoped.kind() == Declaration.Scoped.Kind.ENUM;
+
+        if ((!isEnumConstant && !includeHelper.isIncluded(constant)) ||
+                !constants.add(constant.name())) {
             return null;
         }
 
@@ -196,16 +199,16 @@ public class OutputFactory implements Declaration.Visitor<Void, Declaration> {
             case STRUCT, UNION -> true;
             default -> false;
         };
+        String scopedName = d.name();
+        if (!scopedName.isEmpty() && !includeHelper.isIncluded(d)) {
+            return null;
+        }
         StructBuilder structBuilder = null;
         if (isStructKind) {
-            String className = d.name();
-            if (!className.isEmpty() && !includeHelper.isIncluded(d)) {
-                return null;
-            }
             GroupLayout layout = (GroupLayout) layoutFor(d);
-            currentBuilder = structBuilder = currentBuilder.addStruct(className, parent, layout, Type.declared(d));
+            currentBuilder = structBuilder = currentBuilder.addStruct(scopedName, parent, layout, Type.declared(d));
             structBuilder.classBegin();
-            if (!className.isEmpty()) {
+            if (!scopedName.isEmpty()) {
                 addStructDefinition(d, structBuilder.fullName());
             }
         }

--- a/src/main/resources/org/openjdk/jextract/impl/resources/Messages.properties
+++ b/src/main/resources/org/openjdk/jextract/impl/resources/Messages.properties
@@ -35,6 +35,7 @@ help.include-function=name of function to include
 help.include-typedef=name of type definition to include
 help.include-struct=name of struct definition to include
 help.include-union=name of union definition to include
+help.include-enum=name of enum definition to include
 help.D=define a C preprocessor macro
 help.dump-includes=dump included symbols into specified file
 help.h=print help
@@ -56,6 +57,7 @@ Option                         Description                               \n\
 --dump-includes <file>         dump included symbols into specified file \n\
 --header-class-name <name>     name of the header class                  \n\
 --include-function <name>      name of function to include               \n\
+--include-enum <name>          name of enum definition to include        \n\
 --include-macro <name>         name of constant macro to include         \n\
 --include-struct <name>        name of struct definition to include      \n\
 --include-typedef <name>       name of type definition to include        \n\

--- a/test/testng/org/openjdk/jextract/test/toolprovider/TestFilters.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/TestFilters.java
@@ -28,6 +28,7 @@ import org.testng.annotations.Test;
 import testlib.JextractToolRunner;
 
 import java.io.IOException;
+import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Iterator;
@@ -92,7 +93,8 @@ public class TestFilters extends JextractToolRunner {
         CONSTANT("_constant", "--include-macro"),
         TYPEDEF("_typedef", "--include-typedef"),
         STRUCT("_struct", "--include-struct"),
-        UNION("_union", "--include-union");
+        UNION("_union", "--include-union"),
+        ENUM("_enum", "--include-enum");
 
         final String symbolName;
         final String filterOption;
@@ -113,6 +115,15 @@ public class TestFilters extends JextractToolRunner {
                     } catch (ReflectiveOperationException ex) {
                         yield null;
                     }
+                }
+                case ENUM -> {
+                    String[] constantNames = { "one", "two", "three" };
+                    Method method = null;
+                    for (String c : constantNames) {
+                        method = findMethod(headerClass, c);
+                        if (method == null) break;
+                    }
+                    yield method;
                 }
             };
         }

--- a/test/testng/org/openjdk/jextract/test/toolprovider/filters.h
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/filters.h
@@ -43,6 +43,8 @@ struct _struct { int x; };
 
 union _union { int y; };
 
+enum _enum { one = 1, two = 2, three = 3 };
+
 #ifdef __cplusplus
 }
 #endif // __cplusplus


### PR DESCRIPTION
This patch fixes an issue with the logic for filtering constants.
Since both enum constants and `#define` macros are represented as `Declaration.Constant` nodes, `OutputFactory` is confused as to whether the constant being generated is a macro or not.

This patch adds a new filtering option `--include-enum`; this option can be used to include an enum (and all its constants). `OutputFactory` has been rectified so that:
* `IncludeHelper` is also called on the enum (so that filtering happens)
* `visitConstant` does not call `IncludingHelper` filtering routine on things that are non toplevel constants

In other words, if we get to `visitConstant` and the parent node is an enum - we should not filter: if we're here it means that the parent enum is included in the filtering.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no reviews required)

### Issue
 * [CODETOOLS-7903198](https://bugs.openjdk.java.net/browse/CODETOOLS-7903198): Refine filtering for enums


### Reviewers
 * [Athijegannathan Sundararajan](https://openjdk.java.net/census#sundar) (@sundararajana - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jextract pull/36/head:pull/36` \
`$ git checkout pull/36`

Update a local copy of the PR: \
`$ git checkout pull/36` \
`$ git pull https://git.openjdk.java.net/jextract pull/36/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 36`

View PR using the GUI difftool: \
`$ git pr show -t 36`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jextract/pull/36.diff">https://git.openjdk.java.net/jextract/pull/36.diff</a>

</details>
