### PR TITLE
7903200: sync makefiles to build jmod for jextract

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ def clang_version = clang_versions[0]
 
 def jextract_version = "18"
 def jmods_dir = "$buildDir/jmods"
-def jextract_jmod_file = "$jmods_dir/jextract.jmod"
+def jextract_jmod_file = "$jmods_dir/org.openjdk.jextract.jmod"
 def jextract_jmod_libs_dir = "$buildDir/jextract_jmod_libs"
 def jextract_jmod_conf_dir = "$buildDir/jextract_jmod_conf";
 def jextract_app_dir = "$buildDir/jextract"

--- a/make/Build.gmk
+++ b/make/Build.gmk
@@ -22,8 +22,10 @@ LIBCLANG_LIB_DIR := $(LIBCLANG_HOME)/$(OS_LIB_DIR)
 LIBCLANG_INCLUDE_DIR := $(LIBCLANG_HOME)/lib/clang/$(LIBCLANG_VERSION)/include
 
 BUILD_CLASSES_DIR := $(BUILD_DIR)/classes
-BUILD_MODULES_DIR := $(BUILD_DIR)/modules
+BUILD_MODULES_DIR := $(BUILD_DIR)/jmods
 BUILD_TEST_SUPPORT_DIR := $(BUILD_DIR)/support/test
+JEXTRACT_JMOD_LIBS_DIR := $(BUILD_DIR)/jextract_jmod_libs
+JEXTRACT_JMOD_CONF_DIR := $(BUILD_DIR)/jextract_jmod_conf
 
 ifeq ($(PLATFORM_OS), macosx)
   BUNDLE_PLATFORM := macos-$(PLATFORM_CPU)
@@ -57,10 +59,23 @@ $(BUILD_CLASSES_DIR):
 	$(CP) -r src/main/resources/org/openjdk/jextract/impl/resources $(BUILD_CLASSES_DIR)/org/openjdk/jextract/impl
 
 $(BUILD_MODULES_DIR): $(BUILD_CLASSES_DIR)
-	$(MKDIR) -p $(BUILD_MODULES_DIR)/org.openjdk.jextract
+	$(MKDIR) -p $(BUILD_MODULES_DIR)
+	$(MKDIR) -p $(JEXTRACT_JMOD_LIBS_DIR)
+	$(MKDIR) -p $(JEXTRACT_JMOD_CONF_DIR)
 
-        # Copy org.openjdk.jextract classes to the right place
-	$(CP) -r $(BUILD_CLASSES_DIR)/* $(BUILD_MODULES_DIR)/org.openjdk.jextract
+	# Copy libclang library and header files
+	$(CP) "$(LIBCLANG_LIB_DIR)/"*clang.* "$(JEXTRACT_JMOD_LIBS_DIR)"
+	$(MKDIR) -p "$(JEXTRACT_JMOD_CONF_DIR)/jextract"
+	$(CP) "$(LIBCLANG_INCLUDE_DIR)/"*.h "$(JEXTRACT_JMOD_CONF_DIR)/jextract/"
+
+	# create jextract jmod file
+	$(FIXPATH) $(PANAMA_JAVA_HOME)/bin/jmod \
+	    create \
+	    --module-version=18 \
+	    --class-path=$(BUILD_CLASSES_DIR) \
+	    --libs=$(JEXTRACT_JMOD_LIBS_DIR) \
+	    --conf=$(JEXTRACT_JMOD_CONF_DIR) \
+	    $(BUILD_MODULES_DIR)/org.openjdk.jextract.jmod
 
 $(JEXTRACT_IMAGE_DIR): $(BUILD_MODULES_DIR)
         # jlink the modules to create a custom runtime image for jextract
@@ -72,11 +87,6 @@ $(JEXTRACT_IMAGE_DIR): $(BUILD_MODULES_DIR)
 	    --add-options \"--enable-native-access=org.openjdk.jextract\" \
 	    --launcher jextract=org.openjdk.jextract/org.openjdk.jextract.JextractTool
 
-        # Copy libclang library and header files into the jlink'ed image
-	$(CP) "$(LIBCLANG_LIB_DIR)/"*clang.* "$(JEXTRACT_IMAGE_DIR)/$(OS_LIB_DIR)"
-	$(MKDIR) -p $(JEXTRACT_IMAGE_DIR)/conf/jextract
-	$(CP) "$(LIBCLANG_INCLUDE_DIR)/"*.h "$(JEXTRACT_IMAGE_DIR)/conf/jextract/"
-
 $(JEXTRACT_IMAGE_TEST_JDK_DIR): $(JEXTRACT_IMAGE_DIR)
         # jlink the modules to create a custom runtime image for jextract testing
 	$(FIXPATH) $(PANAMA_JAVA_HOME)/bin/jlink \
@@ -84,11 +94,6 @@ $(JEXTRACT_IMAGE_TEST_JDK_DIR): $(JEXTRACT_IMAGE_DIR)
 	    --output "$(JEXTRACT_IMAGE_TEST_JDK_DIR)" \
 	    --module-path "$(BUILD_MODULES_DIR):$(PANAMA_JAVA_HOME)/jmods" \
 	    --add-modules ALL-MODULE-PATH
-
-        # Copy libclang library and header files into the jlink'ed test image
-	$(CP) $(LIBCLANG_LIB_DIR)/*clang.* $(JEXTRACT_IMAGE_TEST_JDK_DIR)/$(OS_LIB_DIR)
-	$(MKDIR) -p $(JEXTRACT_IMAGE_TEST_JDK_DIR)/conf/jextract
-	$(CP) $(LIBCLANG_INCLUDE_DIR)/*.h $(JEXTRACT_IMAGE_TEST_JDK_DIR)/conf/jextract/
 
 
 $(JEXTRACT_BUNDLE): $(JEXTRACT_IMAGE_DIR)


### PR DESCRIPTION
Fixing makefiles for jmod creation. Changed the name of the jmod file.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no reviews required)

### Issue
 * [CODETOOLS-7903200](https://bugs.openjdk.java.net/browse/CODETOOLS-7903200): sync makefiles to build jmod for jextract


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jextract pull/38/head:pull/38` \
`$ git checkout pull/38`

Update a local copy of the PR: \
`$ git checkout pull/38` \
`$ git pull https://git.openjdk.java.net/jextract pull/38/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 38`

View PR using the GUI difftool: \
`$ git pr show -t 38`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jextract/pull/38.diff">https://git.openjdk.java.net/jextract/pull/38.diff</a>

</details>
