### PR TITLE
7903201: README.md referes to old API and old generated code pattern

### DIFF
--- a/make/Build.gmk
+++ b/make/Build.gmk
@@ -71,7 +71,7 @@ $(BUILD_MODULES_DIR): $(BUILD_CLASSES_DIR)
 	# create jextract jmod file
 	$(FIXPATH) $(PANAMA_JAVA_HOME)/bin/jmod \
 	    create \
-	    --module-version=18 \
+	    --module-version=19 \
 	    --class-path=$(BUILD_CLASSES_DIR) \
 	    --libs=$(JEXTRACT_JMOD_LIBS_DIR) \
 	    --conf=$(JEXTRACT_JMOD_CONF_DIR) \

--- a/src/main/java/org/openjdk/jextract/JextractTool.java
+++ b/src/main/java/org/openjdk/jextract/JextractTool.java
@@ -354,7 +354,8 @@ public final class JextractTool {
         }
 
         if (optionSet.has("--version")) {
-            err.printf("%s %s\n", "jextract", System.getProperty("java.version"));
+            var version = JextractTool.class.getModule().getDescriptor().version();
+            err.printf("%s %s\n", "jextract", version.get());
             err.printf("%s %s\n", "JDK version", System.getProperty("java.runtime.version"));
             err.printf("%s\n", LibClang.version());
             return SUCCESS;


### PR DESCRIPTION
* fixed README.md for new API usage and new generated code pattern
* --version uses module version rather than java.version
* fixed makefile --module-version to be 19

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Issue
 * [CODETOOLS-7903201](https://bugs.openjdk.java.net/browse/CODETOOLS-7903201): README.md referes to old API and old generated code pattern


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jextract pull/42/head:pull/42` \
`$ git checkout pull/42`

Update a local copy of the PR: \
`$ git checkout pull/42` \
`$ git pull https://git.openjdk.java.net/jextract pull/42/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 42`

View PR using the GUI difftool: \
`$ git pr show -t 42`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jextract/pull/42.diff">https://git.openjdk.java.net/jextract/pull/42.diff</a>

</details>
