### PR TITLE
README.md referes old generated code pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,23 +85,22 @@ class TestPoint {
 As we can see, the `jextract` tool generated a `Point2d` class, modelling the C struct, and a `point_h` class which contains static native function wrappers, such as `distance`. If we look inside the generated code for `distance` we can find the following:
 
 ```java
-static final FunctionDescriptor distance$FUNC =
-    FunctionDescriptor.of(Constants$root.C_DOUBLE$LAYOUT,
-                          MemoryLayout.structLayout(
-    	                      Constants$root.C_DOUBLE$LAYOUT.withName("x"),
-                              Constants$root.C_DOUBLE$LAYOUT.withName("y")
-                          ).withName("Point2d"));
-
+static final FunctionDescriptor distance$FUNC = FunctionDescriptor.of(Constants$root.C_DOUBLE$LAYOUT,
+    MemoryLayout.structLayout(
+         Constants$root.C_DOUBLE$LAYOUT.withName("x"),
+         Constants$root.C_DOUBLE$LAYOUT.withName("y")
+    ).withName("Point2d")
+);
 static final MethodHandle distance$MH = RuntimeHelper.downcallHandle(
     "distance",
-    constants$0.distance$FUNC, false
+    constants$0.distance$FUNC
 );
 
 public static MethodHandle distance$MH() {
     return RuntimeHelper.requireNonNull(constants$0.distance$MH,"distance");
 }
 public static double distance ( MemorySegment x0) {
-    var mh$ = RuntimeHelper.requireNonNull(constants$0.distance$MH, "distance");
+    var mh$ = distance$MH();
     try {
         return (double)mh$.invokeExact(x0);
     } catch (Throwable ex$) {

--- a/src/main/java/org/openjdk/jextract/JextractTool.java
+++ b/src/main/java/org/openjdk/jextract/JextractTool.java
@@ -354,7 +354,8 @@ public final class JextractTool {
         }
 
         if (optionSet.has("--version")) {
-            err.printf("%s %s\n", "jextract", System.getProperty("java.version"));
+            var version = JextractTool.class.getModule().getDescriptor().version();
+            err.printf("%s %s\n", "jextract", version.get());
             err.printf("%s %s\n", "JDK version", System.getProperty("java.runtime.version"));
             err.printf("%s\n", LibClang.version());
             return SUCCESS;


### PR DESCRIPTION
backporting applicable parts of the same fix from jdk19. 

* using latest generated code pattern in README.md
* using module-version in --version output

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jextract pull/43/head:pull/43` \
`$ git checkout pull/43`

Update a local copy of the PR: \
`$ git checkout pull/43` \
`$ git pull https://git.openjdk.java.net/jextract pull/43/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 43`

View PR using the GUI difftool: \
`$ git pr show -t 43`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jextract/pull/43.diff">https://git.openjdk.java.net/jextract/pull/43.diff</a>

</details>
