### PR TITLE
Fixes needed for mach5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,52 +1,64 @@
-default: all
+#
+# Copyright (c) 2012, 2015, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.  Oracle designates this
+# particular file as subject to the "Classpath" exception as provided
+# by Oracle in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
 
-.NOTPARALLEL:
+###
+### This file is just a very small wrapper needed to run the real make/Init.gmk.
+### It also performs some sanity checks on make.
+###
 
-include make/Common.gmk
+# The shell code below will be executed on /usr/bin/make on Solaris, but not in GNU Make.
+# /usr/bin/make lacks basically every other flow control mechanism.
+.TEST_FOR_NON_GNUMAKE:sh=echo You are not using GNU Make/gmake, this is a requirement. Check your path. 1>&2 && exit 1
 
-JEXTRACT_NATIVE_TEST_DIR ?= $(JEXTRACT_IMAGE_NATIVE_TEST_DIR)
-JEXTRACT_TEST_JDK ?= $(JEXTRACT_IMAGE_TEST_JDK_DIR)
-JEXTRACT_DIR ?= $(JEXTRACT_IMAGE_DIR)
+# The .FEATURES variable is likely to be unique for GNU Make.
+ifeq ($(.FEATURES), )
+  $(info Error: '$(MAKE)' does not seem to be GNU Make, which is a requirement.)
+  $(info Check your path, or upgrade to GNU Make 3.81 or newer.)
+  $(error Cannot continue)
+endif
 
-TEST ?= test
+# Assume we have GNU Make, but check version.
+ifeq ($(strip $(foreach v, 3.81% 3.82% 4.%, $(filter $v, $(MAKE_VERSION)))), )
+  $(info Error: This version of GNU Make is too low ($(MAKE_VERSION)).)
+  $(info Check your path, or upgrade to GNU Make 3.81 or newer.)
+  $(error Cannot continue)
+endif
 
-all: bundles
+# In Cygwin, the MAKE variable gets prepended with the current directory if the
+# make executable is called using a Windows mixed path (c:/cygwin/bin/make.exe).
+ifneq ($(findstring :, $(MAKE)), )
+  MAKE := $(patsubst $(CURDIR)%, %, $(patsubst $(CURDIR)/%, %, $(MAKE)))
+endif
 
-TARGETS += all
+# Locate this Makefile
+ifeq ($(filter /%, $(lastword $(MAKEFILE_LIST))),)
+  makefile_path := $(CURDIR)/$(strip $(lastword $(MAKEFILE_LIST)))
+else
+  makefile_path := $(lastword $(MAKEFILE_LIST))
+endif
+topdir := $(strip $(patsubst %/, %, $(dir $(makefile_path))))
 
-
-image images test-image bundles:
-	$(MAKE) -f make/Build.gmk $@
-
-TARGETS += image images test-image bundles
-
-
-verify: test test-integration
-
-TARGETS += verify
-
-
-test-prebuilt:
-	@( \
-	    $(MAKE) --no-print-directory -r -R -I make/common/ -f make/RunTestsPrebuilt.gmk \
-	        test-prebuilt $(MAKE_ARGS) \
-	        JEXTRACT_TEST_JDK="$(JEXTRACT_TEST_JDK)" \
-	        JEXTRACT_NATIVE_TEST_DIR="$(JEXTRACT_NATIVE_TEST_DIR)" \
-	        JEXTRACT_DIR="$(JEXTRACT_DIR)" \
-	        TEST="$(TEST)" \
-	)
-
-TARGETS += test-prebuilt
-
-
-test: image test-image test-prebuilt
-
-TARGETS += test
-
-clean:
-	rm -rf $(BUILD_DIR)
-
-TARGETS += clean
-
-
-.PHONY: default $(TARGETS)
+# ... and then we can include the real makefile
+include $(topdir)/make/Init.gmk

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012, 2015, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/make/Init.gmk
+++ b/make/Init.gmk
@@ -1,0 +1,53 @@
+default: all
+
+.NOTPARALLEL:
+
+include $(topdir)/make/Common.gmk
+
+JEXTRACT_NATIVE_TEST_DIR ?= $(JEXTRACT_IMAGE_NATIVE_TEST_DIR)
+JEXTRACT_TEST_JDK ?= $(JEXTRACT_IMAGE_TEST_JDK_DIR)
+JEXTRACT_DIR ?= $(JEXTRACT_IMAGE_DIR)
+
+TEST ?= test
+
+all: bundles
+
+TARGETS += all
+
+
+image images test-image bundles:
+	( cd $(topdir) && \
+	    $(MAKE) -f $(topdir)/make/Build.gmk $@)
+
+TARGETS += image images test-image bundles
+
+
+verify: test test-integration
+
+TARGETS += verify
+
+
+test-prebuilt:
+	@( cd $(topdir) && \
+	    $(MAKE) --no-print-directory -r -R -f $(topdir)/make/RunTestsPrebuilt.gmk \
+	        test-prebuilt $(MAKE_ARGS) \
+	        JEXTRACT_TEST_JDK="$(JEXTRACT_TEST_JDK)" \
+	        JEXTRACT_NATIVE_TEST_DIR="$(JEXTRACT_NATIVE_TEST_DIR)" \
+	        JEXTRACT_DIR="$(JEXTRACT_DIR)" \
+	        TEST="$(TEST)" \
+	)
+
+TARGETS += test-prebuilt
+
+
+test: image test-image test-prebuilt
+
+TARGETS += test
+
+clean:
+	rm -rf $(BUILD_DIR)
+
+TARGETS += clean
+
+
+.PHONY: default $(TARGETS)

--- a/make/Init.gmk
+++ b/make/Init.gmk
@@ -1,3 +1,28 @@
+#
+# Copyright (c) 2012, 2015, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.  Oracle designates this
+# particular file as subject to the "Classpath" exception as provided
+# by Oracle in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+
 default: all
 
 .NOTPARALLEL:

--- a/make/Init.gmk
+++ b/make/Init.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012, 2015, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
This patch adds the wrapper Makefile from the jdk repo to the jextract repo, and moves the existing Makefile contents to `make/Init.gmk` (mirroring jdk).

The wrapper will set the `topdir` variable, which is then used in `Init.gmk` to include the common makefile, as well as cd into the right working directory before running the `Build.gmk` and `RunTestsPrebuilt.gmk` makefiles

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - Committer) ⚠️ Review applies to [8b88a006](https://git.openjdk.java.net/jextract/pull/46/files/8b88a006b5ed9fb706872d818c7a4493eef06ad5)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jextract pull/46/head:pull/46` \
`$ git checkout pull/46`

Update a local copy of the PR: \
`$ git checkout pull/46` \
`$ git pull https://git.openjdk.java.net/jextract pull/46/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 46`

View PR using the GUI difftool: \
`$ git pr show -t 46`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jextract/pull/46.diff">https://git.openjdk.java.net/jextract/pull/46.diff</a>

</details>
