### PR TITLE
7903209: Handle lifecycle of libclang abstractions more explicitly

### DIFF
--- a/src/main/java/org/openjdk/jextract/clang/ClangDisposable.java
+++ b/src/main/java/org/openjdk/jextract/clang/ClangDisposable.java
@@ -1,0 +1,56 @@
+package org.openjdk.jextract.clang;
+
+import java.lang.foreign.MemoryAddress;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.MemorySession;
+import java.lang.foreign.SegmentAllocator;
+
+/**
+ * This class models a libclang entity that has an explicit lifecycle (e.g. TranslationUnit, Index).
+ * This class starts a new confined session and an arena allocator; this arena allocator is used by all
+ * the abstractions "owned" by this disposable. For instance, as a CXCursor's lifetime is the same as that of
+ * the CXTranslationUnit's lifetime, cursors are allocated inside the translation unit's lifetime.
+ */
+public abstract class ClangDisposable implements AutoCloseable {
+    protected final MemorySegment ptr;
+    protected final MemorySession session;
+    protected final SegmentAllocator arena;
+
+    public ClangDisposable(MemoryAddress ptr, long size, Runnable cleanup) {
+        this.session = MemorySession.openConfined();
+        this.ptr = MemorySegment.ofAddress(ptr, size, session).asReadOnly();
+        session.addCloseAction(cleanup);
+        this.arena = SegmentAllocator.newNativeArena(session);
+    }
+
+    public ClangDisposable(MemoryAddress ptr, Runnable cleanup) {
+        this(ptr, 0, cleanup);
+    }
+
+    @Override
+    public void close() {
+        session.close();
+    }
+
+    MemorySession session() {
+        return session;
+    }
+
+    SegmentAllocator arena() {
+        return arena;
+    }
+
+    /**
+     * An libclang entity owned by some libclang disposable entity. Entities modelled by this class
+     * do not have their own session; instead, they piggyback on the session of their owner.
+     */
+    static class Owned {
+        final MemorySegment segment;
+        final ClangDisposable owner;
+
+        protected Owned(MemorySegment segment, ClangDisposable owner) {
+            this.segment = segment;
+            this.owner = owner;
+        }
+    }
+}

--- a/src/main/java/org/openjdk/jextract/clang/ClangDisposable.java
+++ b/src/main/java/org/openjdk/jextract/clang/ClangDisposable.java
@@ -1,3 +1,29 @@
+/*
+ *  Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ *  This code is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License version 2 only, as
+ *  published by the Free Software Foundation.  Oracle designates this
+ *  particular file as subject to the "Classpath" exception as provided
+ *  by Oracle in the LICENSE file that accompanied this code.
+ *
+ *  This code is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ *  version 2 for more details (a copy is included in the LICENSE file that
+ *  accompanied this code).
+ *
+ *  You should have received a copy of the GNU General Public License version
+ *  2 along with this work; if not, write to the Free Software Foundation,
+ *  Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *   Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ *  or visit www.oracle.com if you need additional information or have any
+ *  questions.
+ *
+ */
+
 package org.openjdk.jextract.clang;
 
 import java.lang.foreign.MemoryAddress;

--- a/src/main/java/org/openjdk/jextract/clang/ClangDisposable.java
+++ b/src/main/java/org/openjdk/jextract/clang/ClangDisposable.java
@@ -37,7 +37,7 @@ import java.lang.foreign.SegmentAllocator;
  * the abstractions "owned" by this disposable. For instance, as a CXCursor's lifetime is the same as that of
  * the CXTranslationUnit's lifetime, cursors are allocated inside the translation unit's lifetime.
  */
-public abstract class ClangDisposable implements AutoCloseable {
+public abstract class ClangDisposable implements SegmentAllocator, AutoCloseable {
     protected final MemorySegment ptr;
     protected final MemorySession session;
     protected final SegmentAllocator arena;
@@ -58,16 +58,13 @@ public abstract class ClangDisposable implements AutoCloseable {
         session.close();
     }
 
-    MemorySession session() {
-        return session;
-    }
-
-    SegmentAllocator arena() {
-        return arena;
+    @Override
+    public MemorySegment allocate(long bytesSize, long bytesAlignment) {
+        return arena.allocate(bytesSize, bytesAlignment);
     }
 
     /**
-     * An libclang entity owned by some libclang disposable entity. Entities modelled by this class
+     * A libclang entity owned by some libclang disposable entity. Entities modelled by this class
      * do not have their own session; instead, they piggyback on the session of their owner.
      */
     static class Owned {

--- a/src/main/java/org/openjdk/jextract/clang/Cursor.java
+++ b/src/main/java/org/openjdk/jextract/clang/Cursor.java
@@ -29,24 +29,18 @@ package org.openjdk.jextract.clang;
 import java.lang.foreign.MemoryAddress;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.MemorySession;
-import java.lang.foreign.SegmentAllocator;
 import org.openjdk.jextract.clang.libclang.CXCursorVisitor;
 import org.openjdk.jextract.clang.libclang.Index_h;
 
-import java.util.ArrayList;
 import java.util.function.Consumer;
-import java.util.stream.Stream;
 
-import static org.openjdk.jextract.clang.LibClang.IMPLICIT_ALLOCATOR;
+public final class Cursor extends ClangDisposable.Owned {
 
-public final class Cursor {
-
-    private final MemorySegment cursor;
     private final int kind;
 
-    Cursor(MemorySegment cursor) {
-        this.cursor = cursor;
-        kind = Index_h.clang_getCursorKind(cursor);
+    Cursor(MemorySegment segment, ClangDisposable owner) {
+        super(segment, owner);
+        kind = Index_h.clang_getCursorKind(segment);
     }
 
     public boolean isDeclaration() {
@@ -62,32 +56,32 @@ public final class Cursor {
     }
 
     public boolean isDefinition() {
-        return Index_h.clang_isCursorDefinition(cursor) != 0;
+        return Index_h.clang_isCursorDefinition(segment) != 0;
     }
 
     public boolean isAttribute() { return Index_h.clang_isAttribute(kind) != 0; }
 
     public boolean isAnonymousStruct() {
-        return Index_h.clang_Cursor_isAnonymousRecordDecl(cursor) != 0;
+        return Index_h.clang_Cursor_isAnonymousRecordDecl(segment) != 0;
     }
 
     public boolean isMacroFunctionLike() {
-        return Index_h.clang_Cursor_isMacroFunctionLike(cursor) != 0;
+        return Index_h.clang_Cursor_isMacroFunctionLike(segment) != 0;
     }
 
     public String spelling() {
-        return LibClang.CXStrToString(allocator ->
-            Index_h.clang_getCursorSpelling(allocator, cursor));
+        var spelling = Index_h.clang_getCursorSpelling(LibClang.STRING_ALLOCATOR, segment);
+        return LibClang.CXStrToString(spelling);
     }
 
     public String USR() {
-        return LibClang.CXStrToString(allocator ->
-                Index_h.clang_getCursorUSR(allocator, cursor));
+        var USR = Index_h.clang_getCursorUSR(LibClang.STRING_ALLOCATOR, segment);
+        return LibClang.CXStrToString(USR);
     }
 
     public String prettyPrinted(PrintingPolicy policy) {
-        return LibClang.CXStrToString(allocator ->
-            Index_h.clang_getCursorPrettyPrinted(allocator, cursor, policy.ptr()));
+        var prettyOutput = Index_h.clang_getCursorPrettyPrinted(LibClang.STRING_ALLOCATOR, segment, policy.ptr());
+        return LibClang.CXStrToString(prettyOutput);
     }
 
     public String prettyPrinted() {
@@ -97,68 +91,72 @@ public final class Cursor {
     }
 
     public String displayName() {
-        return LibClang.CXStrToString(allocator ->
-                Index_h.clang_getCursorDisplayName(allocator, cursor));
+        var displayName = Index_h.clang_getCursorDisplayName(LibClang.STRING_ALLOCATOR, segment);
+        return LibClang.CXStrToString(displayName);
     }
 
     public boolean equalCursor(Cursor other) {
-        return Index_h.clang_equalCursors(cursor, other.cursor) != 0;
+        return Index_h.clang_equalCursors(segment, other.segment) != 0;
     }
 
     public Type type() {
-        return new Type(Index_h.clang_getCursorType(IMPLICIT_ALLOCATOR, cursor));
+        var cursorType = Index_h.clang_getCursorType(owner.arena(), segment);
+        return new Type(cursorType, owner);
     }
 
     public Type getEnumDeclIntegerType() {
-        return new Type(Index_h.clang_getEnumDeclIntegerType(IMPLICIT_ALLOCATOR, cursor));
+        var enumType = Index_h.clang_getEnumDeclIntegerType(owner.arena(), segment);
+        return new Type(enumType, owner);
     }
 
     public Cursor getDefinition() {
-        return new Cursor(Index_h.clang_getCursorDefinition(IMPLICIT_ALLOCATOR, cursor));
+        var cursorDef = Index_h.clang_getCursorDefinition(owner.arena(), segment);
+        return new Cursor(cursorDef, owner);
     }
 
     public SourceLocation getSourceLocation() {
-        MemorySegment loc = Index_h.clang_getCursorLocation(IMPLICIT_ALLOCATOR, cursor);
+        MemorySegment loc = Index_h.clang_getCursorLocation(owner.arena(), segment);
         try (MemorySession session = MemorySession.openConfined()) {
             if (Index_h.clang_equalLocations(loc, Index_h.clang_getNullLocation(session)) != 0) {
                 return null;
             }
         }
-        return new SourceLocation(loc);
+        return new SourceLocation(loc, owner);
     }
 
     public SourceRange getExtent() {
-        MemorySegment range = Index_h.clang_getCursorExtent(IMPLICIT_ALLOCATOR, cursor);
+        MemorySegment range = Index_h.clang_getCursorExtent(owner.arena(), segment);
         if (Index_h.clang_Range_isNull(range) != 0) {
             return null;
         }
-        return new SourceRange(range);
+        return new SourceRange(range, owner);
     }
 
     public int numberOfArgs() {
-        return Index_h.clang_Cursor_getNumArguments(cursor);
+        return Index_h.clang_Cursor_getNumArguments(segment);
     }
 
     public Cursor getArgument(int idx) {
-        return new Cursor(Index_h.clang_Cursor_getArgument(IMPLICIT_ALLOCATOR, cursor, idx));
+        var cursorArg = Index_h.clang_Cursor_getArgument(owner.arena(), segment, idx);
+        return new Cursor(cursorArg, owner);
     }
 
     // C long long, 64-bit
     public long getEnumConstantValue() {
-        return Index_h.clang_getEnumConstantDeclValue(cursor);
+        return Index_h.clang_getEnumConstantDeclValue(segment);
     }
 
     // C unsigned long long, 64-bit
     public long getEnumConstantUnsignedValue() {
-        return Index_h.clang_getEnumConstantDeclUnsignedValue(cursor);
+        return Index_h.clang_getEnumConstantDeclUnsignedValue(segment);
     }
 
     public boolean isBitField() {
-        return Index_h.clang_Cursor_isBitField(cursor) != 0;
+        return Index_h.clang_Cursor_isBitField(segment) != 0;
     }
 
     public int getBitFieldWidth() {
-        return Index_h.clang_getFieldDeclBitWidth(cursor);
+        return Index_h.clang_getFieldDeclBitWidth(segment);
     }
 
     public CursorKind kind() {
@@ -166,7 +164,7 @@ public final class Cursor {
     }
 
     public CursorLanguage language() {
-        return CursorLanguage.valueOf(Index_h.clang_getCursorLanguage(cursor));
+        return CursorLanguage.valueOf(Index_h.clang_getCursorLanguage(segment));
     }
 
     public int kind0() {
@@ -174,11 +172,11 @@ public final class Cursor {
     }
 
     /**
-     * For a cursor that is a reference, retrieve a cursor representing the entity that it references.
+     * For a segment that is a reference, retrieve a segment representing the entity that it references.
      */
     public Cursor getCursorReferenced() {
-        return new Cursor(Index_h.clang_getCursorReferenced(
-                IMPLICIT_ALLOCATOR, cursor));
+        var referenced = Index_h.clang_getCursorReferenced(owner.arena(), segment);
+        return new Cursor(referenced, owner);
     }
 
     public void forEach(Consumer<Cursor> action) {
@@ -186,42 +184,64 @@ public final class Cursor {
     }
 
     private static class CursorChildren {
-        private static Consumer<Cursor> action = cursor -> {
-            throw new IllegalStateException("NOT SET!");
-        };
 
-        static RuntimeException pendingException = null;
+        static class Context {
+            private final Consumer<Cursor> action;
+            private final ClangDisposable owner;
+            private RuntimeException exception;
+
+            Context(Consumer<Cursor> action, ClangDisposable owner) {
+                this.action = action;
+                this.owner = owner;
+            }
+
+            boolean visit(MemorySegment segment) {
+                MemorySegment child =
+                        MemorySegment.ofAddress(segment.address(), segment.byteSize(), owner.session());
+                try {
+                    action.accept(new Cursor(child, owner));
+                    return true;
+                } catch (RuntimeException ex) {
+                    exception = ex;
+                    return false;
+                }
+            }
+
+            void handleExceptions() {
+                if (exception != null) {
+                    throw exception;
+                }
+            }
+        }
+
+        static Context pendingContext = null;
+
         private static final MemorySegment callback = CXCursorVisitor.allocate((c, p, d) -> {
-            try {
-                action.accept(new Cursor(c));
+            if (pendingContext.visit(c)) {
                 return Index_h.CXChildVisit_Continue();
-            } catch (RuntimeException ex) {
-                pendingException = ex;
+            } else {
                 return Index_h.CXChildVisit_Break();
             }
         }, MemorySession.openImplicit());
 
         synchronized static void forEach(Cursor c, Consumer<Cursor> op) {
-            Consumer<Cursor> prev = action;
+            Context prevContext = pendingContext;
             try {
-                action = op;
-                Index_h.clang_visitChildren(c.cursor, callback, MemoryAddress.NULL);
-                if (pendingException != null) {
-                    throw pendingException;
-                }
+                pendingContext = new Context(op, c.owner);
+                Index_h.clang_visitChildren(c.segment, callback, MemoryAddress.NULL);
+                pendingContext.handleExceptions();
             } finally {
-                action = prev;
-                pendingException = null;
+                pendingContext = prevContext;
             }
         }
     }
 
     public TranslationUnit getTranslationUnit() {
-        return new TranslationUnit(Index_h.clang_Cursor_getTranslationUnit(cursor));
+        return new TranslationUnit(Index_h.clang_Cursor_getTranslationUnit(segment));
     }
 
     private MemoryAddress eval0() {
-        return Index_h.clang_Cursor_Evaluate(cursor);
+        return Index_h.clang_Cursor_Evaluate(segment);
     }
 
     public EvalResult eval() {
@@ -230,7 +250,7 @@ public final class Cursor {
     }
 
     public PrintingPolicy getPrintingPolicy() {
-        return new PrintingPolicy(Index_h.clang_getCursorPrintingPolicy(cursor));
+        return new PrintingPolicy(Index_h.clang_getCursorPrintingPolicy(segment));
     }
 
     @Override
@@ -239,7 +259,7 @@ public final class Cursor {
             return true;
         }
         return other instanceof Cursor otherCursor &&
-                (Index_h.clang_equalCursors(cursor, otherCursor.cursor) != 0);
+                (Index_h.clang_equalCursors(segment, otherCursor.segment) != 0);
     }
 
     @Override

--- a/src/main/java/org/openjdk/jextract/clang/Cursor.java
+++ b/src/main/java/org/openjdk/jextract/clang/Cursor.java
@@ -100,22 +100,22 @@ public final class Cursor extends ClangDisposable.Owned {
     }
 
     public Type type() {
-        var cursorType = Index_h.clang_getCursorType(owner.arena(), segment);
+        var cursorType = Index_h.clang_getCursorType(owner, segment);
         return new Type(cursorType, owner);
     }
 
     public Type getEnumDeclIntegerType() {
-        var enumType = Index_h.clang_getEnumDeclIntegerType(owner.arena(), segment);
+        var enumType = Index_h.clang_getEnumDeclIntegerType(owner, segment);
         return new Type(enumType, owner);
     }
 
     public Cursor getDefinition() {
-        var cursorDef = Index_h.clang_getCursorDefinition(owner.arena(), segment);
+        var cursorDef = Index_h.clang_getCursorDefinition(owner, segment);
         return new Cursor(cursorDef, owner);
     }
 
     public SourceLocation getSourceLocation() {
-        MemorySegment loc = Index_h.clang_getCursorLocation(owner.arena(), segment);
+        MemorySegment loc = Index_h.clang_getCursorLocation(owner, segment);
         try (MemorySession session = MemorySession.openConfined()) {
             if (Index_h.clang_equalLocations(loc, Index_h.clang_getNullLocation(session)) != 0) {
                 return null;
@@ -125,7 +125,7 @@ public final class Cursor extends ClangDisposable.Owned {
     }
 
     public SourceRange getExtent() {
-        MemorySegment range = Index_h.clang_getCursorExtent(owner.arena(), segment);
+        MemorySegment range = Index_h.clang_getCursorExtent(owner, segment);
         if (Index_h.clang_Range_isNull(range) != 0) {
             return null;
         }
@@ -137,7 +137,7 @@ public final class Cursor extends ClangDisposable.Owned {
     }
 
     public Cursor getArgument(int idx) {
-        var cursorArg = Index_h.clang_Cursor_getArgument(owner.arena(), segment, idx);
+        var cursorArg = Index_h.clang_Cursor_getArgument(owner, segment, idx);
         return new Cursor(cursorArg, owner);
     }
 
@@ -175,7 +175,7 @@ public final class Cursor extends ClangDisposable.Owned {
      * For a segment that is a reference, retrieve a segment representing the entity that it references.
      */
     public Cursor getCursorReferenced() {
-        var referenced = Index_h.clang_getCursorReferenced(owner.arena(), segment);
+        var referenced = Index_h.clang_getCursorReferenced(owner, segment);
         return new Cursor(referenced, owner);
     }
 

--- a/src/main/java/org/openjdk/jextract/clang/LibClang.java
+++ b/src/main/java/org/openjdk/jextract/clang/LibClang.java
@@ -46,11 +46,9 @@ public class LibClang {
     // crash recovery is not an issue on Windows, so enable it there by default to work around a libclang issue with reparseTranslationUnit
     private static final boolean CRASH_RECOVERY = IS_WINDOWS || Boolean.getBoolean("libclang.crash_recovery");
 
-    final static SegmentAllocator IMPLICIT_ALLOCATOR =
-            (size, align) -> MemorySegment.allocateNative(size, align, MemorySession.openImplicit());
-
     private final static MemorySegment disableCrashRecovery =
-            IMPLICIT_ALLOCATOR.allocateUtf8String("LIBCLANG_DISABLE_CRASH_RECOVERY=" + CRASH_RECOVERY);
+            SegmentAllocator.implicitAllocator()
+                            .allocateUtf8String("LIBCLANG_DISABLE_CRASH_RECOVERY=" + CRASH_RECOVERY);
 
     static {
         if (!CRASH_RECOVERY) {

--- a/src/main/java/org/openjdk/jextract/clang/SourceLocation.java
+++ b/src/main/java/org/openjdk/jextract/clang/SourceLocation.java
@@ -29,21 +29,22 @@ import java.lang.foreign.Addressable;
 import java.lang.foreign.MemoryAddress;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.MemorySession;
-import java.lang.foreign.SegmentAllocator;
 import org.openjdk.jextract.clang.libclang.Index_h;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Objects;
 
+import static org.openjdk.jextract.clang.LibClang.STRING_ALLOCATOR;
 import static org.openjdk.jextract.clang.libclang.Index_h.C_INT;
 import static org.openjdk.jextract.clang.libclang.Index_h.C_POINTER;
 
-public class SourceLocation {
+public class SourceLocation extends ClangDisposable.Owned {
 
     private final MemorySegment loc;
 
-    SourceLocation(MemorySegment loc) {
+    SourceLocation(MemorySegment loc, ClangDisposable owner) {
+        super(loc, owner);
         this.loc = loc;
     }
 
@@ -71,8 +72,8 @@ public class SourceLocation {
     }
 
     private static String getFileName(MemoryAddress fname) {
-        return LibClang.CXStrToString(allocator ->
-                Index_h.clang_getFileName(allocator, fname));
+        var filename = Index_h.clang_getFileName(STRING_ALLOCATOR, fname);
+        return LibClang.CXStrToString(filename);
     }
 
     public Location getFileLocation() { return getLocation(Index_h::clang_getFileLocation); }

--- a/src/main/java/org/openjdk/jextract/clang/SourceRange.java
+++ b/src/main/java/org/openjdk/jextract/clang/SourceRange.java
@@ -35,12 +35,12 @@ public class SourceRange extends ClangDisposable.Owned {
     }
 
     public SourceLocation getBegin() {
-        var rangeStart = Index_h.clang_getRangeStart(owner.arena(), segment);
+        var rangeStart = Index_h.clang_getRangeStart(owner, segment);
         return new SourceLocation(rangeStart, owner);
     }
 
     public SourceLocation getEnd() {
-        var rangeEnd = Index_h.clang_getRangeEnd(owner.arena(), segment);
+        var rangeEnd = Index_h.clang_getRangeEnd(owner, segment);
         return new SourceLocation(rangeEnd, owner);
     }
 }

--- a/src/main/java/org/openjdk/jextract/clang/SourceRange.java
+++ b/src/main/java/org/openjdk/jextract/clang/SourceRange.java
@@ -26,25 +26,21 @@
 package org.openjdk.jextract.clang;
 
 import java.lang.foreign.MemorySegment;
-import java.lang.foreign.MemorySession;
 import org.openjdk.jextract.clang.libclang.Index_h;
 
-import static org.openjdk.jextract.clang.LibClang.IMPLICIT_ALLOCATOR;
+public class SourceRange extends ClangDisposable.Owned {
 
-public class SourceRange {
-    final MemorySegment range;
-
-    SourceRange(MemorySegment range) {
-        this.range = range;
+    SourceRange(MemorySegment range, ClangDisposable owner) {
+        super(range, owner);
     }
 
     public SourceLocation getBegin() {
-        MemorySegment loc = Index_h.clang_getRangeStart(IMPLICIT_ALLOCATOR, range);
-        return new SourceLocation(loc);
+        var rangeStart = Index_h.clang_getRangeStart(owner.arena(), segment);
+        return new SourceLocation(rangeStart, owner);
     }
 
     public SourceLocation getEnd() {
-        MemorySegment loc = Index_h.clang_getRangeEnd(IMPLICIT_ALLOCATOR, range);
-        return new SourceLocation(loc);
+        var rangeEnd = Index_h.clang_getRangeEnd(owner.arena(), segment);
+        return new SourceLocation(rangeEnd, owner);
     }
 }

--- a/src/main/java/org/openjdk/jextract/clang/TranslationUnit.java
+++ b/src/main/java/org/openjdk/jextract/clang/TranslationUnit.java
@@ -182,12 +182,12 @@ public class TranslationUnit extends ClangDisposable {
             }
 
             public SourceLocation getLocation() {
-                var tokenLoc = Index_h.clang_getTokenLocation(owner.arena(), TranslationUnit.this.ptr, segment);
+                var tokenLoc = Index_h.clang_getTokenLocation(owner, TranslationUnit.this.ptr, segment);
                 return new SourceLocation(tokenLoc, owner);
             }
 
             public SourceRange getExtent() {
-                var tokenExt = Index_h.clang_getTokenExtent(owner.arena(), TranslationUnit.this.ptr, segment);
+                var tokenExt = Index_h.clang_getTokenExtent(owner, TranslationUnit.this.ptr, segment);
                 return new SourceRange(tokenExt, owner);
             }
         }

--- a/src/main/java/org/openjdk/jextract/clang/TranslationUnit.java
+++ b/src/main/java/org/openjdk/jextract/clang/TranslationUnit.java
@@ -40,40 +40,27 @@ import java.nio.file.Path;
 import java.util.Objects;
 import java.util.function.Consumer;
 
+import static org.openjdk.jextract.clang.LibClang.STRING_ALLOCATOR;
 import static org.openjdk.jextract.clang.libclang.Index_h.C_INT;
 import static org.openjdk.jextract.clang.libclang.Index_h.C_POINTER;
 
-import static org.openjdk.jextract.clang.LibClang.IMPLICIT_ALLOCATOR;
-
-public class TranslationUnit implements AutoCloseable {
+public class TranslationUnit extends ClangDisposable {
     private static final int MAX_RETRIES = 10;
 
-    private MemoryAddress tu;
-
-    TranslationUnit(MemoryAddress tu) {
-        this.tu = tu;
+    TranslationUnit(MemoryAddress addr) {
+        super(addr, () -> Index_h.clang_disposeTranslationUnit(addr));
     }
 
     public Cursor getCursor() {
-        return new Cursor(Index_h.clang_getTranslationUnitCursor(IMPLICIT_ALLOCATOR, tu));
-    }
-
-    public Diagnostic[] getDiagnostics() {
-        int cntDiags = Index_h.clang_getNumDiagnostics(tu);
-        Diagnostic[] rv = new Diagnostic[cntDiags];
-        for (int i = 0; i < cntDiags; i++) {
-            MemoryAddress diag = Index_h.clang_getDiagnostic(tu, i);
-            rv[i] = new Diagnostic(diag);
-        }
-
-        return rv;
+        var cursor = Index_h.clang_getTranslationUnitCursor(arena, ptr);
+        return new Cursor(cursor, this);
     }
 
     public final void save(Path path) throws TranslationUnitSaveException {
         try (MemorySession session = MemorySession.openConfined()) {
             var allocator = session;
             MemorySegment pathStr = allocator.allocateUtf8String(path.toAbsolutePath().toString());
-            SaveError res = SaveError.valueOf(Index_h.clang_saveTranslationUnit(tu, pathStr, 0));
+            SaveError res = SaveError.valueOf(Index_h.clang_saveTranslationUnit(ptr, pathStr, 0));
             if (res != SaveError.None) {
                 throw new TranslationUnitSaveException(path, res);
             }
@@ -82,8 +69,10 @@ public class TranslationUnit implements AutoCloseable {
 
     void processDiagnostics(Consumer<Diagnostic> dh) {
         Objects.requireNonNull(dh);
-        for (Diagnostic diag : getDiagnostics()) {
-            dh.accept(diag);
+        int cntDiags = Index_h.clang_getNumDiagnostics(ptr);
+        for (int i = 0; i < cntDiags; i++) {
+            MemoryAddress diag = Index_h.clang_getDiagnostic(ptr, i);
+            dh.accept(new Diagnostic(diag));
         }
     }
 
@@ -107,10 +96,10 @@ public class TranslationUnit implements AutoCloseable {
             int tries = 0;
             do {
                 code = ErrorCode.valueOf(Index_h.clang_reparseTranslationUnit(
-                        tu,
+                        ptr,
                         inMemoryFiles.length,
                         files == null ? MemoryAddress.NULL : files,
-                        Index_h.clang_defaultReparseOptions(tu)));
+                        Index_h.clang_defaultReparseOptions(ptr)));
             } while(code == ErrorCode.Crashed && (++tries) < MAX_RETRIES); // this call can crash on Windows. Retry in that case.
 
             if (code != ErrorCode.Success) {
@@ -125,47 +114,32 @@ public class TranslationUnit implements AutoCloseable {
     }
 
     public String[] tokens(SourceRange range) {
-        Tokens tokens = tokenize(range);
-        String rv[] = new String[tokens.size()];
-        for (int i = 0; i < rv.length; i++) {
-            rv[i] = tokens.getToken(i).spelling();
+        try (Tokens tokens = tokenize(range)) {
+            String rv[] = new String[tokens.size()];
+            for (int i = 0; i < rv.length; i++) {
+                rv[i] = tokens.getToken(i).spelling();
+            }
+            return rv;
         }
-        return rv;
     }
 
     public Tokens tokenize(SourceRange range) {
         try (MemorySession session = MemorySession.openConfined()) {
             MemorySegment p = MemorySegment.allocateNative(C_POINTER, session);
             MemorySegment pCnt = MemorySegment.allocateNative(C_INT, session);
-            Index_h.clang_tokenize(tu, range.range, p, pCnt);
+            Index_h.clang_tokenize(ptr, range.segment, p, pCnt);
             Tokens rv = new Tokens(p.get(C_POINTER, 0), pCnt.get(C_INT, 0));
             return rv;
         }
     }
 
-    @Override
-    public void close() {
-        dispose();
-    }
-
-    public void dispose() {
-        if (tu != MemoryAddress.NULL) {
-            Index_h.clang_disposeTranslationUnit(tu);
-            tu = MemoryAddress.NULL;
-        }
-    }
-
-    public class Tokens {
-        private final MemoryAddress ar;
+    public class Tokens extends ClangDisposable {
         private final int size;
 
-        Tokens(MemoryAddress ar, int size) {
-            this.ar = ar;
+        Tokens(MemoryAddress addr, int size) {
+            super(addr, size * CXToken.$LAYOUT().byteSize(),
+                    () -> Index_h.clang_disposeTokens(TranslationUnit.this.ptr, addr, size));
             this.size = size;
-        }
-
-        public void dispose() {
-            Index_h.clang_disposeTokens(tu, ar, size);
         }
 
         public int size() {
@@ -173,12 +147,11 @@ public class TranslationUnit implements AutoCloseable {
         }
 
         public MemorySegment getTokenSegment(int idx) {
-            MemoryAddress p = ar.addOffset(idx * CXToken.$LAYOUT().byteSize());
-            return MemorySegment.ofAddress(p, CXToken.$LAYOUT().byteSize(), MemorySession.openConfined());
+            return ptr.asSlice(idx * CXToken.$LAYOUT().byteSize());
         }
 
         public Token getToken(int index) {
-            return new Token(getTokenSegment(index));
+            return new Token(getTokenSegment(index), this);
         }
 
         @Override
@@ -188,39 +161,35 @@ public class TranslationUnit implements AutoCloseable {
                 sb.append("Token[");
                 sb.append(i);
                 sb.append("]=");
-                int pos = i;
-                sb.append(LibClang.CXStrToString(allocator ->
-                        Index_h.clang_getTokenSpelling(allocator, tu, getTokenSegment(pos))));
+                sb.append(getToken(i).spelling());
                 sb.append("\n");
             }
             return sb.toString();
         }
-    }
 
-    public class Token {
-        final MemorySegment token;
+        public class Token extends ClangDisposable.Owned {
+            Token(MemorySegment token, ClangDisposable owner) {
+                super(token, owner);
+            }
 
-        Token(MemorySegment token) {
-            this.token = token;
-        }
+            public int kind() {
+                return Index_h.clang_getTokenKind(segment);
+            }
 
-        public int kind() {
-            return Index_h.clang_getTokenKind(token);
-        }
+            public String spelling() {
+                var spelling = Index_h.clang_getTokenSpelling(STRING_ALLOCATOR, TranslationUnit.this.ptr, segment);
+                return LibClang.CXStrToString(spelling);
+            }
 
-        public String spelling() {
-            return LibClang.CXStrToString(allocator ->
-                    Index_h.clang_getTokenSpelling(allocator, tu, token));
-        }
+            public SourceLocation getLocation() {
+                var tokenLoc = Index_h.clang_getTokenLocation(owner.arena(), TranslationUnit.this.ptr, segment);
+                return new SourceLocation(tokenLoc, owner);
+            }
 
-        public SourceLocation getLocation() {
-            return new SourceLocation(Index_h.clang_getTokenLocation(
-                IMPLICIT_ALLOCATOR, tu, token));
-        }
-
-        public SourceRange getExtent() {
-            return new SourceRange(Index_h.clang_getTokenExtent(IMPLICIT_ALLOCATOR,
-                    tu, token));
+            public SourceRange getExtent() {
+                var tokenExt = Index_h.clang_getTokenExtent(owner.arena(), TranslationUnit.this.ptr, segment);
+                return new SourceRange(tokenExt, owner);
+            }
         }
     }
 

--- a/src/main/java/org/openjdk/jextract/clang/Type.java
+++ b/src/main/java/org/openjdk/jextract/clang/Type.java
@@ -48,14 +48,14 @@ public final class Type extends ClangDisposable.Owned {
         return Index_h.clang_isFunctionTypeVariadic(segment) != 0;
     }
     public Type resultType() {
-        var resultType = Index_h.clang_getResultType(owner.arena(), segment);
+        var resultType = Index_h.clang_getResultType(owner, segment);
         return new Type(resultType, owner);
     }
     public int numberOfArgs() {
         return Index_h.clang_getNumArgTypes(segment);
     }
     public Type argType(int idx) {
-        var argType = Index_h.clang_getArgType(owner.arena(), segment, idx);
+        var argType = Index_h.clang_getArgType(owner, segment, idx);
         return new Type(argType, owner);
     }
     private int getCallingConvention0() {
@@ -88,13 +88,13 @@ public final class Type extends ClangDisposable.Owned {
 
     // Pointer segment
     public Type getPointeeType() {
-        var pointee = Index_h.clang_getPointeeType(owner.arena(), segment);
+        var pointee = Index_h.clang_getPointeeType(owner, segment);
         return new Type(pointee, owner);
     }
 
     // array/vector segment
     public Type getElementType() {
-        var elementType = Index_h.clang_getElementType(owner.arena(), segment);
+        var elementType = Index_h.clang_getElementType(owner, segment);
         return new Type(elementType, owner);
     }
 
@@ -129,7 +129,7 @@ public final class Type extends ClangDisposable.Owned {
      * for 'int', the canonical segment for 'T' would be 'int'.
      */
     public Type canonicalType() {
-        var canonicalType = Index_h.clang_getCanonicalType(owner.arena(), segment);
+        var canonicalType = Index_h.clang_getCanonicalType(owner, segment);
         return new Type(canonicalType, owner);
     }
 
@@ -180,7 +180,7 @@ public final class Type extends ClangDisposable.Owned {
     }
 
     public Cursor getDeclarationCursor() {
-        var cursorDecl = Index_h.clang_getTypeDeclaration(owner.arena(), segment);
+        var cursorDecl = Index_h.clang_getTypeDeclaration(owner, segment);
         return new Cursor(cursorDecl, owner);
     }
 

--- a/src/main/java/org/openjdk/jextract/clang/Type.java
+++ b/src/main/java/org/openjdk/jextract/clang/Type.java
@@ -34,7 +34,7 @@ import org.openjdk.jextract.clang.libclang.Index_h;
 import static org.openjdk.jextract.clang.LibClang.STRING_ALLOCATOR;
 
 public final class Type extends ClangDisposable.Owned {
-    
+
     Type(MemorySegment segment, ClangDisposable owner) {
         super(segment, owner);
     }

--- a/src/main/java/org/openjdk/jextract/impl/MacroParserImpl.java
+++ b/src/main/java/org/openjdk/jextract/impl/MacroParserImpl.java
@@ -49,7 +49,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-class MacroParserImpl {
+class MacroParserImpl implements AutoCloseable {
 
     private final ClangReparser reparser;
     private final TreeMaker treeMaker;
@@ -304,7 +304,7 @@ class MacroParserImpl {
             treeMaker.typeMaker.resolveTypeReferences();
             return macrosByMangledName.values().stream()
                     .filter(Entry::isSuccess)
-                    .map(e -> ((Success)e).constant())
+                    .map(e -> ((Success) e).constant())
                     .collect(Collectors.toList());
         }
 
@@ -370,5 +370,11 @@ class MacroParserImpl {
                     });
             return buf.toString();
         }
+    }
+
+    @Override
+    public void close() {
+        reparser.macroUnit.close();
+        reparser.macroIndex.close();
     }
 }

--- a/src/main/java/org/openjdk/jextract/impl/Parser.java
+++ b/src/main/java/org/openjdk/jextract/impl/Parser.java
@@ -63,8 +63,7 @@ public class Parser {
 
         List<Declaration> decls = new ArrayList<>();
         Cursor tuCursor = tu.getCursor();
-        tuCursor.children().
-            forEach(c -> {
+        tuCursor.forEach(c -> {
                 SourceLocation loc = c.getSourceLocation();
                 if (loc == null) {
                     return;
@@ -79,9 +78,12 @@ public class Parser {
                 if (c.isDeclaration()) {
                     if (c.kind() == CursorKind.UnexposedDecl ||
                         c.kind() == CursorKind.Namespace) {
-                        c.children().map(treeMaker::createTree)
-                                .filter(t -> t != null)
-                                .forEach(decls::add);
+                        c.forEach(t -> {
+                            Declaration declaration = treeMaker.createTree(t);
+                            if (declaration != null) {
+                                decls.add(declaration);
+                            }
+                        });
                     } else {
                         Declaration decl = treeMaker.createTree(c);
                         if (decl != null) {
@@ -91,7 +93,7 @@ public class Parser {
                 } else if (isMacro(c) && src.path() != null) {
                     SourceRange range = c.getExtent();
                     String[] tokens = c.getTranslationUnit().tokens(range);
-                    Optional<Declaration.Constant> constant = macroParser.parseConstant(TreeMaker.CursorPosition.of(c), c.spelling(), tokens);
+                    Optional<Declaration.Constant> constant = macroParser.parseConstant(c, c.spelling(), tokens);
                     if (constant.isPresent()) {
                         decls.add(constant.get());
                     }

--- a/src/main/java/org/openjdk/jextract/impl/RecordLayoutComputer.java
+++ b/src/main/java/org/openjdk/jextract/impl/RecordLayoutComputer.java
@@ -105,12 +105,17 @@ abstract class RecordLayoutComputer {
             }
         });
 
-        return finishRecord(anonName);
+        Declaration.Scoped declaration = finishRecord(anonName);
+        if (cursor.isAnonymousStruct()) {
+            // record this with a declaration attribute, so we don't have to rely on the cursor again later
+            declaration = (Declaration.Scoped)declaration.withAttribute("ANONYMOUS", true);
+        }
+        return org.openjdk.jextract.Type.declared(declaration);
     }
 
     abstract void startBitfield();
     abstract void processField(Cursor c);
-    abstract org.openjdk.jextract.Type.Declared finishRecord(String anonName);
+    abstract Declaration.Scoped finishRecord(String anonName);
 
     void addField(Declaration declaration) {
         fieldDecls.add(declaration);

--- a/src/main/java/org/openjdk/jextract/impl/StructLayoutComputer.java
+++ b/src/main/java/org/openjdk/jextract/impl/StructLayoutComputer.java
@@ -148,7 +148,11 @@ final class StructLayoutComputer extends RecordLayoutComputer {
         } else if (anonName != null) {
             g = g.withName(anonName);
         }
-        return org.openjdk.jextract.Type.declared(Declaration.struct(TreeMaker.CursorPosition.of(cursor), cursor.spelling(), g, fieldDecls.stream().toArray(Declaration[]::new)));
+        Declaration.Scoped declaration = Declaration.struct(TreeMaker.CursorPosition.of(cursor), cursor.spelling(), g, fieldDecls.stream().toArray(Declaration[]::new));
+        if (cursor.isAnonymousStruct()) {
+            declaration = (Declaration.Scoped)declaration.withAttribute("ANONYMOUS", true);
+        }
+        return org.openjdk.jextract.Type.declared(declaration);
     }
 
     // process bitfields if any and clear bitfield layouts

--- a/src/main/java/org/openjdk/jextract/impl/StructLayoutComputer.java
+++ b/src/main/java/org/openjdk/jextract/impl/StructLayoutComputer.java
@@ -123,7 +123,7 @@ final class StructLayoutComputer extends RecordLayoutComputer {
     }
 
     @Override
-    org.openjdk.jextract.Type.Declared finishRecord(String anonName) {
+    Declaration.Scoped finishRecord(String anonName) {
         // pad at the end, if any
         long expectedSize = type.size() * 8;
         if (actualSize < expectedSize) {
@@ -149,10 +149,7 @@ final class StructLayoutComputer extends RecordLayoutComputer {
             g = g.withName(anonName);
         }
         Declaration.Scoped declaration = Declaration.struct(TreeMaker.CursorPosition.of(cursor), cursor.spelling(), g, fieldDecls.stream().toArray(Declaration[]::new));
-        if (cursor.isAnonymousStruct()) {
-            declaration = (Declaration.Scoped)declaration.withAttribute("ANONYMOUS", true);
-        }
-        return org.openjdk.jextract.Type.declared(declaration);
+        return declaration;
     }
 
     // process bitfields if any and clear bitfield layouts

--- a/src/main/java/org/openjdk/jextract/impl/UnionLayoutComputer.java
+++ b/src/main/java/org/openjdk/jextract/impl/UnionLayoutComputer.java
@@ -102,6 +102,10 @@ final class UnionLayoutComputer extends RecordLayoutComputer {
         } else if (anonName != null) {
             g = g.withName(anonName);
         }
-        return org.openjdk.jextract.Type.declared(Declaration.union(TreeMaker.CursorPosition.of(cursor), cursor.spelling(), g, fieldDecls.stream().toArray(Declaration[]::new)));
+        Declaration.Scoped declaration = Declaration.union(TreeMaker.CursorPosition.of(cursor), cursor.spelling(), g, fieldDecls.stream().toArray(Declaration[]::new));
+        if (cursor.isAnonymousStruct()) {
+            declaration = (Declaration.Scoped)declaration.withAttribute("ANONYMOUS", true);
+        }
+        return org.openjdk.jextract.Type.declared(declaration);
     }
 }

--- a/src/main/java/org/openjdk/jextract/impl/UnionLayoutComputer.java
+++ b/src/main/java/org/openjdk/jextract/impl/UnionLayoutComputer.java
@@ -85,7 +85,7 @@ final class UnionLayoutComputer extends RecordLayoutComputer {
     }
 
     @Override
-    org.openjdk.jextract.Type.Declared finishRecord(String anonName) {
+    Declaration.Scoped finishRecord(String anonName) {
         // size mismatch indicates use of bitfields in union
         long expectedSize = type.size() * 8;
         if (actualSize < expectedSize) {
@@ -102,10 +102,6 @@ final class UnionLayoutComputer extends RecordLayoutComputer {
         } else if (anonName != null) {
             g = g.withName(anonName);
         }
-        Declaration.Scoped declaration = Declaration.union(TreeMaker.CursorPosition.of(cursor), cursor.spelling(), g, fieldDecls.stream().toArray(Declaration[]::new));
-        if (cursor.isAnonymousStruct()) {
-            declaration = (Declaration.Scoped)declaration.withAttribute("ANONYMOUS", true);
-        }
-        return org.openjdk.jextract.Type.declared(declaration);
+        return Declaration.union(TreeMaker.CursorPosition.of(cursor), cursor.spelling(), g, fieldDecls.stream().toArray(Declaration[]::new));
     }
 }

--- a/src/main/java/org/openjdk/jextract/impl/Utils.java
+++ b/src/main/java/org/openjdk/jextract/impl/Utils.java
@@ -26,9 +26,6 @@
 
 package org.openjdk.jextract.impl;
 
-import java.lang.foreign.MemoryAddress;
-import java.lang.foreign.VaList;
-import java.lang.foreign.ValueLayout;
 import org.openjdk.jextract.Type.Delegated;
 import org.openjdk.jextract.clang.Cursor;
 import org.openjdk.jextract.clang.CursorKind;
@@ -215,9 +212,8 @@ class Utils {
         return sb.toString();
     }
 
-    static Stream<Cursor> flattenableChildren(Cursor c) {
-        return c.children()
-                .filter(cx -> cx.isAnonymousStruct() || cx.kind() == CursorKind.FieldDecl);
+    static boolean isFlattenable(Cursor c) {
+        return c.isAnonymousStruct() || c.kind() == CursorKind.FieldDecl;
     }
 
     // return builtin Record types accessible from the given Type


### PR DESCRIPTION
This patch clarifies the lifecycle of the entities generated by jextract. The main changes are two:

1. First, instead of "buffering" cursors in the `Cursor.children` method, so that a `Stream` can be returned, it instead accepts an action which will be executed for each visited cursor. This allows us to get rid of the buffering code, but at the same time it means that the downstream code has to be careful: any attempt to cache the cursor into a field, and access it _after_ the visitor has completed wil result in issues.

2. Secondly, it replaces uses of implicit session and implicit allocator almost everywhere. There are two main lifecycle entities: index and translation unit (there are others too, but these are the main ones). Translation units are created inside an index lifetime, whereas cursors and types are created inside the translation unit lifetime. This patch makes this organization clear, by adding a new type called `ClangDisposable`, an entity that has a session, and an associated arena allocator - and an `Owned` an entity that is owned by some `ClangDisposable` (and so it can use its arena to perform allocation). This scheme is relatively simple, but at the same time quite expressive, and helps keeping the complexity in check.

As a result, most of the allocation now occurs in a confined scope, with clear lifetime boundaries. Any  attemp to access e.g. a cursor after its translation unit is gone will result in an exception. I believe this can be quite useful to catch latent lifecycle issues in the code (I already fixed a few when working on this patch).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Issue
 * [CODETOOLS-7903209](https://bugs.openjdk.org/browse/CODETOOLS-7903209): Handle lifecycle of libclang abstractions more explicitly


### Reviewers
 * [Athijegannathan Sundararajan](https://openjdk.org/census#sundar) (@sundararajana - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract pull/48/head:pull/48` \
`$ git checkout pull/48`

Update a local copy of the PR: \
`$ git checkout pull/48` \
`$ git pull https://git.openjdk.org/jextract pull/48/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 48`

View PR using the GUI difftool: \
`$ git pr show -t 48`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/48.diff">https://git.openjdk.org/jextract/pull/48.diff</a>

</details>
