### PR TITLE
CODETOOLS-7903218: jextract test failure testng/org/openjdk/jextract/test/toolprovider/TestClassGeneration.java

### DIFF
--- a/test/testng/org/openjdk/jextract/test/toolprovider/TestClassGeneration.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/TestClassGeneration.java
@@ -44,7 +44,7 @@ import static org.testng.Assert.assertNotNull;
 
 public class TestClassGeneration extends JextractToolRunner {
 
-    private static final VarHandle VH_bytes = MemoryLayout.sequenceLayout(0, C_CHAR).varHandle(sequenceElement());
+    private static final VarHandle VH_bytes = MemoryLayout.sequenceLayout(-1, C_CHAR).varHandle(sequenceElement());
 
     private Path outputDir;
     private TestUtils.Loader loader;


### PR DESCRIPTION
Fixed VH_bytes layout

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Issue
 * [CODETOOLS-7903218](https://bugs.openjdk.org/browse/CODETOOLS-7903218): jextract test failure testng/org/openjdk/jextract/test/toolprovider/TestClassGeneration.java


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract pull/49/head:pull/49` \
`$ git checkout pull/49`

Update a local copy of the PR: \
`$ git checkout pull/49` \
`$ git pull https://git.openjdk.org/jextract pull/49/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 49`

View PR using the GUI difftool: \
`$ git pr show -t 49`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/49.diff">https://git.openjdk.org/jextract/pull/49.diff</a>

</details>
