### PR TITLE
updating libclang binding for jextract changes and llvm 13.0.0

### DIFF
--- a/src/main/java/org/openjdk/jextract/clang/libclang/CXCursorVisitor.java
+++ b/src/main/java/org/openjdk/jextract/clang/libclang/CXCursorVisitor.java
@@ -36,7 +36,7 @@ public interface CXCursorVisitor {
 
     int apply(java.lang.foreign.MemorySegment cursor, java.lang.foreign.MemorySegment parent, java.lang.foreign.MemoryAddress client_data);
     static MemorySegment allocate(CXCursorVisitor fi, MemorySession session) {
-        return RuntimeHelper.upcallStub(CXCursorVisitor.class, fi, constants$13.CXCursorVisitor$FUNC, "(Ljava/lang/foreign/MemorySegment;Ljava/lang/foreign/MemorySegment;Ljava/lang/foreign/MemoryAddress;)I", session);
+        return RuntimeHelper.upcallStub(CXCursorVisitor.class, fi, constants$13.CXCursorVisitor$FUNC, session);
     }
     static CXCursorVisitor ofAddress(MemoryAddress addr, MemorySession session) {
         MemorySegment symbol = MemorySegment.ofAddress(addr, 0, session);

--- a/src/main/java/org/openjdk/jextract/clang/libclang/Index_h.java
+++ b/src/main/java/org/openjdk/jextract/clang/libclang/Index_h.java
@@ -62,7 +62,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$0.clang_getCString$MH,"clang_getCString");
     }
     public static MemoryAddress clang_getCString ( MemorySegment string) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$0.clang_getCString$MH, "clang_getCString");
+        var mh$ = clang_getCString$MH();
         try {
             return (java.lang.foreign.MemoryAddress)mh$.invokeExact(string);
         } catch (Throwable ex$) {
@@ -73,7 +73,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$0.clang_disposeString$MH,"clang_disposeString");
     }
     public static void clang_disposeString ( MemorySegment string) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$0.clang_disposeString$MH, "clang_disposeString");
+        var mh$ = clang_disposeString$MH();
         try {
             mh$.invokeExact(string);
         } catch (Throwable ex$) {
@@ -116,7 +116,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$0.clang_createIndex$MH,"clang_createIndex");
     }
     public static MemoryAddress clang_createIndex ( int excludeDeclarationsFromPCH,  int displayDiagnostics) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$0.clang_createIndex$MH, "clang_createIndex");
+        var mh$ = clang_createIndex$MH();
         try {
             return (java.lang.foreign.MemoryAddress)mh$.invokeExact(excludeDeclarationsFromPCH, displayDiagnostics);
         } catch (Throwable ex$) {
@@ -127,7 +127,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$0.clang_disposeIndex$MH,"clang_disposeIndex");
     }
     public static void clang_disposeIndex ( Addressable index) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$0.clang_disposeIndex$MH, "clang_disposeIndex");
+        var mh$ = clang_disposeIndex$MH();
         try {
             mh$.invokeExact(index);
         } catch (Throwable ex$) {
@@ -138,7 +138,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$0.clang_getFileName$MH,"clang_getFileName");
     }
     public static MemorySegment clang_getFileName ( SegmentAllocator allocator,  Addressable SFile) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$0.clang_getFileName$MH, "clang_getFileName");
+        var mh$ = clang_getFileName$MH();
         try {
             return (java.lang.foreign.MemorySegment)mh$.invokeExact(allocator, SFile);
         } catch (Throwable ex$) {
@@ -149,7 +149,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$0.clang_getNullLocation$MH,"clang_getNullLocation");
     }
     public static MemorySegment clang_getNullLocation ( SegmentAllocator allocator) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$0.clang_getNullLocation$MH, "clang_getNullLocation");
+        var mh$ = clang_getNullLocation$MH();
         try {
             return (java.lang.foreign.MemorySegment)mh$.invokeExact(allocator);
         } catch (Throwable ex$) {
@@ -160,7 +160,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$1.clang_equalLocations$MH,"clang_equalLocations");
     }
     public static int clang_equalLocations ( MemorySegment loc1,  MemorySegment loc2) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$1.clang_equalLocations$MH, "clang_equalLocations");
+        var mh$ = clang_equalLocations$MH();
         try {
             return (int)mh$.invokeExact(loc1, loc2);
         } catch (Throwable ex$) {
@@ -171,7 +171,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$1.clang_getLocation$MH,"clang_getLocation");
     }
     public static MemorySegment clang_getLocation ( SegmentAllocator allocator,  Addressable tu,  Addressable file,  int line,  int column) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$1.clang_getLocation$MH, "clang_getLocation");
+        var mh$ = clang_getLocation$MH();
         try {
             return (java.lang.foreign.MemorySegment)mh$.invokeExact(allocator, tu, file, line, column);
         } catch (Throwable ex$) {
@@ -182,7 +182,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$1.clang_getLocationForOffset$MH,"clang_getLocationForOffset");
     }
     public static MemorySegment clang_getLocationForOffset ( SegmentAllocator allocator,  Addressable tu,  Addressable file,  int offset) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$1.clang_getLocationForOffset$MH, "clang_getLocationForOffset");
+        var mh$ = clang_getLocationForOffset$MH();
         try {
             return (java.lang.foreign.MemorySegment)mh$.invokeExact(allocator, tu, file, offset);
         } catch (Throwable ex$) {
@@ -193,7 +193,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$1.clang_Location_isInSystemHeader$MH,"clang_Location_isInSystemHeader");
     }
     public static int clang_Location_isInSystemHeader ( MemorySegment location) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$1.clang_Location_isInSystemHeader$MH, "clang_Location_isInSystemHeader");
+        var mh$ = clang_Location_isInSystemHeader$MH();
         try {
             return (int)mh$.invokeExact(location);
         } catch (Throwable ex$) {
@@ -204,7 +204,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$1.clang_Location_isFromMainFile$MH,"clang_Location_isFromMainFile");
     }
     public static int clang_Location_isFromMainFile ( MemorySegment location) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$1.clang_Location_isFromMainFile$MH, "clang_Location_isFromMainFile");
+        var mh$ = clang_Location_isFromMainFile$MH();
         try {
             return (int)mh$.invokeExact(location);
         } catch (Throwable ex$) {
@@ -215,7 +215,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$1.clang_Range_isNull$MH,"clang_Range_isNull");
     }
     public static int clang_Range_isNull ( MemorySegment range) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$1.clang_Range_isNull$MH, "clang_Range_isNull");
+        var mh$ = clang_Range_isNull$MH();
         try {
             return (int)mh$.invokeExact(range);
         } catch (Throwable ex$) {
@@ -226,7 +226,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$2.clang_getExpansionLocation$MH,"clang_getExpansionLocation");
     }
     public static void clang_getExpansionLocation ( MemorySegment location,  Addressable file,  Addressable line,  Addressable column,  Addressable offset) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$2.clang_getExpansionLocation$MH, "clang_getExpansionLocation");
+        var mh$ = clang_getExpansionLocation$MH();
         try {
             mh$.invokeExact(location, file, line, column, offset);
         } catch (Throwable ex$) {
@@ -237,7 +237,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$2.clang_getSpellingLocation$MH,"clang_getSpellingLocation");
     }
     public static void clang_getSpellingLocation ( MemorySegment location,  Addressable file,  Addressable line,  Addressable column,  Addressable offset) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$2.clang_getSpellingLocation$MH, "clang_getSpellingLocation");
+        var mh$ = clang_getSpellingLocation$MH();
         try {
             mh$.invokeExact(location, file, line, column, offset);
         } catch (Throwable ex$) {
@@ -248,7 +248,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$2.clang_getFileLocation$MH,"clang_getFileLocation");
     }
     public static void clang_getFileLocation ( MemorySegment location,  Addressable file,  Addressable line,  Addressable column,  Addressable offset) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$2.clang_getFileLocation$MH, "clang_getFileLocation");
+        var mh$ = clang_getFileLocation$MH();
         try {
             mh$.invokeExact(location, file, line, column, offset);
         } catch (Throwable ex$) {
@@ -259,7 +259,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$2.clang_getRangeStart$MH,"clang_getRangeStart");
     }
     public static MemorySegment clang_getRangeStart ( SegmentAllocator allocator,  MemorySegment range) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$2.clang_getRangeStart$MH, "clang_getRangeStart");
+        var mh$ = clang_getRangeStart$MH();
         try {
             return (java.lang.foreign.MemorySegment)mh$.invokeExact(allocator, range);
         } catch (Throwable ex$) {
@@ -270,7 +270,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$2.clang_getRangeEnd$MH,"clang_getRangeEnd");
     }
     public static MemorySegment clang_getRangeEnd ( SegmentAllocator allocator,  MemorySegment range) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$2.clang_getRangeEnd$MH, "clang_getRangeEnd");
+        var mh$ = clang_getRangeEnd$MH();
         try {
             return (java.lang.foreign.MemorySegment)mh$.invokeExact(allocator, range);
         } catch (Throwable ex$) {
@@ -296,7 +296,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$2.clang_getChildDiagnostics$MH,"clang_getChildDiagnostics");
     }
     public static MemoryAddress clang_getChildDiagnostics ( Addressable D) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$2.clang_getChildDiagnostics$MH, "clang_getChildDiagnostics");
+        var mh$ = clang_getChildDiagnostics$MH();
         try {
             return (java.lang.foreign.MemoryAddress)mh$.invokeExact(D);
         } catch (Throwable ex$) {
@@ -307,7 +307,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$3.clang_getNumDiagnostics$MH,"clang_getNumDiagnostics");
     }
     public static int clang_getNumDiagnostics ( Addressable Unit) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$3.clang_getNumDiagnostics$MH, "clang_getNumDiagnostics");
+        var mh$ = clang_getNumDiagnostics$MH();
         try {
             return (int)mh$.invokeExact(Unit);
         } catch (Throwable ex$) {
@@ -318,7 +318,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$3.clang_getDiagnostic$MH,"clang_getDiagnostic");
     }
     public static MemoryAddress clang_getDiagnostic ( Addressable Unit,  int Index) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$3.clang_getDiagnostic$MH, "clang_getDiagnostic");
+        var mh$ = clang_getDiagnostic$MH();
         try {
             return (java.lang.foreign.MemoryAddress)mh$.invokeExact(Unit, Index);
         } catch (Throwable ex$) {
@@ -329,7 +329,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$3.clang_disposeDiagnostic$MH,"clang_disposeDiagnostic");
     }
     public static void clang_disposeDiagnostic ( Addressable Diagnostic) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$3.clang_disposeDiagnostic$MH, "clang_disposeDiagnostic");
+        var mh$ = clang_disposeDiagnostic$MH();
         try {
             mh$.invokeExact(Diagnostic);
         } catch (Throwable ex$) {
@@ -358,7 +358,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$3.clang_formatDiagnostic$MH,"clang_formatDiagnostic");
     }
     public static MemorySegment clang_formatDiagnostic ( SegmentAllocator allocator,  Addressable Diagnostic,  int Options) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$3.clang_formatDiagnostic$MH, "clang_formatDiagnostic");
+        var mh$ = clang_formatDiagnostic$MH();
         try {
             return (java.lang.foreign.MemorySegment)mh$.invokeExact(allocator, Diagnostic, Options);
         } catch (Throwable ex$) {
@@ -369,7 +369,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$3.clang_defaultDiagnosticDisplayOptions$MH,"clang_defaultDiagnosticDisplayOptions");
     }
     public static int clang_defaultDiagnosticDisplayOptions () {
-        var mh$ = RuntimeHelper.requireNonNull(constants$3.clang_defaultDiagnosticDisplayOptions$MH, "clang_defaultDiagnosticDisplayOptions");
+        var mh$ = clang_defaultDiagnosticDisplayOptions$MH();
         try {
             return (int)mh$.invokeExact();
         } catch (Throwable ex$) {
@@ -380,7 +380,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$3.clang_getDiagnosticSeverity$MH,"clang_getDiagnosticSeverity");
     }
     public static int clang_getDiagnosticSeverity ( Addressable x0) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$3.clang_getDiagnosticSeverity$MH, "clang_getDiagnosticSeverity");
+        var mh$ = clang_getDiagnosticSeverity$MH();
         try {
             return (int)mh$.invokeExact(x0);
         } catch (Throwable ex$) {
@@ -391,7 +391,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$4.clang_getDiagnosticLocation$MH,"clang_getDiagnosticLocation");
     }
     public static MemorySegment clang_getDiagnosticLocation ( SegmentAllocator allocator,  Addressable x1) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$4.clang_getDiagnosticLocation$MH, "clang_getDiagnosticLocation");
+        var mh$ = clang_getDiagnosticLocation$MH();
         try {
             return (java.lang.foreign.MemorySegment)mh$.invokeExact(allocator, x1);
         } catch (Throwable ex$) {
@@ -402,7 +402,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$4.clang_getDiagnosticSpelling$MH,"clang_getDiagnosticSpelling");
     }
     public static MemorySegment clang_getDiagnosticSpelling ( SegmentAllocator allocator,  Addressable x1) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$4.clang_getDiagnosticSpelling$MH, "clang_getDiagnosticSpelling");
+        var mh$ = clang_getDiagnosticSpelling$MH();
         try {
             return (java.lang.foreign.MemorySegment)mh$.invokeExact(allocator, x1);
         } catch (Throwable ex$) {
@@ -464,7 +464,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$4.clang_parseTranslationUnit$MH,"clang_parseTranslationUnit");
     }
     public static MemoryAddress clang_parseTranslationUnit ( Addressable CIdx,  Addressable source_filename,  Addressable command_line_args,  int num_command_line_args,  Addressable unsaved_files,  int num_unsaved_files,  int options) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$4.clang_parseTranslationUnit$MH, "clang_parseTranslationUnit");
+        var mh$ = clang_parseTranslationUnit$MH();
         try {
             return (java.lang.foreign.MemoryAddress)mh$.invokeExact(CIdx, source_filename, command_line_args, num_command_line_args, unsaved_files, num_unsaved_files, options);
         } catch (Throwable ex$) {
@@ -475,7 +475,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$4.clang_parseTranslationUnit2$MH,"clang_parseTranslationUnit2");
     }
     public static int clang_parseTranslationUnit2 ( Addressable CIdx,  Addressable source_filename,  Addressable command_line_args,  int num_command_line_args,  Addressable unsaved_files,  int num_unsaved_files,  int options,  Addressable out_TU) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$4.clang_parseTranslationUnit2$MH, "clang_parseTranslationUnit2");
+        var mh$ = clang_parseTranslationUnit2$MH();
         try {
             return (int)mh$.invokeExact(CIdx, source_filename, command_line_args, num_command_line_args, unsaved_files, num_unsaved_files, options, out_TU);
         } catch (Throwable ex$) {
@@ -501,7 +501,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$4.clang_saveTranslationUnit$MH,"clang_saveTranslationUnit");
     }
     public static int clang_saveTranslationUnit ( Addressable TU,  Addressable FileName,  int options) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$4.clang_saveTranslationUnit$MH, "clang_saveTranslationUnit");
+        var mh$ = clang_saveTranslationUnit$MH();
         try {
             return (int)mh$.invokeExact(TU, FileName, options);
         } catch (Throwable ex$) {
@@ -512,7 +512,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$4.clang_disposeTranslationUnit$MH,"clang_disposeTranslationUnit");
     }
     public static void clang_disposeTranslationUnit ( Addressable x0) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$4.clang_disposeTranslationUnit$MH, "clang_disposeTranslationUnit");
+        var mh$ = clang_disposeTranslationUnit$MH();
         try {
             mh$.invokeExact(x0);
         } catch (Throwable ex$) {
@@ -526,7 +526,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$5.clang_defaultReparseOptions$MH,"clang_defaultReparseOptions");
     }
     public static int clang_defaultReparseOptions ( Addressable TU) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$5.clang_defaultReparseOptions$MH, "clang_defaultReparseOptions");
+        var mh$ = clang_defaultReparseOptions$MH();
         try {
             return (int)mh$.invokeExact(TU);
         } catch (Throwable ex$) {
@@ -537,7 +537,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$5.clang_reparseTranslationUnit$MH,"clang_reparseTranslationUnit");
     }
     public static int clang_reparseTranslationUnit ( Addressable TU,  int num_unsaved_files,  Addressable unsaved_files,  int options) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$5.clang_reparseTranslationUnit$MH, "clang_reparseTranslationUnit");
+        var mh$ = clang_reparseTranslationUnit$MH();
         try {
             return (int)mh$.invokeExact(TU, num_unsaved_files, unsaved_files, options);
         } catch (Throwable ex$) {
@@ -878,7 +878,7 @@ public class Index_h  {
         return (int)149L;
     }
     public static int CXCursor_LastExpr() {
-        return (int)149L;
+        return (int)152L;
     }
     public static int CXCursor_FirstStmt() {
         return (int)200L;
@@ -1142,7 +1142,7 @@ public class Index_h  {
         return (int)284L;
     }
     public static int CXCursor_LastStmt() {
-        return (int)285L;
+        return (int)293L;
     }
     public static int CXCursor_TranslationUnit() {
         return (int)300L;
@@ -1325,7 +1325,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$5.clang_getNullCursor$MH,"clang_getNullCursor");
     }
     public static MemorySegment clang_getNullCursor ( SegmentAllocator allocator) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$5.clang_getNullCursor$MH, "clang_getNullCursor");
+        var mh$ = clang_getNullCursor$MH();
         try {
             return (java.lang.foreign.MemorySegment)mh$.invokeExact(allocator);
         } catch (Throwable ex$) {
@@ -1336,7 +1336,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$5.clang_getTranslationUnitCursor$MH,"clang_getTranslationUnitCursor");
     }
     public static MemorySegment clang_getTranslationUnitCursor ( SegmentAllocator allocator,  Addressable x1) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$5.clang_getTranslationUnitCursor$MH, "clang_getTranslationUnitCursor");
+        var mh$ = clang_getTranslationUnitCursor$MH();
         try {
             return (java.lang.foreign.MemorySegment)mh$.invokeExact(allocator, x1);
         } catch (Throwable ex$) {
@@ -1347,7 +1347,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$5.clang_equalCursors$MH,"clang_equalCursors");
     }
     public static int clang_equalCursors ( MemorySegment x0,  MemorySegment x1) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$5.clang_equalCursors$MH, "clang_equalCursors");
+        var mh$ = clang_equalCursors$MH();
         try {
             return (int)mh$.invokeExact(x0, x1);
         } catch (Throwable ex$) {
@@ -1358,7 +1358,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$5.clang_Cursor_isNull$MH,"clang_Cursor_isNull");
     }
     public static int clang_Cursor_isNull ( MemorySegment cursor) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$5.clang_Cursor_isNull$MH, "clang_Cursor_isNull");
+        var mh$ = clang_Cursor_isNull$MH();
         try {
             return (int)mh$.invokeExact(cursor);
         } catch (Throwable ex$) {
@@ -1369,7 +1369,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$6.clang_getCursorKind$MH,"clang_getCursorKind");
     }
     public static int clang_getCursorKind ( MemorySegment x0) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$6.clang_getCursorKind$MH, "clang_getCursorKind");
+        var mh$ = clang_getCursorKind$MH();
         try {
             return (int)mh$.invokeExact(x0);
         } catch (Throwable ex$) {
@@ -1380,7 +1380,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$6.clang_isDeclaration$MH,"clang_isDeclaration");
     }
     public static int clang_isDeclaration ( int x0) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$6.clang_isDeclaration$MH, "clang_isDeclaration");
+        var mh$ = clang_isDeclaration$MH();
         try {
             return (int)mh$.invokeExact(x0);
         } catch (Throwable ex$) {
@@ -1391,7 +1391,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$6.clang_isAttribute$MH,"clang_isAttribute");
     }
     public static int clang_isAttribute ( int x0) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$6.clang_isAttribute$MH, "clang_isAttribute");
+        var mh$ = clang_isAttribute$MH();
         try {
             return (int)mh$.invokeExact(x0);
         } catch (Throwable ex$) {
@@ -1402,7 +1402,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$6.clang_isInvalid$MH,"clang_isInvalid");
     }
     public static int clang_isInvalid ( int x0) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$6.clang_isInvalid$MH, "clang_isInvalid");
+        var mh$ = clang_isInvalid$MH();
         try {
             return (int)mh$.invokeExact(x0);
         } catch (Throwable ex$) {
@@ -1413,7 +1413,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$6.clang_isPreprocessing$MH,"clang_isPreprocessing");
     }
     public static int clang_isPreprocessing ( int x0) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$6.clang_isPreprocessing$MH, "clang_isPreprocessing");
+        var mh$ = clang_isPreprocessing$MH();
         try {
             return (int)mh$.invokeExact(x0);
         } catch (Throwable ex$) {
@@ -1436,7 +1436,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$6.clang_getCursorLanguage$MH,"clang_getCursorLanguage");
     }
     public static int clang_getCursorLanguage ( MemorySegment cursor) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$6.clang_getCursorLanguage$MH, "clang_getCursorLanguage");
+        var mh$ = clang_getCursorLanguage$MH();
         try {
             return (int)mh$.invokeExact(cursor);
         } catch (Throwable ex$) {
@@ -1447,7 +1447,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$7.clang_Cursor_getTranslationUnit$MH,"clang_Cursor_getTranslationUnit");
     }
     public static MemoryAddress clang_Cursor_getTranslationUnit ( MemorySegment x0) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$7.clang_Cursor_getTranslationUnit$MH, "clang_Cursor_getTranslationUnit");
+        var mh$ = clang_Cursor_getTranslationUnit$MH();
         try {
             return (java.lang.foreign.MemoryAddress)mh$.invokeExact(x0);
         } catch (Throwable ex$) {
@@ -1458,7 +1458,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$7.clang_getCursorLocation$MH,"clang_getCursorLocation");
     }
     public static MemorySegment clang_getCursorLocation ( SegmentAllocator allocator,  MemorySegment x1) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$7.clang_getCursorLocation$MH, "clang_getCursorLocation");
+        var mh$ = clang_getCursorLocation$MH();
         try {
             return (java.lang.foreign.MemorySegment)mh$.invokeExact(allocator, x1);
         } catch (Throwable ex$) {
@@ -1469,7 +1469,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$7.clang_getCursorExtent$MH,"clang_getCursorExtent");
     }
     public static MemorySegment clang_getCursorExtent ( SegmentAllocator allocator,  MemorySegment x1) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$7.clang_getCursorExtent$MH, "clang_getCursorExtent");
+        var mh$ = clang_getCursorExtent$MH();
         try {
             return (java.lang.foreign.MemorySegment)mh$.invokeExact(allocator, x1);
         } catch (Throwable ex$) {
@@ -1597,7 +1597,7 @@ public class Index_h  {
         return (int)2L;
     }
     public static int CXType_LastBuiltin() {
-        return (int)38L;
+        return (int)39L;
     }
     public static int CXType_Complex() {
         return (int)100L;
@@ -1894,7 +1894,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$7.clang_getCursorType$MH,"clang_getCursorType");
     }
     public static MemorySegment clang_getCursorType ( SegmentAllocator allocator,  MemorySegment C) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$7.clang_getCursorType$MH, "clang_getCursorType");
+        var mh$ = clang_getCursorType$MH();
         try {
             return (java.lang.foreign.MemorySegment)mh$.invokeExact(allocator, C);
         } catch (Throwable ex$) {
@@ -1905,7 +1905,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$7.clang_getTypeSpelling$MH,"clang_getTypeSpelling");
     }
     public static MemorySegment clang_getTypeSpelling ( SegmentAllocator allocator,  MemorySegment CT) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$7.clang_getTypeSpelling$MH, "clang_getTypeSpelling");
+        var mh$ = clang_getTypeSpelling$MH();
         try {
             return (java.lang.foreign.MemorySegment)mh$.invokeExact(allocator, CT);
         } catch (Throwable ex$) {
@@ -1916,7 +1916,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$7.clang_getTypedefDeclUnderlyingType$MH,"clang_getTypedefDeclUnderlyingType");
     }
     public static MemorySegment clang_getTypedefDeclUnderlyingType ( SegmentAllocator allocator,  MemorySegment C) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$7.clang_getTypedefDeclUnderlyingType$MH, "clang_getTypedefDeclUnderlyingType");
+        var mh$ = clang_getTypedefDeclUnderlyingType$MH();
         try {
             return (java.lang.foreign.MemorySegment)mh$.invokeExact(allocator, C);
         } catch (Throwable ex$) {
@@ -1927,7 +1927,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$8.clang_getEnumDeclIntegerType$MH,"clang_getEnumDeclIntegerType");
     }
     public static MemorySegment clang_getEnumDeclIntegerType ( SegmentAllocator allocator,  MemorySegment C) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$8.clang_getEnumDeclIntegerType$MH, "clang_getEnumDeclIntegerType");
+        var mh$ = clang_getEnumDeclIntegerType$MH();
         try {
             return (java.lang.foreign.MemorySegment)mh$.invokeExact(allocator, C);
         } catch (Throwable ex$) {
@@ -1938,7 +1938,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$8.clang_getEnumConstantDeclValue$MH,"clang_getEnumConstantDeclValue");
     }
     public static long clang_getEnumConstantDeclValue ( MemorySegment C) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$8.clang_getEnumConstantDeclValue$MH, "clang_getEnumConstantDeclValue");
+        var mh$ = clang_getEnumConstantDeclValue$MH();
         try {
             return (long)mh$.invokeExact(C);
         } catch (Throwable ex$) {
@@ -1949,7 +1949,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$8.clang_getEnumConstantDeclUnsignedValue$MH,"clang_getEnumConstantDeclUnsignedValue");
     }
     public static long clang_getEnumConstantDeclUnsignedValue ( MemorySegment C) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$8.clang_getEnumConstantDeclUnsignedValue$MH, "clang_getEnumConstantDeclUnsignedValue");
+        var mh$ = clang_getEnumConstantDeclUnsignedValue$MH();
         try {
             return (long)mh$.invokeExact(C);
         } catch (Throwable ex$) {
@@ -1960,7 +1960,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$8.clang_getFieldDeclBitWidth$MH,"clang_getFieldDeclBitWidth");
     }
     public static int clang_getFieldDeclBitWidth ( MemorySegment C) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$8.clang_getFieldDeclBitWidth$MH, "clang_getFieldDeclBitWidth");
+        var mh$ = clang_getFieldDeclBitWidth$MH();
         try {
             return (int)mh$.invokeExact(C);
         } catch (Throwable ex$) {
@@ -1971,7 +1971,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$8.clang_Cursor_getNumArguments$MH,"clang_Cursor_getNumArguments");
     }
     public static int clang_Cursor_getNumArguments ( MemorySegment C) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$8.clang_Cursor_getNumArguments$MH, "clang_Cursor_getNumArguments");
+        var mh$ = clang_Cursor_getNumArguments$MH();
         try {
             return (int)mh$.invokeExact(C);
         } catch (Throwable ex$) {
@@ -1982,7 +1982,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$8.clang_Cursor_getArgument$MH,"clang_Cursor_getArgument");
     }
     public static MemorySegment clang_Cursor_getArgument ( SegmentAllocator allocator,  MemorySegment C,  int i) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$8.clang_Cursor_getArgument$MH, "clang_Cursor_getArgument");
+        var mh$ = clang_Cursor_getArgument$MH();
         try {
             return (java.lang.foreign.MemorySegment)mh$.invokeExact(allocator, C, i);
         } catch (Throwable ex$) {
@@ -1993,7 +1993,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$9.clang_equalTypes$MH,"clang_equalTypes");
     }
     public static int clang_equalTypes ( MemorySegment A,  MemorySegment B) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$9.clang_equalTypes$MH, "clang_equalTypes");
+        var mh$ = clang_equalTypes$MH();
         try {
             return (int)mh$.invokeExact(A, B);
         } catch (Throwable ex$) {
@@ -2004,7 +2004,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$9.clang_getCanonicalType$MH,"clang_getCanonicalType");
     }
     public static MemorySegment clang_getCanonicalType ( SegmentAllocator allocator,  MemorySegment T) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$9.clang_getCanonicalType$MH, "clang_getCanonicalType");
+        var mh$ = clang_getCanonicalType$MH();
         try {
             return (java.lang.foreign.MemorySegment)mh$.invokeExact(allocator, T);
         } catch (Throwable ex$) {
@@ -2015,7 +2015,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$9.clang_isConstQualifiedType$MH,"clang_isConstQualifiedType");
     }
     public static int clang_isConstQualifiedType ( MemorySegment T) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$9.clang_isConstQualifiedType$MH, "clang_isConstQualifiedType");
+        var mh$ = clang_isConstQualifiedType$MH();
         try {
             return (int)mh$.invokeExact(T);
         } catch (Throwable ex$) {
@@ -2026,7 +2026,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$9.clang_Cursor_isMacroFunctionLike$MH,"clang_Cursor_isMacroFunctionLike");
     }
     public static int clang_Cursor_isMacroFunctionLike ( MemorySegment C) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$9.clang_Cursor_isMacroFunctionLike$MH, "clang_Cursor_isMacroFunctionLike");
+        var mh$ = clang_Cursor_isMacroFunctionLike$MH();
         try {
             return (int)mh$.invokeExact(C);
         } catch (Throwable ex$) {
@@ -2037,7 +2037,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$9.clang_isVolatileQualifiedType$MH,"clang_isVolatileQualifiedType");
     }
     public static int clang_isVolatileQualifiedType ( MemorySegment T) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$9.clang_isVolatileQualifiedType$MH, "clang_isVolatileQualifiedType");
+        var mh$ = clang_isVolatileQualifiedType$MH();
         try {
             return (int)mh$.invokeExact(T);
         } catch (Throwable ex$) {
@@ -2048,7 +2048,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$9.clang_getTypedefName$MH,"clang_getTypedefName");
     }
     public static MemorySegment clang_getTypedefName ( SegmentAllocator allocator,  MemorySegment CT) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$9.clang_getTypedefName$MH, "clang_getTypedefName");
+        var mh$ = clang_getTypedefName$MH();
         try {
             return (java.lang.foreign.MemorySegment)mh$.invokeExact(allocator, CT);
         } catch (Throwable ex$) {
@@ -2059,7 +2059,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$10.clang_getPointeeType$MH,"clang_getPointeeType");
     }
     public static MemorySegment clang_getPointeeType ( SegmentAllocator allocator,  MemorySegment T) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$10.clang_getPointeeType$MH, "clang_getPointeeType");
+        var mh$ = clang_getPointeeType$MH();
         try {
             return (java.lang.foreign.MemorySegment)mh$.invokeExact(allocator, T);
         } catch (Throwable ex$) {
@@ -2070,7 +2070,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$10.clang_getTypeDeclaration$MH,"clang_getTypeDeclaration");
     }
     public static MemorySegment clang_getTypeDeclaration ( SegmentAllocator allocator,  MemorySegment T) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$10.clang_getTypeDeclaration$MH, "clang_getTypeDeclaration");
+        var mh$ = clang_getTypeDeclaration$MH();
         try {
             return (java.lang.foreign.MemorySegment)mh$.invokeExact(allocator, T);
         } catch (Throwable ex$) {
@@ -2081,7 +2081,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$10.clang_getTypeKindSpelling$MH,"clang_getTypeKindSpelling");
     }
     public static MemorySegment clang_getTypeKindSpelling ( SegmentAllocator allocator,  int K) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$10.clang_getTypeKindSpelling$MH, "clang_getTypeKindSpelling");
+        var mh$ = clang_getTypeKindSpelling$MH();
         try {
             return (java.lang.foreign.MemorySegment)mh$.invokeExact(allocator, K);
         } catch (Throwable ex$) {
@@ -2092,7 +2092,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$10.clang_getFunctionTypeCallingConv$MH,"clang_getFunctionTypeCallingConv");
     }
     public static int clang_getFunctionTypeCallingConv ( MemorySegment T) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$10.clang_getFunctionTypeCallingConv$MH, "clang_getFunctionTypeCallingConv");
+        var mh$ = clang_getFunctionTypeCallingConv$MH();
         try {
             return (int)mh$.invokeExact(T);
         } catch (Throwable ex$) {
@@ -2103,7 +2103,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$10.clang_getResultType$MH,"clang_getResultType");
     }
     public static MemorySegment clang_getResultType ( SegmentAllocator allocator,  MemorySegment T) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$10.clang_getResultType$MH, "clang_getResultType");
+        var mh$ = clang_getResultType$MH();
         try {
             return (java.lang.foreign.MemorySegment)mh$.invokeExact(allocator, T);
         } catch (Throwable ex$) {
@@ -2114,7 +2114,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$10.clang_getNumArgTypes$MH,"clang_getNumArgTypes");
     }
     public static int clang_getNumArgTypes ( MemorySegment T) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$10.clang_getNumArgTypes$MH, "clang_getNumArgTypes");
+        var mh$ = clang_getNumArgTypes$MH();
         try {
             return (int)mh$.invokeExact(T);
         } catch (Throwable ex$) {
@@ -2125,7 +2125,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$11.clang_getArgType$MH,"clang_getArgType");
     }
     public static MemorySegment clang_getArgType ( SegmentAllocator allocator,  MemorySegment T,  int i) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$11.clang_getArgType$MH, "clang_getArgType");
+        var mh$ = clang_getArgType$MH();
         try {
             return (java.lang.foreign.MemorySegment)mh$.invokeExact(allocator, T, i);
         } catch (Throwable ex$) {
@@ -2136,7 +2136,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$11.clang_isFunctionTypeVariadic$MH,"clang_isFunctionTypeVariadic");
     }
     public static int clang_isFunctionTypeVariadic ( MemorySegment T) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$11.clang_isFunctionTypeVariadic$MH, "clang_isFunctionTypeVariadic");
+        var mh$ = clang_isFunctionTypeVariadic$MH();
         try {
             return (int)mh$.invokeExact(T);
         } catch (Throwable ex$) {
@@ -2147,7 +2147,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$11.clang_getCursorResultType$MH,"clang_getCursorResultType");
     }
     public static MemorySegment clang_getCursorResultType ( SegmentAllocator allocator,  MemorySegment C) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$11.clang_getCursorResultType$MH, "clang_getCursorResultType");
+        var mh$ = clang_getCursorResultType$MH();
         try {
             return (java.lang.foreign.MemorySegment)mh$.invokeExact(allocator, C);
         } catch (Throwable ex$) {
@@ -2158,7 +2158,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$11.clang_getElementType$MH,"clang_getElementType");
     }
     public static MemorySegment clang_getElementType ( SegmentAllocator allocator,  MemorySegment T) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$11.clang_getElementType$MH, "clang_getElementType");
+        var mh$ = clang_getElementType$MH();
         try {
             return (java.lang.foreign.MemorySegment)mh$.invokeExact(allocator, T);
         } catch (Throwable ex$) {
@@ -2169,7 +2169,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$11.clang_getNumElements$MH,"clang_getNumElements");
     }
     public static long clang_getNumElements ( MemorySegment T) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$11.clang_getNumElements$MH, "clang_getNumElements");
+        var mh$ = clang_getNumElements$MH();
         try {
             return (long)mh$.invokeExact(T);
         } catch (Throwable ex$) {
@@ -2180,7 +2180,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$11.clang_getArrayElementType$MH,"clang_getArrayElementType");
     }
     public static MemorySegment clang_getArrayElementType ( SegmentAllocator allocator,  MemorySegment T) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$11.clang_getArrayElementType$MH, "clang_getArrayElementType");
+        var mh$ = clang_getArrayElementType$MH();
         try {
             return (java.lang.foreign.MemorySegment)mh$.invokeExact(allocator, T);
         } catch (Throwable ex$) {
@@ -2191,7 +2191,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$12.clang_getArraySize$MH,"clang_getArraySize");
     }
     public static long clang_getArraySize ( MemorySegment T) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$12.clang_getArraySize$MH, "clang_getArraySize");
+        var mh$ = clang_getArraySize$MH();
         try {
             return (long)mh$.invokeExact(T);
         } catch (Throwable ex$) {
@@ -2232,7 +2232,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$12.clang_Type_getSizeOf$MH,"clang_Type_getSizeOf");
     }
     public static long clang_Type_getSizeOf ( MemorySegment T) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$12.clang_Type_getSizeOf$MH, "clang_Type_getSizeOf");
+        var mh$ = clang_Type_getSizeOf$MH();
         try {
             return (long)mh$.invokeExact(T);
         } catch (Throwable ex$) {
@@ -2243,7 +2243,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$12.clang_Type_getOffsetOf$MH,"clang_Type_getOffsetOf");
     }
     public static long clang_Type_getOffsetOf ( MemorySegment T,  Addressable S) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$12.clang_Type_getOffsetOf$MH, "clang_Type_getOffsetOf");
+        var mh$ = clang_Type_getOffsetOf$MH();
         try {
             return (long)mh$.invokeExact(T, S);
         } catch (Throwable ex$) {
@@ -2254,7 +2254,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$12.clang_Cursor_isAnonymous$MH,"clang_Cursor_isAnonymous");
     }
     public static int clang_Cursor_isAnonymous ( MemorySegment C) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$12.clang_Cursor_isAnonymous$MH, "clang_Cursor_isAnonymous");
+        var mh$ = clang_Cursor_isAnonymous$MH();
         try {
             return (int)mh$.invokeExact(C);
         } catch (Throwable ex$) {
@@ -2265,7 +2265,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$12.clang_Cursor_isAnonymousRecordDecl$MH,"clang_Cursor_isAnonymousRecordDecl");
     }
     public static int clang_Cursor_isAnonymousRecordDecl ( MemorySegment C) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$12.clang_Cursor_isAnonymousRecordDecl$MH, "clang_Cursor_isAnonymousRecordDecl");
+        var mh$ = clang_Cursor_isAnonymousRecordDecl$MH();
         try {
             return (int)mh$.invokeExact(C);
         } catch (Throwable ex$) {
@@ -2276,7 +2276,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$12.clang_Cursor_isBitField$MH,"clang_Cursor_isBitField");
     }
     public static int clang_Cursor_isBitField ( MemorySegment C) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$12.clang_Cursor_isBitField$MH, "clang_Cursor_isBitField");
+        var mh$ = clang_Cursor_isBitField$MH();
         try {
             return (int)mh$.invokeExact(C);
         } catch (Throwable ex$) {
@@ -2296,7 +2296,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$13.clang_visitChildren$MH,"clang_visitChildren");
     }
     public static int clang_visitChildren ( MemorySegment parent,  Addressable visitor,  Addressable client_data) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$13.clang_visitChildren$MH, "clang_visitChildren");
+        var mh$ = clang_visitChildren$MH();
         try {
             return (int)mh$.invokeExact(parent, visitor, client_data);
         } catch (Throwable ex$) {
@@ -2307,7 +2307,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$13.clang_getCursorUSR$MH,"clang_getCursorUSR");
     }
     public static MemorySegment clang_getCursorUSR ( SegmentAllocator allocator,  MemorySegment x1) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$13.clang_getCursorUSR$MH, "clang_getCursorUSR");
+        var mh$ = clang_getCursorUSR$MH();
         try {
             return (java.lang.foreign.MemorySegment)mh$.invokeExact(allocator, x1);
         } catch (Throwable ex$) {
@@ -2318,7 +2318,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$13.clang_getCursorSpelling$MH,"clang_getCursorSpelling");
     }
     public static MemorySegment clang_getCursorSpelling ( SegmentAllocator allocator,  MemorySegment x1) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$13.clang_getCursorSpelling$MH, "clang_getCursorSpelling");
+        var mh$ = clang_getCursorSpelling$MH();
         try {
             return (java.lang.foreign.MemorySegment)mh$.invokeExact(allocator, x1);
         } catch (Throwable ex$) {
@@ -2410,7 +2410,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$13.clang_PrintingPolicy_getProperty$MH,"clang_PrintingPolicy_getProperty");
     }
     public static int clang_PrintingPolicy_getProperty ( Addressable Policy,  int Property) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$13.clang_PrintingPolicy_getProperty$MH, "clang_PrintingPolicy_getProperty");
+        var mh$ = clang_PrintingPolicy_getProperty$MH();
         try {
             return (int)mh$.invokeExact(Policy, Property);
         } catch (Throwable ex$) {
@@ -2421,7 +2421,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$14.clang_PrintingPolicy_setProperty$MH,"clang_PrintingPolicy_setProperty");
     }
     public static void clang_PrintingPolicy_setProperty ( Addressable Policy,  int Property,  int Value) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$14.clang_PrintingPolicy_setProperty$MH, "clang_PrintingPolicy_setProperty");
+        var mh$ = clang_PrintingPolicy_setProperty$MH();
         try {
             mh$.invokeExact(Policy, Property, Value);
         } catch (Throwable ex$) {
@@ -2432,7 +2432,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$14.clang_getCursorPrintingPolicy$MH,"clang_getCursorPrintingPolicy");
     }
     public static MemoryAddress clang_getCursorPrintingPolicy ( MemorySegment x0) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$14.clang_getCursorPrintingPolicy$MH, "clang_getCursorPrintingPolicy");
+        var mh$ = clang_getCursorPrintingPolicy$MH();
         try {
             return (java.lang.foreign.MemoryAddress)mh$.invokeExact(x0);
         } catch (Throwable ex$) {
@@ -2443,7 +2443,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$14.clang_PrintingPolicy_dispose$MH,"clang_PrintingPolicy_dispose");
     }
     public static void clang_PrintingPolicy_dispose ( Addressable Policy) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$14.clang_PrintingPolicy_dispose$MH, "clang_PrintingPolicy_dispose");
+        var mh$ = clang_PrintingPolicy_dispose$MH();
         try {
             mh$.invokeExact(Policy);
         } catch (Throwable ex$) {
@@ -2454,7 +2454,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$14.clang_getCursorPrettyPrinted$MH,"clang_getCursorPrettyPrinted");
     }
     public static MemorySegment clang_getCursorPrettyPrinted ( SegmentAllocator allocator,  MemorySegment Cursor,  Addressable Policy) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$14.clang_getCursorPrettyPrinted$MH, "clang_getCursorPrettyPrinted");
+        var mh$ = clang_getCursorPrettyPrinted$MH();
         try {
             return (java.lang.foreign.MemorySegment)mh$.invokeExact(allocator, Cursor, Policy);
         } catch (Throwable ex$) {
@@ -2465,7 +2465,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$14.clang_getCursorDisplayName$MH,"clang_getCursorDisplayName");
     }
     public static MemorySegment clang_getCursorDisplayName ( SegmentAllocator allocator,  MemorySegment x1) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$14.clang_getCursorDisplayName$MH, "clang_getCursorDisplayName");
+        var mh$ = clang_getCursorDisplayName$MH();
         try {
             return (java.lang.foreign.MemorySegment)mh$.invokeExact(allocator, x1);
         } catch (Throwable ex$) {
@@ -2476,7 +2476,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$14.clang_getCursorReferenced$MH,"clang_getCursorReferenced");
     }
     public static MemorySegment clang_getCursorReferenced ( SegmentAllocator allocator,  MemorySegment x1) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$14.clang_getCursorReferenced$MH, "clang_getCursorReferenced");
+        var mh$ = clang_getCursorReferenced$MH();
         try {
             return (java.lang.foreign.MemorySegment)mh$.invokeExact(allocator, x1);
         } catch (Throwable ex$) {
@@ -2487,7 +2487,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$15.clang_getCursorDefinition$MH,"clang_getCursorDefinition");
     }
     public static MemorySegment clang_getCursorDefinition ( SegmentAllocator allocator,  MemorySegment x1) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$15.clang_getCursorDefinition$MH, "clang_getCursorDefinition");
+        var mh$ = clang_getCursorDefinition$MH();
         try {
             return (java.lang.foreign.MemorySegment)mh$.invokeExact(allocator, x1);
         } catch (Throwable ex$) {
@@ -2498,7 +2498,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$15.clang_isCursorDefinition$MH,"clang_isCursorDefinition");
     }
     public static int clang_isCursorDefinition ( MemorySegment x0) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$15.clang_isCursorDefinition$MH, "clang_isCursorDefinition");
+        var mh$ = clang_isCursorDefinition$MH();
         try {
             return (int)mh$.invokeExact(x0);
         } catch (Throwable ex$) {
@@ -2509,7 +2509,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$15.clang_Cursor_isVariadic$MH,"clang_Cursor_isVariadic");
     }
     public static int clang_Cursor_isVariadic ( MemorySegment C) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$15.clang_Cursor_isVariadic$MH, "clang_Cursor_isVariadic");
+        var mh$ = clang_Cursor_isVariadic$MH();
         try {
             return (int)mh$.invokeExact(C);
         } catch (Throwable ex$) {
@@ -2520,7 +2520,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$15.clang_Cursor_getMangling$MH,"clang_Cursor_getMangling");
     }
     public static MemorySegment clang_Cursor_getMangling ( SegmentAllocator allocator,  MemorySegment x1) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$15.clang_Cursor_getMangling$MH, "clang_Cursor_getMangling");
+        var mh$ = clang_Cursor_getMangling$MH();
         try {
             return (java.lang.foreign.MemorySegment)mh$.invokeExact(allocator, x1);
         } catch (Throwable ex$) {
@@ -2546,7 +2546,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$15.clang_getTokenKind$MH,"clang_getTokenKind");
     }
     public static int clang_getTokenKind ( MemorySegment x0) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$15.clang_getTokenKind$MH, "clang_getTokenKind");
+        var mh$ = clang_getTokenKind$MH();
         try {
             return (int)mh$.invokeExact(x0);
         } catch (Throwable ex$) {
@@ -2557,7 +2557,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$15.clang_getTokenSpelling$MH,"clang_getTokenSpelling");
     }
     public static MemorySegment clang_getTokenSpelling ( SegmentAllocator allocator,  Addressable x1,  MemorySegment x2) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$15.clang_getTokenSpelling$MH, "clang_getTokenSpelling");
+        var mh$ = clang_getTokenSpelling$MH();
         try {
             return (java.lang.foreign.MemorySegment)mh$.invokeExact(allocator, x1, x2);
         } catch (Throwable ex$) {
@@ -2568,7 +2568,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$16.clang_getTokenLocation$MH,"clang_getTokenLocation");
     }
     public static MemorySegment clang_getTokenLocation ( SegmentAllocator allocator,  Addressable x1,  MemorySegment x2) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$16.clang_getTokenLocation$MH, "clang_getTokenLocation");
+        var mh$ = clang_getTokenLocation$MH();
         try {
             return (java.lang.foreign.MemorySegment)mh$.invokeExact(allocator, x1, x2);
         } catch (Throwable ex$) {
@@ -2579,7 +2579,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$16.clang_getTokenExtent$MH,"clang_getTokenExtent");
     }
     public static MemorySegment clang_getTokenExtent ( SegmentAllocator allocator,  Addressable x1,  MemorySegment x2) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$16.clang_getTokenExtent$MH, "clang_getTokenExtent");
+        var mh$ = clang_getTokenExtent$MH();
         try {
             return (java.lang.foreign.MemorySegment)mh$.invokeExact(allocator, x1, x2);
         } catch (Throwable ex$) {
@@ -2590,7 +2590,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$16.clang_tokenize$MH,"clang_tokenize");
     }
     public static void clang_tokenize ( Addressable TU,  MemorySegment Range,  Addressable Tokens,  Addressable NumTokens) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$16.clang_tokenize$MH, "clang_tokenize");
+        var mh$ = clang_tokenize$MH();
         try {
             mh$.invokeExact(TU, Range, Tokens, NumTokens);
         } catch (Throwable ex$) {
@@ -2601,7 +2601,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$16.clang_disposeTokens$MH,"clang_disposeTokens");
     }
     public static void clang_disposeTokens ( Addressable TU,  Addressable Tokens,  int NumTokens) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$16.clang_disposeTokens$MH, "clang_disposeTokens");
+        var mh$ = clang_disposeTokens$MH();
         try {
             mh$.invokeExact(TU, Tokens, NumTokens);
         } catch (Throwable ex$) {
@@ -2612,7 +2612,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$16.clang_getCursorKindSpelling$MH,"clang_getCursorKindSpelling");
     }
     public static MemorySegment clang_getCursorKindSpelling ( SegmentAllocator allocator,  int Kind) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$16.clang_getCursorKindSpelling$MH, "clang_getCursorKindSpelling");
+        var mh$ = clang_getCursorKindSpelling$MH();
         try {
             return (java.lang.foreign.MemorySegment)mh$.invokeExact(allocator, Kind);
         } catch (Throwable ex$) {
@@ -2623,7 +2623,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$16.clang_getClangVersion$MH,"clang_getClangVersion");
     }
     public static MemorySegment clang_getClangVersion ( SegmentAllocator allocator) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$16.clang_getClangVersion$MH, "clang_getClangVersion");
+        var mh$ = clang_getClangVersion$MH();
         try {
             return (java.lang.foreign.MemorySegment)mh$.invokeExact(allocator);
         } catch (Throwable ex$) {
@@ -2634,7 +2634,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$17.clang_toggleCrashRecovery$MH,"clang_toggleCrashRecovery");
     }
     public static void clang_toggleCrashRecovery ( int isEnabled) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$17.clang_toggleCrashRecovery$MH, "clang_toggleCrashRecovery");
+        var mh$ = clang_toggleCrashRecovery$MH();
         try {
             mh$.invokeExact(isEnabled);
         } catch (Throwable ex$) {
@@ -2645,7 +2645,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$17.clang_Cursor_Evaluate$MH,"clang_Cursor_Evaluate");
     }
     public static MemoryAddress clang_Cursor_Evaluate ( MemorySegment C) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$17.clang_Cursor_Evaluate$MH, "clang_Cursor_Evaluate");
+        var mh$ = clang_Cursor_Evaluate$MH();
         try {
             return (java.lang.foreign.MemoryAddress)mh$.invokeExact(C);
         } catch (Throwable ex$) {
@@ -2656,7 +2656,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$17.clang_EvalResult_getKind$MH,"clang_EvalResult_getKind");
     }
     public static int clang_EvalResult_getKind ( Addressable E) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$17.clang_EvalResult_getKind$MH, "clang_EvalResult_getKind");
+        var mh$ = clang_EvalResult_getKind$MH();
         try {
             return (int)mh$.invokeExact(E);
         } catch (Throwable ex$) {
@@ -2667,7 +2667,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$17.clang_EvalResult_getAsInt$MH,"clang_EvalResult_getAsInt");
     }
     public static int clang_EvalResult_getAsInt ( Addressable E) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$17.clang_EvalResult_getAsInt$MH, "clang_EvalResult_getAsInt");
+        var mh$ = clang_EvalResult_getAsInt$MH();
         try {
             return (int)mh$.invokeExact(E);
         } catch (Throwable ex$) {
@@ -2678,7 +2678,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$17.clang_EvalResult_getAsLongLong$MH,"clang_EvalResult_getAsLongLong");
     }
     public static long clang_EvalResult_getAsLongLong ( Addressable E) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$17.clang_EvalResult_getAsLongLong$MH, "clang_EvalResult_getAsLongLong");
+        var mh$ = clang_EvalResult_getAsLongLong$MH();
         try {
             return (long)mh$.invokeExact(E);
         } catch (Throwable ex$) {
@@ -2689,7 +2689,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$17.clang_EvalResult_isUnsignedInt$MH,"clang_EvalResult_isUnsignedInt");
     }
     public static int clang_EvalResult_isUnsignedInt ( Addressable E) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$17.clang_EvalResult_isUnsignedInt$MH, "clang_EvalResult_isUnsignedInt");
+        var mh$ = clang_EvalResult_isUnsignedInt$MH();
         try {
             return (int)mh$.invokeExact(E);
         } catch (Throwable ex$) {
@@ -2700,7 +2700,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$18.clang_EvalResult_getAsUnsigned$MH,"clang_EvalResult_getAsUnsigned");
     }
     public static long clang_EvalResult_getAsUnsigned ( Addressable E) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$18.clang_EvalResult_getAsUnsigned$MH, "clang_EvalResult_getAsUnsigned");
+        var mh$ = clang_EvalResult_getAsUnsigned$MH();
         try {
             return (long)mh$.invokeExact(E);
         } catch (Throwable ex$) {
@@ -2711,7 +2711,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$18.clang_EvalResult_getAsDouble$MH,"clang_EvalResult_getAsDouble");
     }
     public static double clang_EvalResult_getAsDouble ( Addressable E) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$18.clang_EvalResult_getAsDouble$MH, "clang_EvalResult_getAsDouble");
+        var mh$ = clang_EvalResult_getAsDouble$MH();
         try {
             return (double)mh$.invokeExact(E);
         } catch (Throwable ex$) {
@@ -2722,7 +2722,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$18.clang_EvalResult_getAsStr$MH,"clang_EvalResult_getAsStr");
     }
     public static MemoryAddress clang_EvalResult_getAsStr ( Addressable E) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$18.clang_EvalResult_getAsStr$MH, "clang_EvalResult_getAsStr");
+        var mh$ = clang_EvalResult_getAsStr$MH();
         try {
             return (java.lang.foreign.MemoryAddress)mh$.invokeExact(E);
         } catch (Throwable ex$) {
@@ -2733,7 +2733,7 @@ public class Index_h  {
         return RuntimeHelper.requireNonNull(constants$18.clang_EvalResult_dispose$MH,"clang_EvalResult_dispose");
     }
     public static void clang_EvalResult_dispose ( Addressable E) {
-        var mh$ = RuntimeHelper.requireNonNull(constants$18.clang_EvalResult_dispose$MH, "clang_EvalResult_dispose");
+        var mh$ = clang_EvalResult_dispose$MH();
         try {
             mh$.invokeExact(E);
         } catch (Throwable ex$) {

--- a/src/main/java/org/openjdk/jextract/clang/libclang/RuntimeHelper.java
+++ b/src/main/java/org/openjdk/jextract/clang/libclang/RuntimeHelper.java
@@ -62,7 +62,10 @@ final class RuntimeHelper {
             (size, align) -> MemorySegment.allocateNative(size, align, MemorySession.openImplicit());
 
     static {
-        System.loadLibrary("clang");
+        // Manual change to handle platform specific library name difference
+        String libName = System.getProperty("os.name").startsWith("Windows")? "libclang" : "clang";
+        System.loadLibrary(libName);
+
         SymbolLookup loaderLookup = SymbolLookup.loaderLookup();
         SYMBOL_LOOKUP = name -> loaderLookup.lookup(name).or(() -> LINKER.defaultLookup().lookup(name));
     }

--- a/src/main/java/org/openjdk/jextract/clang/libclang/constants$0.java
+++ b/src/main/java/org/openjdk/jextract/clang/libclang/constants$0.java
@@ -43,7 +43,7 @@ class constants$0 {
     );
     static final MethodHandle clang_getCString$MH = RuntimeHelper.downcallHandle(
         "clang_getCString",
-        constants$0.clang_getCString$FUNC, false
+        constants$0.clang_getCString$FUNC
     );
     static final FunctionDescriptor clang_disposeString$FUNC = FunctionDescriptor.ofVoid(
         MemoryLayout.structLayout(
@@ -54,7 +54,7 @@ class constants$0 {
     );
     static final MethodHandle clang_disposeString$MH = RuntimeHelper.downcallHandle(
         "clang_disposeString",
-        constants$0.clang_disposeString$FUNC, false
+        constants$0.clang_disposeString$FUNC
     );
     static final FunctionDescriptor clang_createIndex$FUNC = FunctionDescriptor.of(Constants$root.C_POINTER$LAYOUT,
         Constants$root.C_INT$LAYOUT,
@@ -62,14 +62,14 @@ class constants$0 {
     );
     static final MethodHandle clang_createIndex$MH = RuntimeHelper.downcallHandle(
         "clang_createIndex",
-        constants$0.clang_createIndex$FUNC, false
+        constants$0.clang_createIndex$FUNC
     );
     static final FunctionDescriptor clang_disposeIndex$FUNC = FunctionDescriptor.ofVoid(
         Constants$root.C_POINTER$LAYOUT
     );
     static final MethodHandle clang_disposeIndex$MH = RuntimeHelper.downcallHandle(
         "clang_disposeIndex",
-        constants$0.clang_disposeIndex$FUNC, false
+        constants$0.clang_disposeIndex$FUNC
     );
     static final FunctionDescriptor clang_getFileName$FUNC = FunctionDescriptor.of(MemoryLayout.structLayout(
         Constants$root.C_POINTER$LAYOUT.withName("data"),
@@ -80,7 +80,7 @@ class constants$0 {
     );
     static final MethodHandle clang_getFileName$MH = RuntimeHelper.downcallHandle(
         "clang_getFileName",
-        constants$0.clang_getFileName$FUNC, false
+        constants$0.clang_getFileName$FUNC
     );
     static final FunctionDescriptor clang_getNullLocation$FUNC = FunctionDescriptor.of(MemoryLayout.structLayout(
         MemoryLayout.sequenceLayout(2, Constants$root.C_POINTER$LAYOUT).withName("ptr_data"),
@@ -89,7 +89,7 @@ class constants$0 {
     ));
     static final MethodHandle clang_getNullLocation$MH = RuntimeHelper.downcallHandle(
         "clang_getNullLocation",
-        constants$0.clang_getNullLocation$FUNC, false
+        constants$0.clang_getNullLocation$FUNC
     );
 }
 

--- a/src/main/java/org/openjdk/jextract/clang/libclang/constants$1.java
+++ b/src/main/java/org/openjdk/jextract/clang/libclang/constants$1.java
@@ -48,7 +48,7 @@ class constants$1 {
     );
     static final MethodHandle clang_equalLocations$MH = RuntimeHelper.downcallHandle(
         "clang_equalLocations",
-        constants$1.clang_equalLocations$FUNC, false
+        constants$1.clang_equalLocations$FUNC
     );
     static final FunctionDescriptor clang_getLocation$FUNC = FunctionDescriptor.of(MemoryLayout.structLayout(
         MemoryLayout.sequenceLayout(2, Constants$root.C_POINTER$LAYOUT).withName("ptr_data"),
@@ -62,7 +62,7 @@ class constants$1 {
     );
     static final MethodHandle clang_getLocation$MH = RuntimeHelper.downcallHandle(
         "clang_getLocation",
-        constants$1.clang_getLocation$FUNC, false
+        constants$1.clang_getLocation$FUNC
     );
     static final FunctionDescriptor clang_getLocationForOffset$FUNC = FunctionDescriptor.of(MemoryLayout.structLayout(
         MemoryLayout.sequenceLayout(2, Constants$root.C_POINTER$LAYOUT).withName("ptr_data"),
@@ -75,7 +75,7 @@ class constants$1 {
     );
     static final MethodHandle clang_getLocationForOffset$MH = RuntimeHelper.downcallHandle(
         "clang_getLocationForOffset",
-        constants$1.clang_getLocationForOffset$FUNC, false
+        constants$1.clang_getLocationForOffset$FUNC
     );
     static final FunctionDescriptor clang_Location_isInSystemHeader$FUNC = FunctionDescriptor.of(Constants$root.C_INT$LAYOUT,
         MemoryLayout.structLayout(
@@ -86,7 +86,7 @@ class constants$1 {
     );
     static final MethodHandle clang_Location_isInSystemHeader$MH = RuntimeHelper.downcallHandle(
         "clang_Location_isInSystemHeader",
-        constants$1.clang_Location_isInSystemHeader$FUNC, false
+        constants$1.clang_Location_isInSystemHeader$FUNC
     );
     static final FunctionDescriptor clang_Location_isFromMainFile$FUNC = FunctionDescriptor.of(Constants$root.C_INT$LAYOUT,
         MemoryLayout.structLayout(
@@ -97,7 +97,7 @@ class constants$1 {
     );
     static final MethodHandle clang_Location_isFromMainFile$MH = RuntimeHelper.downcallHandle(
         "clang_Location_isFromMainFile",
-        constants$1.clang_Location_isFromMainFile$FUNC, false
+        constants$1.clang_Location_isFromMainFile$FUNC
     );
     static final FunctionDescriptor clang_Range_isNull$FUNC = FunctionDescriptor.of(Constants$root.C_INT$LAYOUT,
         MemoryLayout.structLayout(
@@ -108,7 +108,7 @@ class constants$1 {
     );
     static final MethodHandle clang_Range_isNull$MH = RuntimeHelper.downcallHandle(
         "clang_Range_isNull",
-        constants$1.clang_Range_isNull$FUNC, false
+        constants$1.clang_Range_isNull$FUNC
     );
 }
 

--- a/src/main/java/org/openjdk/jextract/clang/libclang/constants$10.java
+++ b/src/main/java/org/openjdk/jextract/clang/libclang/constants$10.java
@@ -47,7 +47,7 @@ class constants$10 {
     );
     static final MethodHandle clang_getPointeeType$MH = RuntimeHelper.downcallHandle(
         "clang_getPointeeType",
-        constants$10.clang_getPointeeType$FUNC, false
+        constants$10.clang_getPointeeType$FUNC
     );
     static final FunctionDescriptor clang_getTypeDeclaration$FUNC = FunctionDescriptor.of(MemoryLayout.structLayout(
         Constants$root.C_INT$LAYOUT.withName("kind"),
@@ -62,7 +62,7 @@ class constants$10 {
     );
     static final MethodHandle clang_getTypeDeclaration$MH = RuntimeHelper.downcallHandle(
         "clang_getTypeDeclaration",
-        constants$10.clang_getTypeDeclaration$FUNC, false
+        constants$10.clang_getTypeDeclaration$FUNC
     );
     static final FunctionDescriptor clang_getTypeKindSpelling$FUNC = FunctionDescriptor.of(MemoryLayout.structLayout(
         Constants$root.C_POINTER$LAYOUT.withName("data"),
@@ -73,7 +73,7 @@ class constants$10 {
     );
     static final MethodHandle clang_getTypeKindSpelling$MH = RuntimeHelper.downcallHandle(
         "clang_getTypeKindSpelling",
-        constants$10.clang_getTypeKindSpelling$FUNC, false
+        constants$10.clang_getTypeKindSpelling$FUNC
     );
     static final FunctionDescriptor clang_getFunctionTypeCallingConv$FUNC = FunctionDescriptor.of(Constants$root.C_INT$LAYOUT,
         MemoryLayout.structLayout(
@@ -84,7 +84,7 @@ class constants$10 {
     );
     static final MethodHandle clang_getFunctionTypeCallingConv$MH = RuntimeHelper.downcallHandle(
         "clang_getFunctionTypeCallingConv",
-        constants$10.clang_getFunctionTypeCallingConv$FUNC, false
+        constants$10.clang_getFunctionTypeCallingConv$FUNC
     );
     static final FunctionDescriptor clang_getResultType$FUNC = FunctionDescriptor.of(MemoryLayout.structLayout(
         Constants$root.C_INT$LAYOUT.withName("kind"),
@@ -99,7 +99,7 @@ class constants$10 {
     );
     static final MethodHandle clang_getResultType$MH = RuntimeHelper.downcallHandle(
         "clang_getResultType",
-        constants$10.clang_getResultType$FUNC, false
+        constants$10.clang_getResultType$FUNC
     );
     static final FunctionDescriptor clang_getNumArgTypes$FUNC = FunctionDescriptor.of(Constants$root.C_INT$LAYOUT,
         MemoryLayout.structLayout(
@@ -110,7 +110,7 @@ class constants$10 {
     );
     static final MethodHandle clang_getNumArgTypes$MH = RuntimeHelper.downcallHandle(
         "clang_getNumArgTypes",
-        constants$10.clang_getNumArgTypes$FUNC, false
+        constants$10.clang_getNumArgTypes$FUNC
     );
 }
 

--- a/src/main/java/org/openjdk/jextract/clang/libclang/constants$11.java
+++ b/src/main/java/org/openjdk/jextract/clang/libclang/constants$11.java
@@ -48,7 +48,7 @@ class constants$11 {
     );
     static final MethodHandle clang_getArgType$MH = RuntimeHelper.downcallHandle(
         "clang_getArgType",
-        constants$11.clang_getArgType$FUNC, false
+        constants$11.clang_getArgType$FUNC
     );
     static final FunctionDescriptor clang_isFunctionTypeVariadic$FUNC = FunctionDescriptor.of(Constants$root.C_INT$LAYOUT,
         MemoryLayout.structLayout(
@@ -59,7 +59,7 @@ class constants$11 {
     );
     static final MethodHandle clang_isFunctionTypeVariadic$MH = RuntimeHelper.downcallHandle(
         "clang_isFunctionTypeVariadic",
-        constants$11.clang_isFunctionTypeVariadic$FUNC, false
+        constants$11.clang_isFunctionTypeVariadic$FUNC
     );
     static final FunctionDescriptor clang_getCursorResultType$FUNC = FunctionDescriptor.of(MemoryLayout.structLayout(
         Constants$root.C_INT$LAYOUT.withName("kind"),
@@ -74,7 +74,7 @@ class constants$11 {
     );
     static final MethodHandle clang_getCursorResultType$MH = RuntimeHelper.downcallHandle(
         "clang_getCursorResultType",
-        constants$11.clang_getCursorResultType$FUNC, false
+        constants$11.clang_getCursorResultType$FUNC
     );
     static final FunctionDescriptor clang_getElementType$FUNC = FunctionDescriptor.of(MemoryLayout.structLayout(
         Constants$root.C_INT$LAYOUT.withName("kind"),
@@ -89,7 +89,7 @@ class constants$11 {
     );
     static final MethodHandle clang_getElementType$MH = RuntimeHelper.downcallHandle(
         "clang_getElementType",
-        constants$11.clang_getElementType$FUNC, false
+        constants$11.clang_getElementType$FUNC
     );
     static final FunctionDescriptor clang_getNumElements$FUNC = FunctionDescriptor.of(Constants$root.C_LONG_LONG$LAYOUT,
         MemoryLayout.structLayout(
@@ -100,7 +100,7 @@ class constants$11 {
     );
     static final MethodHandle clang_getNumElements$MH = RuntimeHelper.downcallHandle(
         "clang_getNumElements",
-        constants$11.clang_getNumElements$FUNC, false
+        constants$11.clang_getNumElements$FUNC
     );
     static final FunctionDescriptor clang_getArrayElementType$FUNC = FunctionDescriptor.of(MemoryLayout.structLayout(
         Constants$root.C_INT$LAYOUT.withName("kind"),
@@ -115,7 +115,7 @@ class constants$11 {
     );
     static final MethodHandle clang_getArrayElementType$MH = RuntimeHelper.downcallHandle(
         "clang_getArrayElementType",
-        constants$11.clang_getArrayElementType$FUNC, false
+        constants$11.clang_getArrayElementType$FUNC
     );
 }
 

--- a/src/main/java/org/openjdk/jextract/clang/libclang/constants$12.java
+++ b/src/main/java/org/openjdk/jextract/clang/libclang/constants$12.java
@@ -43,7 +43,7 @@ class constants$12 {
     );
     static final MethodHandle clang_getArraySize$MH = RuntimeHelper.downcallHandle(
         "clang_getArraySize",
-        constants$12.clang_getArraySize$FUNC, false
+        constants$12.clang_getArraySize$FUNC
     );
     static final FunctionDescriptor clang_Type_getSizeOf$FUNC = FunctionDescriptor.of(Constants$root.C_LONG_LONG$LAYOUT,
         MemoryLayout.structLayout(
@@ -54,7 +54,7 @@ class constants$12 {
     );
     static final MethodHandle clang_Type_getSizeOf$MH = RuntimeHelper.downcallHandle(
         "clang_Type_getSizeOf",
-        constants$12.clang_Type_getSizeOf$FUNC, false
+        constants$12.clang_Type_getSizeOf$FUNC
     );
     static final FunctionDescriptor clang_Type_getOffsetOf$FUNC = FunctionDescriptor.of(Constants$root.C_LONG_LONG$LAYOUT,
         MemoryLayout.structLayout(
@@ -66,7 +66,7 @@ class constants$12 {
     );
     static final MethodHandle clang_Type_getOffsetOf$MH = RuntimeHelper.downcallHandle(
         "clang_Type_getOffsetOf",
-        constants$12.clang_Type_getOffsetOf$FUNC, false
+        constants$12.clang_Type_getOffsetOf$FUNC
     );
     static final FunctionDescriptor clang_Cursor_isAnonymous$FUNC = FunctionDescriptor.of(Constants$root.C_INT$LAYOUT,
         MemoryLayout.structLayout(
@@ -77,7 +77,7 @@ class constants$12 {
     );
     static final MethodHandle clang_Cursor_isAnonymous$MH = RuntimeHelper.downcallHandle(
         "clang_Cursor_isAnonymous",
-        constants$12.clang_Cursor_isAnonymous$FUNC, false
+        constants$12.clang_Cursor_isAnonymous$FUNC
     );
     static final FunctionDescriptor clang_Cursor_isAnonymousRecordDecl$FUNC = FunctionDescriptor.of(Constants$root.C_INT$LAYOUT,
         MemoryLayout.structLayout(
@@ -88,7 +88,7 @@ class constants$12 {
     );
     static final MethodHandle clang_Cursor_isAnonymousRecordDecl$MH = RuntimeHelper.downcallHandle(
         "clang_Cursor_isAnonymousRecordDecl",
-        constants$12.clang_Cursor_isAnonymousRecordDecl$FUNC, false
+        constants$12.clang_Cursor_isAnonymousRecordDecl$FUNC
     );
     static final FunctionDescriptor clang_Cursor_isBitField$FUNC = FunctionDescriptor.of(Constants$root.C_INT$LAYOUT,
         MemoryLayout.structLayout(
@@ -99,7 +99,7 @@ class constants$12 {
     );
     static final MethodHandle clang_Cursor_isBitField$MH = RuntimeHelper.downcallHandle(
         "clang_Cursor_isBitField",
-        constants$12.clang_Cursor_isBitField$FUNC, false
+        constants$12.clang_Cursor_isBitField$FUNC
     );
 }
 

--- a/src/main/java/org/openjdk/jextract/clang/libclang/constants$13.java
+++ b/src/main/java/org/openjdk/jextract/clang/libclang/constants$13.java
@@ -48,7 +48,7 @@ class constants$13 {
         Constants$root.C_POINTER$LAYOUT
     );
     static final MethodHandle CXCursorVisitor$MH = RuntimeHelper.downcallHandle(
-        constants$13.CXCursorVisitor$FUNC, false
+        constants$13.CXCursorVisitor$FUNC
     );
     static final FunctionDescriptor clang_visitChildren$FUNC = FunctionDescriptor.of(Constants$root.C_INT$LAYOUT,
         MemoryLayout.structLayout(
@@ -61,7 +61,7 @@ class constants$13 {
     );
     static final MethodHandle clang_visitChildren$MH = RuntimeHelper.downcallHandle(
         "clang_visitChildren",
-        constants$13.clang_visitChildren$FUNC, false
+        constants$13.clang_visitChildren$FUNC
     );
     static final FunctionDescriptor clang_getCursorUSR$FUNC = FunctionDescriptor.of(MemoryLayout.structLayout(
         Constants$root.C_POINTER$LAYOUT.withName("data"),
@@ -76,7 +76,7 @@ class constants$13 {
     );
     static final MethodHandle clang_getCursorUSR$MH = RuntimeHelper.downcallHandle(
         "clang_getCursorUSR",
-        constants$13.clang_getCursorUSR$FUNC, false
+        constants$13.clang_getCursorUSR$FUNC
     );
     static final FunctionDescriptor clang_getCursorSpelling$FUNC = FunctionDescriptor.of(MemoryLayout.structLayout(
         Constants$root.C_POINTER$LAYOUT.withName("data"),
@@ -91,7 +91,7 @@ class constants$13 {
     );
     static final MethodHandle clang_getCursorSpelling$MH = RuntimeHelper.downcallHandle(
         "clang_getCursorSpelling",
-        constants$13.clang_getCursorSpelling$FUNC, false
+        constants$13.clang_getCursorSpelling$FUNC
     );
     static final FunctionDescriptor clang_PrintingPolicy_getProperty$FUNC = FunctionDescriptor.of(Constants$root.C_INT$LAYOUT,
         Constants$root.C_POINTER$LAYOUT,
@@ -99,7 +99,7 @@ class constants$13 {
     );
     static final MethodHandle clang_PrintingPolicy_getProperty$MH = RuntimeHelper.downcallHandle(
         "clang_PrintingPolicy_getProperty",
-        constants$13.clang_PrintingPolicy_getProperty$FUNC, false
+        constants$13.clang_PrintingPolicy_getProperty$FUNC
     );
 }
 

--- a/src/main/java/org/openjdk/jextract/clang/libclang/constants$14.java
+++ b/src/main/java/org/openjdk/jextract/clang/libclang/constants$14.java
@@ -41,7 +41,7 @@ class constants$14 {
     );
     static final MethodHandle clang_PrintingPolicy_setProperty$MH = RuntimeHelper.downcallHandle(
         "clang_PrintingPolicy_setProperty",
-        constants$14.clang_PrintingPolicy_setProperty$FUNC, false
+        constants$14.clang_PrintingPolicy_setProperty$FUNC
     );
     static final FunctionDescriptor clang_getCursorPrintingPolicy$FUNC = FunctionDescriptor.of(Constants$root.C_POINTER$LAYOUT,
         MemoryLayout.structLayout(
@@ -52,14 +52,14 @@ class constants$14 {
     );
     static final MethodHandle clang_getCursorPrintingPolicy$MH = RuntimeHelper.downcallHandle(
         "clang_getCursorPrintingPolicy",
-        constants$14.clang_getCursorPrintingPolicy$FUNC, false
+        constants$14.clang_getCursorPrintingPolicy$FUNC
     );
     static final FunctionDescriptor clang_PrintingPolicy_dispose$FUNC = FunctionDescriptor.ofVoid(
         Constants$root.C_POINTER$LAYOUT
     );
     static final MethodHandle clang_PrintingPolicy_dispose$MH = RuntimeHelper.downcallHandle(
         "clang_PrintingPolicy_dispose",
-        constants$14.clang_PrintingPolicy_dispose$FUNC, false
+        constants$14.clang_PrintingPolicy_dispose$FUNC
     );
     static final FunctionDescriptor clang_getCursorPrettyPrinted$FUNC = FunctionDescriptor.of(MemoryLayout.structLayout(
         Constants$root.C_POINTER$LAYOUT.withName("data"),
@@ -75,7 +75,7 @@ class constants$14 {
     );
     static final MethodHandle clang_getCursorPrettyPrinted$MH = RuntimeHelper.downcallHandle(
         "clang_getCursorPrettyPrinted",
-        constants$14.clang_getCursorPrettyPrinted$FUNC, false
+        constants$14.clang_getCursorPrettyPrinted$FUNC
     );
     static final FunctionDescriptor clang_getCursorDisplayName$FUNC = FunctionDescriptor.of(MemoryLayout.structLayout(
         Constants$root.C_POINTER$LAYOUT.withName("data"),
@@ -90,7 +90,7 @@ class constants$14 {
     );
     static final MethodHandle clang_getCursorDisplayName$MH = RuntimeHelper.downcallHandle(
         "clang_getCursorDisplayName",
-        constants$14.clang_getCursorDisplayName$FUNC, false
+        constants$14.clang_getCursorDisplayName$FUNC
     );
     static final FunctionDescriptor clang_getCursorReferenced$FUNC = FunctionDescriptor.of(MemoryLayout.structLayout(
         Constants$root.C_INT$LAYOUT.withName("kind"),
@@ -105,7 +105,7 @@ class constants$14 {
     );
     static final MethodHandle clang_getCursorReferenced$MH = RuntimeHelper.downcallHandle(
         "clang_getCursorReferenced",
-        constants$14.clang_getCursorReferenced$FUNC, false
+        constants$14.clang_getCursorReferenced$FUNC
     );
 }
 

--- a/src/main/java/org/openjdk/jextract/clang/libclang/constants$15.java
+++ b/src/main/java/org/openjdk/jextract/clang/libclang/constants$15.java
@@ -47,7 +47,7 @@ class constants$15 {
     );
     static final MethodHandle clang_getCursorDefinition$MH = RuntimeHelper.downcallHandle(
         "clang_getCursorDefinition",
-        constants$15.clang_getCursorDefinition$FUNC, false
+        constants$15.clang_getCursorDefinition$FUNC
     );
     static final FunctionDescriptor clang_isCursorDefinition$FUNC = FunctionDescriptor.of(Constants$root.C_INT$LAYOUT,
         MemoryLayout.structLayout(
@@ -58,7 +58,7 @@ class constants$15 {
     );
     static final MethodHandle clang_isCursorDefinition$MH = RuntimeHelper.downcallHandle(
         "clang_isCursorDefinition",
-        constants$15.clang_isCursorDefinition$FUNC, false
+        constants$15.clang_isCursorDefinition$FUNC
     );
     static final FunctionDescriptor clang_Cursor_isVariadic$FUNC = FunctionDescriptor.of(Constants$root.C_INT$LAYOUT,
         MemoryLayout.structLayout(
@@ -69,7 +69,7 @@ class constants$15 {
     );
     static final MethodHandle clang_Cursor_isVariadic$MH = RuntimeHelper.downcallHandle(
         "clang_Cursor_isVariadic",
-        constants$15.clang_Cursor_isVariadic$FUNC, false
+        constants$15.clang_Cursor_isVariadic$FUNC
     );
     static final FunctionDescriptor clang_Cursor_getMangling$FUNC = FunctionDescriptor.of(MemoryLayout.structLayout(
         Constants$root.C_POINTER$LAYOUT.withName("data"),
@@ -84,7 +84,7 @@ class constants$15 {
     );
     static final MethodHandle clang_Cursor_getMangling$MH = RuntimeHelper.downcallHandle(
         "clang_Cursor_getMangling",
-        constants$15.clang_Cursor_getMangling$FUNC, false
+        constants$15.clang_Cursor_getMangling$FUNC
     );
     static final FunctionDescriptor clang_getTokenKind$FUNC = FunctionDescriptor.of(Constants$root.C_INT$LAYOUT,
         MemoryLayout.structLayout(
@@ -94,7 +94,7 @@ class constants$15 {
     );
     static final MethodHandle clang_getTokenKind$MH = RuntimeHelper.downcallHandle(
         "clang_getTokenKind",
-        constants$15.clang_getTokenKind$FUNC, false
+        constants$15.clang_getTokenKind$FUNC
     );
     static final FunctionDescriptor clang_getTokenSpelling$FUNC = FunctionDescriptor.of(MemoryLayout.structLayout(
         Constants$root.C_POINTER$LAYOUT.withName("data"),
@@ -109,7 +109,7 @@ class constants$15 {
     );
     static final MethodHandle clang_getTokenSpelling$MH = RuntimeHelper.downcallHandle(
         "clang_getTokenSpelling",
-        constants$15.clang_getTokenSpelling$FUNC, false
+        constants$15.clang_getTokenSpelling$FUNC
     );
 }
 

--- a/src/main/java/org/openjdk/jextract/clang/libclang/constants$16.java
+++ b/src/main/java/org/openjdk/jextract/clang/libclang/constants$16.java
@@ -47,7 +47,7 @@ class constants$16 {
     );
     static final MethodHandle clang_getTokenLocation$MH = RuntimeHelper.downcallHandle(
         "clang_getTokenLocation",
-        constants$16.clang_getTokenLocation$FUNC, false
+        constants$16.clang_getTokenLocation$FUNC
     );
     static final FunctionDescriptor clang_getTokenExtent$FUNC = FunctionDescriptor.of(MemoryLayout.structLayout(
         MemoryLayout.sequenceLayout(2, Constants$root.C_POINTER$LAYOUT).withName("ptr_data"),
@@ -62,7 +62,7 @@ class constants$16 {
     );
     static final MethodHandle clang_getTokenExtent$MH = RuntimeHelper.downcallHandle(
         "clang_getTokenExtent",
-        constants$16.clang_getTokenExtent$FUNC, false
+        constants$16.clang_getTokenExtent$FUNC
     );
     static final FunctionDescriptor clang_tokenize$FUNC = FunctionDescriptor.ofVoid(
         Constants$root.C_POINTER$LAYOUT,
@@ -76,7 +76,7 @@ class constants$16 {
     );
     static final MethodHandle clang_tokenize$MH = RuntimeHelper.downcallHandle(
         "clang_tokenize",
-        constants$16.clang_tokenize$FUNC, false
+        constants$16.clang_tokenize$FUNC
     );
     static final FunctionDescriptor clang_disposeTokens$FUNC = FunctionDescriptor.ofVoid(
         Constants$root.C_POINTER$LAYOUT,
@@ -85,7 +85,7 @@ class constants$16 {
     );
     static final MethodHandle clang_disposeTokens$MH = RuntimeHelper.downcallHandle(
         "clang_disposeTokens",
-        constants$16.clang_disposeTokens$FUNC, false
+        constants$16.clang_disposeTokens$FUNC
     );
     static final FunctionDescriptor clang_getCursorKindSpelling$FUNC = FunctionDescriptor.of(MemoryLayout.structLayout(
         Constants$root.C_POINTER$LAYOUT.withName("data"),
@@ -96,7 +96,7 @@ class constants$16 {
     );
     static final MethodHandle clang_getCursorKindSpelling$MH = RuntimeHelper.downcallHandle(
         "clang_getCursorKindSpelling",
-        constants$16.clang_getCursorKindSpelling$FUNC, false
+        constants$16.clang_getCursorKindSpelling$FUNC
     );
     static final FunctionDescriptor clang_getClangVersion$FUNC = FunctionDescriptor.of(MemoryLayout.structLayout(
         Constants$root.C_POINTER$LAYOUT.withName("data"),
@@ -105,7 +105,7 @@ class constants$16 {
     ));
     static final MethodHandle clang_getClangVersion$MH = RuntimeHelper.downcallHandle(
         "clang_getClangVersion",
-        constants$16.clang_getClangVersion$FUNC, false
+        constants$16.clang_getClangVersion$FUNC
     );
 }
 

--- a/src/main/java/org/openjdk/jextract/clang/libclang/constants$17.java
+++ b/src/main/java/org/openjdk/jextract/clang/libclang/constants$17.java
@@ -39,7 +39,7 @@ class constants$17 {
     );
     static final MethodHandle clang_toggleCrashRecovery$MH = RuntimeHelper.downcallHandle(
         "clang_toggleCrashRecovery",
-        constants$17.clang_toggleCrashRecovery$FUNC, false
+        constants$17.clang_toggleCrashRecovery$FUNC
     );
     static final FunctionDescriptor clang_Cursor_Evaluate$FUNC = FunctionDescriptor.of(Constants$root.C_POINTER$LAYOUT,
         MemoryLayout.structLayout(
@@ -50,35 +50,35 @@ class constants$17 {
     );
     static final MethodHandle clang_Cursor_Evaluate$MH = RuntimeHelper.downcallHandle(
         "clang_Cursor_Evaluate",
-        constants$17.clang_Cursor_Evaluate$FUNC, false
+        constants$17.clang_Cursor_Evaluate$FUNC
     );
     static final FunctionDescriptor clang_EvalResult_getKind$FUNC = FunctionDescriptor.of(Constants$root.C_INT$LAYOUT,
         Constants$root.C_POINTER$LAYOUT
     );
     static final MethodHandle clang_EvalResult_getKind$MH = RuntimeHelper.downcallHandle(
         "clang_EvalResult_getKind",
-        constants$17.clang_EvalResult_getKind$FUNC, false
+        constants$17.clang_EvalResult_getKind$FUNC
     );
     static final FunctionDescriptor clang_EvalResult_getAsInt$FUNC = FunctionDescriptor.of(Constants$root.C_INT$LAYOUT,
         Constants$root.C_POINTER$LAYOUT
     );
     static final MethodHandle clang_EvalResult_getAsInt$MH = RuntimeHelper.downcallHandle(
         "clang_EvalResult_getAsInt",
-        constants$17.clang_EvalResult_getAsInt$FUNC, false
+        constants$17.clang_EvalResult_getAsInt$FUNC
     );
     static final FunctionDescriptor clang_EvalResult_getAsLongLong$FUNC = FunctionDescriptor.of(Constants$root.C_LONG_LONG$LAYOUT,
         Constants$root.C_POINTER$LAYOUT
     );
     static final MethodHandle clang_EvalResult_getAsLongLong$MH = RuntimeHelper.downcallHandle(
         "clang_EvalResult_getAsLongLong",
-        constants$17.clang_EvalResult_getAsLongLong$FUNC, false
+        constants$17.clang_EvalResult_getAsLongLong$FUNC
     );
     static final FunctionDescriptor clang_EvalResult_isUnsignedInt$FUNC = FunctionDescriptor.of(Constants$root.C_INT$LAYOUT,
         Constants$root.C_POINTER$LAYOUT
     );
     static final MethodHandle clang_EvalResult_isUnsignedInt$MH = RuntimeHelper.downcallHandle(
         "clang_EvalResult_isUnsignedInt",
-        constants$17.clang_EvalResult_isUnsignedInt$FUNC, false
+        constants$17.clang_EvalResult_isUnsignedInt$FUNC
     );
 }
 

--- a/src/main/java/org/openjdk/jextract/clang/libclang/constants$18.java
+++ b/src/main/java/org/openjdk/jextract/clang/libclang/constants$18.java
@@ -39,28 +39,28 @@ class constants$18 {
     );
     static final MethodHandle clang_EvalResult_getAsUnsigned$MH = RuntimeHelper.downcallHandle(
         "clang_EvalResult_getAsUnsigned",
-        constants$18.clang_EvalResult_getAsUnsigned$FUNC, false
+        constants$18.clang_EvalResult_getAsUnsigned$FUNC
     );
     static final FunctionDescriptor clang_EvalResult_getAsDouble$FUNC = FunctionDescriptor.of(Constants$root.C_DOUBLE$LAYOUT,
         Constants$root.C_POINTER$LAYOUT
     );
     static final MethodHandle clang_EvalResult_getAsDouble$MH = RuntimeHelper.downcallHandle(
         "clang_EvalResult_getAsDouble",
-        constants$18.clang_EvalResult_getAsDouble$FUNC, false
+        constants$18.clang_EvalResult_getAsDouble$FUNC
     );
     static final FunctionDescriptor clang_EvalResult_getAsStr$FUNC = FunctionDescriptor.of(Constants$root.C_POINTER$LAYOUT,
         Constants$root.C_POINTER$LAYOUT
     );
     static final MethodHandle clang_EvalResult_getAsStr$MH = RuntimeHelper.downcallHandle(
         "clang_EvalResult_getAsStr",
-        constants$18.clang_EvalResult_getAsStr$FUNC, false
+        constants$18.clang_EvalResult_getAsStr$FUNC
     );
     static final FunctionDescriptor clang_EvalResult_dispose$FUNC = FunctionDescriptor.ofVoid(
         Constants$root.C_POINTER$LAYOUT
     );
     static final MethodHandle clang_EvalResult_dispose$MH = RuntimeHelper.downcallHandle(
         "clang_EvalResult_dispose",
-        constants$18.clang_EvalResult_dispose$FUNC, false
+        constants$18.clang_EvalResult_dispose$FUNC
     );
 }
 

--- a/src/main/java/org/openjdk/jextract/clang/libclang/constants$2.java
+++ b/src/main/java/org/openjdk/jextract/clang/libclang/constants$2.java
@@ -47,7 +47,7 @@ class constants$2 {
     );
     static final MethodHandle clang_getExpansionLocation$MH = RuntimeHelper.downcallHandle(
         "clang_getExpansionLocation",
-        constants$2.clang_getExpansionLocation$FUNC, false
+        constants$2.clang_getExpansionLocation$FUNC
     );
     static final FunctionDescriptor clang_getSpellingLocation$FUNC = FunctionDescriptor.ofVoid(
         MemoryLayout.structLayout(
@@ -62,7 +62,7 @@ class constants$2 {
     );
     static final MethodHandle clang_getSpellingLocation$MH = RuntimeHelper.downcallHandle(
         "clang_getSpellingLocation",
-        constants$2.clang_getSpellingLocation$FUNC, false
+        constants$2.clang_getSpellingLocation$FUNC
     );
     static final FunctionDescriptor clang_getFileLocation$FUNC = FunctionDescriptor.ofVoid(
         MemoryLayout.structLayout(
@@ -77,7 +77,7 @@ class constants$2 {
     );
     static final MethodHandle clang_getFileLocation$MH = RuntimeHelper.downcallHandle(
         "clang_getFileLocation",
-        constants$2.clang_getFileLocation$FUNC, false
+        constants$2.clang_getFileLocation$FUNC
     );
     static final FunctionDescriptor clang_getRangeStart$FUNC = FunctionDescriptor.of(MemoryLayout.structLayout(
         MemoryLayout.sequenceLayout(2, Constants$root.C_POINTER$LAYOUT).withName("ptr_data"),
@@ -92,7 +92,7 @@ class constants$2 {
     );
     static final MethodHandle clang_getRangeStart$MH = RuntimeHelper.downcallHandle(
         "clang_getRangeStart",
-        constants$2.clang_getRangeStart$FUNC, false
+        constants$2.clang_getRangeStart$FUNC
     );
     static final FunctionDescriptor clang_getRangeEnd$FUNC = FunctionDescriptor.of(MemoryLayout.structLayout(
         MemoryLayout.sequenceLayout(2, Constants$root.C_POINTER$LAYOUT).withName("ptr_data"),
@@ -107,14 +107,14 @@ class constants$2 {
     );
     static final MethodHandle clang_getRangeEnd$MH = RuntimeHelper.downcallHandle(
         "clang_getRangeEnd",
-        constants$2.clang_getRangeEnd$FUNC, false
+        constants$2.clang_getRangeEnd$FUNC
     );
     static final FunctionDescriptor clang_getChildDiagnostics$FUNC = FunctionDescriptor.of(Constants$root.C_POINTER$LAYOUT,
         Constants$root.C_POINTER$LAYOUT
     );
     static final MethodHandle clang_getChildDiagnostics$MH = RuntimeHelper.downcallHandle(
         "clang_getChildDiagnostics",
-        constants$2.clang_getChildDiagnostics$FUNC, false
+        constants$2.clang_getChildDiagnostics$FUNC
     );
 }
 

--- a/src/main/java/org/openjdk/jextract/clang/libclang/constants$3.java
+++ b/src/main/java/org/openjdk/jextract/clang/libclang/constants$3.java
@@ -39,7 +39,7 @@ class constants$3 {
     );
     static final MethodHandle clang_getNumDiagnostics$MH = RuntimeHelper.downcallHandle(
         "clang_getNumDiagnostics",
-        constants$3.clang_getNumDiagnostics$FUNC, false
+        constants$3.clang_getNumDiagnostics$FUNC
     );
     static final FunctionDescriptor clang_getDiagnostic$FUNC = FunctionDescriptor.of(Constants$root.C_POINTER$LAYOUT,
         Constants$root.C_POINTER$LAYOUT,
@@ -47,14 +47,14 @@ class constants$3 {
     );
     static final MethodHandle clang_getDiagnostic$MH = RuntimeHelper.downcallHandle(
         "clang_getDiagnostic",
-        constants$3.clang_getDiagnostic$FUNC, false
+        constants$3.clang_getDiagnostic$FUNC
     );
     static final FunctionDescriptor clang_disposeDiagnostic$FUNC = FunctionDescriptor.ofVoid(
         Constants$root.C_POINTER$LAYOUT
     );
     static final MethodHandle clang_disposeDiagnostic$MH = RuntimeHelper.downcallHandle(
         "clang_disposeDiagnostic",
-        constants$3.clang_disposeDiagnostic$FUNC, false
+        constants$3.clang_disposeDiagnostic$FUNC
     );
     static final FunctionDescriptor clang_formatDiagnostic$FUNC = FunctionDescriptor.of(MemoryLayout.structLayout(
         Constants$root.C_POINTER$LAYOUT.withName("data"),
@@ -66,19 +66,19 @@ class constants$3 {
     );
     static final MethodHandle clang_formatDiagnostic$MH = RuntimeHelper.downcallHandle(
         "clang_formatDiagnostic",
-        constants$3.clang_formatDiagnostic$FUNC, false
+        constants$3.clang_formatDiagnostic$FUNC
     );
     static final FunctionDescriptor clang_defaultDiagnosticDisplayOptions$FUNC = FunctionDescriptor.of(Constants$root.C_INT$LAYOUT);
     static final MethodHandle clang_defaultDiagnosticDisplayOptions$MH = RuntimeHelper.downcallHandle(
         "clang_defaultDiagnosticDisplayOptions",
-        constants$3.clang_defaultDiagnosticDisplayOptions$FUNC, false
+        constants$3.clang_defaultDiagnosticDisplayOptions$FUNC
     );
     static final FunctionDescriptor clang_getDiagnosticSeverity$FUNC = FunctionDescriptor.of(Constants$root.C_INT$LAYOUT,
         Constants$root.C_POINTER$LAYOUT
     );
     static final MethodHandle clang_getDiagnosticSeverity$MH = RuntimeHelper.downcallHandle(
         "clang_getDiagnosticSeverity",
-        constants$3.clang_getDiagnosticSeverity$FUNC, false
+        constants$3.clang_getDiagnosticSeverity$FUNC
     );
 }
 

--- a/src/main/java/org/openjdk/jextract/clang/libclang/constants$4.java
+++ b/src/main/java/org/openjdk/jextract/clang/libclang/constants$4.java
@@ -43,7 +43,7 @@ class constants$4 {
     );
     static final MethodHandle clang_getDiagnosticLocation$MH = RuntimeHelper.downcallHandle(
         "clang_getDiagnosticLocation",
-        constants$4.clang_getDiagnosticLocation$FUNC, false
+        constants$4.clang_getDiagnosticLocation$FUNC
     );
     static final FunctionDescriptor clang_getDiagnosticSpelling$FUNC = FunctionDescriptor.of(MemoryLayout.structLayout(
         Constants$root.C_POINTER$LAYOUT.withName("data"),
@@ -54,7 +54,7 @@ class constants$4 {
     );
     static final MethodHandle clang_getDiagnosticSpelling$MH = RuntimeHelper.downcallHandle(
         "clang_getDiagnosticSpelling",
-        constants$4.clang_getDiagnosticSpelling$FUNC, false
+        constants$4.clang_getDiagnosticSpelling$FUNC
     );
     static final FunctionDescriptor clang_parseTranslationUnit$FUNC = FunctionDescriptor.of(Constants$root.C_POINTER$LAYOUT,
         Constants$root.C_POINTER$LAYOUT,
@@ -67,7 +67,7 @@ class constants$4 {
     );
     static final MethodHandle clang_parseTranslationUnit$MH = RuntimeHelper.downcallHandle(
         "clang_parseTranslationUnit",
-        constants$4.clang_parseTranslationUnit$FUNC, false
+        constants$4.clang_parseTranslationUnit$FUNC
     );
     static final FunctionDescriptor clang_parseTranslationUnit2$FUNC = FunctionDescriptor.of(Constants$root.C_INT$LAYOUT,
         Constants$root.C_POINTER$LAYOUT,
@@ -81,7 +81,7 @@ class constants$4 {
     );
     static final MethodHandle clang_parseTranslationUnit2$MH = RuntimeHelper.downcallHandle(
         "clang_parseTranslationUnit2",
-        constants$4.clang_parseTranslationUnit2$FUNC, false
+        constants$4.clang_parseTranslationUnit2$FUNC
     );
     static final FunctionDescriptor clang_saveTranslationUnit$FUNC = FunctionDescriptor.of(Constants$root.C_INT$LAYOUT,
         Constants$root.C_POINTER$LAYOUT,
@@ -90,14 +90,14 @@ class constants$4 {
     );
     static final MethodHandle clang_saveTranslationUnit$MH = RuntimeHelper.downcallHandle(
         "clang_saveTranslationUnit",
-        constants$4.clang_saveTranslationUnit$FUNC, false
+        constants$4.clang_saveTranslationUnit$FUNC
     );
     static final FunctionDescriptor clang_disposeTranslationUnit$FUNC = FunctionDescriptor.ofVoid(
         Constants$root.C_POINTER$LAYOUT
     );
     static final MethodHandle clang_disposeTranslationUnit$MH = RuntimeHelper.downcallHandle(
         "clang_disposeTranslationUnit",
-        constants$4.clang_disposeTranslationUnit$FUNC, false
+        constants$4.clang_disposeTranslationUnit$FUNC
     );
 }
 

--- a/src/main/java/org/openjdk/jextract/clang/libclang/constants$5.java
+++ b/src/main/java/org/openjdk/jextract/clang/libclang/constants$5.java
@@ -39,7 +39,7 @@ class constants$5 {
     );
     static final MethodHandle clang_defaultReparseOptions$MH = RuntimeHelper.downcallHandle(
         "clang_defaultReparseOptions",
-        constants$5.clang_defaultReparseOptions$FUNC, false
+        constants$5.clang_defaultReparseOptions$FUNC
     );
     static final FunctionDescriptor clang_reparseTranslationUnit$FUNC = FunctionDescriptor.of(Constants$root.C_INT$LAYOUT,
         Constants$root.C_POINTER$LAYOUT,
@@ -49,7 +49,7 @@ class constants$5 {
     );
     static final MethodHandle clang_reparseTranslationUnit$MH = RuntimeHelper.downcallHandle(
         "clang_reparseTranslationUnit",
-        constants$5.clang_reparseTranslationUnit$FUNC, false
+        constants$5.clang_reparseTranslationUnit$FUNC
     );
     static final FunctionDescriptor clang_getNullCursor$FUNC = FunctionDescriptor.of(MemoryLayout.structLayout(
         Constants$root.C_INT$LAYOUT.withName("kind"),
@@ -58,7 +58,7 @@ class constants$5 {
     ));
     static final MethodHandle clang_getNullCursor$MH = RuntimeHelper.downcallHandle(
         "clang_getNullCursor",
-        constants$5.clang_getNullCursor$FUNC, false
+        constants$5.clang_getNullCursor$FUNC
     );
     static final FunctionDescriptor clang_getTranslationUnitCursor$FUNC = FunctionDescriptor.of(MemoryLayout.structLayout(
         Constants$root.C_INT$LAYOUT.withName("kind"),
@@ -69,7 +69,7 @@ class constants$5 {
     );
     static final MethodHandle clang_getTranslationUnitCursor$MH = RuntimeHelper.downcallHandle(
         "clang_getTranslationUnitCursor",
-        constants$5.clang_getTranslationUnitCursor$FUNC, false
+        constants$5.clang_getTranslationUnitCursor$FUNC
     );
     static final FunctionDescriptor clang_equalCursors$FUNC = FunctionDescriptor.of(Constants$root.C_INT$LAYOUT,
         MemoryLayout.structLayout(
@@ -85,7 +85,7 @@ class constants$5 {
     );
     static final MethodHandle clang_equalCursors$MH = RuntimeHelper.downcallHandle(
         "clang_equalCursors",
-        constants$5.clang_equalCursors$FUNC, false
+        constants$5.clang_equalCursors$FUNC
     );
     static final FunctionDescriptor clang_Cursor_isNull$FUNC = FunctionDescriptor.of(Constants$root.C_INT$LAYOUT,
         MemoryLayout.structLayout(
@@ -96,7 +96,7 @@ class constants$5 {
     );
     static final MethodHandle clang_Cursor_isNull$MH = RuntimeHelper.downcallHandle(
         "clang_Cursor_isNull",
-        constants$5.clang_Cursor_isNull$FUNC, false
+        constants$5.clang_Cursor_isNull$FUNC
     );
 }
 

--- a/src/main/java/org/openjdk/jextract/clang/libclang/constants$6.java
+++ b/src/main/java/org/openjdk/jextract/clang/libclang/constants$6.java
@@ -43,35 +43,35 @@ class constants$6 {
     );
     static final MethodHandle clang_getCursorKind$MH = RuntimeHelper.downcallHandle(
         "clang_getCursorKind",
-        constants$6.clang_getCursorKind$FUNC, false
+        constants$6.clang_getCursorKind$FUNC
     );
     static final FunctionDescriptor clang_isDeclaration$FUNC = FunctionDescriptor.of(Constants$root.C_INT$LAYOUT,
         Constants$root.C_INT$LAYOUT
     );
     static final MethodHandle clang_isDeclaration$MH = RuntimeHelper.downcallHandle(
         "clang_isDeclaration",
-        constants$6.clang_isDeclaration$FUNC, false
+        constants$6.clang_isDeclaration$FUNC
     );
     static final FunctionDescriptor clang_isAttribute$FUNC = FunctionDescriptor.of(Constants$root.C_INT$LAYOUT,
         Constants$root.C_INT$LAYOUT
     );
     static final MethodHandle clang_isAttribute$MH = RuntimeHelper.downcallHandle(
         "clang_isAttribute",
-        constants$6.clang_isAttribute$FUNC, false
+        constants$6.clang_isAttribute$FUNC
     );
     static final FunctionDescriptor clang_isInvalid$FUNC = FunctionDescriptor.of(Constants$root.C_INT$LAYOUT,
         Constants$root.C_INT$LAYOUT
     );
     static final MethodHandle clang_isInvalid$MH = RuntimeHelper.downcallHandle(
         "clang_isInvalid",
-        constants$6.clang_isInvalid$FUNC, false
+        constants$6.clang_isInvalid$FUNC
     );
     static final FunctionDescriptor clang_isPreprocessing$FUNC = FunctionDescriptor.of(Constants$root.C_INT$LAYOUT,
         Constants$root.C_INT$LAYOUT
     );
     static final MethodHandle clang_isPreprocessing$MH = RuntimeHelper.downcallHandle(
         "clang_isPreprocessing",
-        constants$6.clang_isPreprocessing$FUNC, false
+        constants$6.clang_isPreprocessing$FUNC
     );
     static final FunctionDescriptor clang_getCursorLanguage$FUNC = FunctionDescriptor.of(Constants$root.C_INT$LAYOUT,
         MemoryLayout.structLayout(
@@ -82,7 +82,7 @@ class constants$6 {
     );
     static final MethodHandle clang_getCursorLanguage$MH = RuntimeHelper.downcallHandle(
         "clang_getCursorLanguage",
-        constants$6.clang_getCursorLanguage$FUNC, false
+        constants$6.clang_getCursorLanguage$FUNC
     );
 }
 

--- a/src/main/java/org/openjdk/jextract/clang/libclang/constants$7.java
+++ b/src/main/java/org/openjdk/jextract/clang/libclang/constants$7.java
@@ -43,7 +43,7 @@ class constants$7 {
     );
     static final MethodHandle clang_Cursor_getTranslationUnit$MH = RuntimeHelper.downcallHandle(
         "clang_Cursor_getTranslationUnit",
-        constants$7.clang_Cursor_getTranslationUnit$FUNC, false
+        constants$7.clang_Cursor_getTranslationUnit$FUNC
     );
     static final FunctionDescriptor clang_getCursorLocation$FUNC = FunctionDescriptor.of(MemoryLayout.structLayout(
         MemoryLayout.sequenceLayout(2, Constants$root.C_POINTER$LAYOUT).withName("ptr_data"),
@@ -58,7 +58,7 @@ class constants$7 {
     );
     static final MethodHandle clang_getCursorLocation$MH = RuntimeHelper.downcallHandle(
         "clang_getCursorLocation",
-        constants$7.clang_getCursorLocation$FUNC, false
+        constants$7.clang_getCursorLocation$FUNC
     );
     static final FunctionDescriptor clang_getCursorExtent$FUNC = FunctionDescriptor.of(MemoryLayout.structLayout(
         MemoryLayout.sequenceLayout(2, Constants$root.C_POINTER$LAYOUT).withName("ptr_data"),
@@ -73,7 +73,7 @@ class constants$7 {
     );
     static final MethodHandle clang_getCursorExtent$MH = RuntimeHelper.downcallHandle(
         "clang_getCursorExtent",
-        constants$7.clang_getCursorExtent$FUNC, false
+        constants$7.clang_getCursorExtent$FUNC
     );
     static final FunctionDescriptor clang_getCursorType$FUNC = FunctionDescriptor.of(MemoryLayout.structLayout(
         Constants$root.C_INT$LAYOUT.withName("kind"),
@@ -88,7 +88,7 @@ class constants$7 {
     );
     static final MethodHandle clang_getCursorType$MH = RuntimeHelper.downcallHandle(
         "clang_getCursorType",
-        constants$7.clang_getCursorType$FUNC, false
+        constants$7.clang_getCursorType$FUNC
     );
     static final FunctionDescriptor clang_getTypeSpelling$FUNC = FunctionDescriptor.of(MemoryLayout.structLayout(
         Constants$root.C_POINTER$LAYOUT.withName("data"),
@@ -103,7 +103,7 @@ class constants$7 {
     );
     static final MethodHandle clang_getTypeSpelling$MH = RuntimeHelper.downcallHandle(
         "clang_getTypeSpelling",
-        constants$7.clang_getTypeSpelling$FUNC, false
+        constants$7.clang_getTypeSpelling$FUNC
     );
     static final FunctionDescriptor clang_getTypedefDeclUnderlyingType$FUNC = FunctionDescriptor.of(MemoryLayout.structLayout(
         Constants$root.C_INT$LAYOUT.withName("kind"),
@@ -118,7 +118,7 @@ class constants$7 {
     );
     static final MethodHandle clang_getTypedefDeclUnderlyingType$MH = RuntimeHelper.downcallHandle(
         "clang_getTypedefDeclUnderlyingType",
-        constants$7.clang_getTypedefDeclUnderlyingType$FUNC, false
+        constants$7.clang_getTypedefDeclUnderlyingType$FUNC
     );
 }
 

--- a/src/main/java/org/openjdk/jextract/clang/libclang/constants$8.java
+++ b/src/main/java/org/openjdk/jextract/clang/libclang/constants$8.java
@@ -47,7 +47,7 @@ class constants$8 {
     );
     static final MethodHandle clang_getEnumDeclIntegerType$MH = RuntimeHelper.downcallHandle(
         "clang_getEnumDeclIntegerType",
-        constants$8.clang_getEnumDeclIntegerType$FUNC, false
+        constants$8.clang_getEnumDeclIntegerType$FUNC
     );
     static final FunctionDescriptor clang_getEnumConstantDeclValue$FUNC = FunctionDescriptor.of(Constants$root.C_LONG_LONG$LAYOUT,
         MemoryLayout.structLayout(
@@ -58,7 +58,7 @@ class constants$8 {
     );
     static final MethodHandle clang_getEnumConstantDeclValue$MH = RuntimeHelper.downcallHandle(
         "clang_getEnumConstantDeclValue",
-        constants$8.clang_getEnumConstantDeclValue$FUNC, false
+        constants$8.clang_getEnumConstantDeclValue$FUNC
     );
     static final FunctionDescriptor clang_getEnumConstantDeclUnsignedValue$FUNC = FunctionDescriptor.of(Constants$root.C_LONG_LONG$LAYOUT,
         MemoryLayout.structLayout(
@@ -69,7 +69,7 @@ class constants$8 {
     );
     static final MethodHandle clang_getEnumConstantDeclUnsignedValue$MH = RuntimeHelper.downcallHandle(
         "clang_getEnumConstantDeclUnsignedValue",
-        constants$8.clang_getEnumConstantDeclUnsignedValue$FUNC, false
+        constants$8.clang_getEnumConstantDeclUnsignedValue$FUNC
     );
     static final FunctionDescriptor clang_getFieldDeclBitWidth$FUNC = FunctionDescriptor.of(Constants$root.C_INT$LAYOUT,
         MemoryLayout.structLayout(
@@ -80,7 +80,7 @@ class constants$8 {
     );
     static final MethodHandle clang_getFieldDeclBitWidth$MH = RuntimeHelper.downcallHandle(
         "clang_getFieldDeclBitWidth",
-        constants$8.clang_getFieldDeclBitWidth$FUNC, false
+        constants$8.clang_getFieldDeclBitWidth$FUNC
     );
     static final FunctionDescriptor clang_Cursor_getNumArguments$FUNC = FunctionDescriptor.of(Constants$root.C_INT$LAYOUT,
         MemoryLayout.structLayout(
@@ -91,7 +91,7 @@ class constants$8 {
     );
     static final MethodHandle clang_Cursor_getNumArguments$MH = RuntimeHelper.downcallHandle(
         "clang_Cursor_getNumArguments",
-        constants$8.clang_Cursor_getNumArguments$FUNC, false
+        constants$8.clang_Cursor_getNumArguments$FUNC
     );
     static final FunctionDescriptor clang_Cursor_getArgument$FUNC = FunctionDescriptor.of(MemoryLayout.structLayout(
         Constants$root.C_INT$LAYOUT.withName("kind"),
@@ -107,7 +107,7 @@ class constants$8 {
     );
     static final MethodHandle clang_Cursor_getArgument$MH = RuntimeHelper.downcallHandle(
         "clang_Cursor_getArgument",
-        constants$8.clang_Cursor_getArgument$FUNC, false
+        constants$8.clang_Cursor_getArgument$FUNC
     );
 }
 

--- a/src/main/java/org/openjdk/jextract/clang/libclang/constants$9.java
+++ b/src/main/java/org/openjdk/jextract/clang/libclang/constants$9.java
@@ -48,7 +48,7 @@ class constants$9 {
     );
     static final MethodHandle clang_equalTypes$MH = RuntimeHelper.downcallHandle(
         "clang_equalTypes",
-        constants$9.clang_equalTypes$FUNC, false
+        constants$9.clang_equalTypes$FUNC
     );
     static final FunctionDescriptor clang_getCanonicalType$FUNC = FunctionDescriptor.of(MemoryLayout.structLayout(
         Constants$root.C_INT$LAYOUT.withName("kind"),
@@ -63,7 +63,7 @@ class constants$9 {
     );
     static final MethodHandle clang_getCanonicalType$MH = RuntimeHelper.downcallHandle(
         "clang_getCanonicalType",
-        constants$9.clang_getCanonicalType$FUNC, false
+        constants$9.clang_getCanonicalType$FUNC
     );
     static final FunctionDescriptor clang_isConstQualifiedType$FUNC = FunctionDescriptor.of(Constants$root.C_INT$LAYOUT,
         MemoryLayout.structLayout(
@@ -74,7 +74,7 @@ class constants$9 {
     );
     static final MethodHandle clang_isConstQualifiedType$MH = RuntimeHelper.downcallHandle(
         "clang_isConstQualifiedType",
-        constants$9.clang_isConstQualifiedType$FUNC, false
+        constants$9.clang_isConstQualifiedType$FUNC
     );
     static final FunctionDescriptor clang_Cursor_isMacroFunctionLike$FUNC = FunctionDescriptor.of(Constants$root.C_INT$LAYOUT,
         MemoryLayout.structLayout(
@@ -85,7 +85,7 @@ class constants$9 {
     );
     static final MethodHandle clang_Cursor_isMacroFunctionLike$MH = RuntimeHelper.downcallHandle(
         "clang_Cursor_isMacroFunctionLike",
-        constants$9.clang_Cursor_isMacroFunctionLike$FUNC, false
+        constants$9.clang_Cursor_isMacroFunctionLike$FUNC
     );
     static final FunctionDescriptor clang_isVolatileQualifiedType$FUNC = FunctionDescriptor.of(Constants$root.C_INT$LAYOUT,
         MemoryLayout.structLayout(
@@ -96,7 +96,7 @@ class constants$9 {
     );
     static final MethodHandle clang_isVolatileQualifiedType$MH = RuntimeHelper.downcallHandle(
         "clang_isVolatileQualifiedType",
-        constants$9.clang_isVolatileQualifiedType$FUNC, false
+        constants$9.clang_isVolatileQualifiedType$FUNC
     );
     static final FunctionDescriptor clang_getTypedefName$FUNC = FunctionDescriptor.of(MemoryLayout.structLayout(
         Constants$root.C_POINTER$LAYOUT.withName("data"),
@@ -111,7 +111,7 @@ class constants$9 {
     );
     static final MethodHandle clang_getTypedefName$MH = RuntimeHelper.downcallHandle(
         "clang_getTypedefName",
-        constants$9.clang_getTypedefName$FUNC, false
+        constants$9.clang_getTypedefName$FUNC
     );
 }
 


### PR DESCRIPTION
regenerating LibClang binding for jextract changes and llvm 13.0.0

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract pull/52/head:pull/52` \
`$ git checkout pull/52`

Update a local copy of the PR: \
`$ git checkout pull/52` \
`$ git pull https://git.openjdk.org/jextract pull/52/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 52`

View PR using the GUI difftool: \
`$ git pr show -t 52`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/52.diff">https://git.openjdk.org/jextract/pull/52.diff</a>

</details>
