### PR TITLE
backport of 7903237: pointer to function struct member with the same name as struct crashes jextract

### DIFF
--- a/src/main/java/org/openjdk/jextract/impl/JavaSourceBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/JavaSourceBuilder.java
@@ -83,7 +83,7 @@ public abstract class JavaSourceBuilder {
     final String uniqueNestedClassName(String name) {
         name = Utils.javaSafeIdentifier(name);
         var notSeen = nestedClassNames.add(name.toLowerCase());
-        var notEnclosed = !isEnclosedBySameName(name.toLowerCase());
+        var notEnclosed = !isEnclosedBySameName(name);
         return notSeen && notEnclosed? name : (name + "$" + nestedClassNameCount++);
     }
 

--- a/test/testng/org/openjdk/jextract/test/toolprovider/Test7903237.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/Test7903237.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package org.openjdk.jextract.test.toolprovider;
+
+import java.nio.file.Path;
+
+import testlib.TestUtils;
+import org.testng.annotations.Test;
+import testlib.JextractToolRunner;
+
+import static org.testng.Assert.assertNotNull;
+
+public class Test7903237 extends JextractToolRunner {
+    @Test
+    public void testNameClash() {
+        Path test7903237Output = getOutputFilePath("test7903237_gen");
+        Path test7903237H = getInputFilePath("test7903237.h");
+        run("--output", test7903237Output.toString(), test7903237H.toString()).checkSuccess();
+        try(TestUtils.Loader loader = TestUtils.classLoader(test7903237Output)) {
+            Class<?> cls = loader.loadClass("test7903237_h");
+            assertNotNull(cls);
+            assertNotNull(loader.loadClass("Foo$Foo$0"));
+        } finally {
+            TestUtils.deleteDir(test7903237Output);
+        }
+    }
+}

--- a/test/testng/org/openjdk/jextract/test/toolprovider/test7903237.h
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/test7903237.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+struct Foo {
+    int (*Foo)();
+};


### PR DESCRIPTION
backport of 7903237: pointer to function struct member with the same name as struct crashes jextract

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract pull/56/head:pull/56` \
`$ git checkout pull/56`

Update a local copy of the PR: \
`$ git checkout pull/56` \
`$ git pull https://git.openjdk.org/jextract pull/56/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 56`

View PR using the GUI difftool: \
`$ git pr show -t 56`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/56.diff">https://git.openjdk.org/jextract/pull/56.diff</a>

</details>
