### PR TITLE
7903253: sync jextract tests for sequence layout factory split

### DIFF
--- a/test/testng/org/openjdk/jextract/test/toolprovider/TestClassGeneration.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/TestClassGeneration.java
@@ -45,7 +45,7 @@ import static org.testng.Assert.assertNotNull;
 
 public class TestClassGeneration extends JextractToolRunner {
 
-    private static final VarHandle VH_bytes = MemoryLayout.sequenceLayout(-1, C_CHAR).varHandle(sequenceElement());
+    private static final VarHandle VH_bytes = MemoryLayout.sequenceLayout(C_CHAR).varHandle(sequenceElement());
 
     private Path outputDir;
     private TestUtils.Loader loader;


### PR DESCRIPTION
Avoid -1 elementCount for Sequence layout factory call.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Issue
 * [CODETOOLS-7903253](https://bugs.openjdk.org/browse/CODETOOLS-7903253): sync jextract tests for sequence layout factory split


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract pull/61/head:pull/61` \
`$ git checkout pull/61`

Update a local copy of the PR: \
`$ git checkout pull/61` \
`$ git pull https://git.openjdk.org/jextract pull/61/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 61`

View PR using the GUI difftool: \
`$ git pr show -t 61`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/61.diff">https://git.openjdk.org/jextract/pull/61.diff</a>

</details>
