### PR TITLE
7903269: jextract test failures after Layout updates change

### DIFF
--- a/test/testng/org/openjdk/jextract/test/toolprovider/RepeatedDeclsTest.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/RepeatedDeclsTest.java
@@ -31,6 +31,7 @@ import java.nio.file.Path;
 import java.lang.foreign.GroupLayout;
 import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemorySegment;
+import java.lang.foreign.StructLayout;
 import testlib.JextractToolRunner;
 
 import static org.testng.Assert.assertNotNull;
@@ -100,7 +101,7 @@ public class RepeatedDeclsTest extends JextractToolRunner {
     private void checkPoint(Class<?> pointCls) {
         MemoryLayout pointLayout = findLayout(pointCls);
         assertNotNull(pointLayout);
-        assertTrue(((GroupLayout)pointLayout).isStruct());
+        assertTrue(pointLayout instanceof StructLayout);
         checkField(pointLayout, "i", C_INT);
         checkField(pointLayout, "j", C_INT);
     }
@@ -108,7 +109,7 @@ public class RepeatedDeclsTest extends JextractToolRunner {
     private void checkPoint3D(Class<?> point3DCls) {
         MemoryLayout point3DLayout = findLayout(point3DCls);
         assertNotNull(point3DLayout);
-        assertTrue(((GroupLayout)point3DLayout).isStruct());
+        assertTrue(point3DLayout instanceof StructLayout);
         checkField(point3DLayout, "i", C_INT);
         checkField(point3DLayout, "j", C_INT);
         checkField(point3DLayout, "k", C_INT);

--- a/test/testng/org/openjdk/jextract/test/toolprovider/Test8240811.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/Test8240811.java
@@ -27,6 +27,8 @@ import java.nio.file.Path;
 
 import java.lang.foreign.GroupLayout;
 import java.lang.foreign.MemoryLayout;
+import java.lang.foreign.StructLayout;
+import java.lang.foreign.UnionLayout;
 import testlib.TestUtils;
 import org.testng.annotations.Test;
 import testlib.JextractToolRunner;
@@ -48,7 +50,7 @@ public class Test8240811 extends JextractToolRunner {
             Class<?> fooCls = loader.loadClass("foo");
             MemoryLayout fooLayout = findLayout(fooCls);
             assertNotNull(fooLayout);
-            assertTrue(((GroupLayout)fooLayout).isStruct());
+            assertTrue(fooLayout instanceof StructLayout);
             checkField(fooLayout, "x",  C_INT);
             checkField(fooLayout, "y",  C_INT);
             checkField(fooLayout, "z",  C_INT);
@@ -60,7 +62,7 @@ public class Test8240811 extends JextractToolRunner {
             Class<?> foo2Cls = loader.loadClass("foo2");
             MemoryLayout foo2Layout = findLayout(foo2Cls);
             assertNotNull(foo2Layout);
-            assertTrue(((GroupLayout)foo2Layout).isUnion());
+            assertTrue(foo2Layout instanceof UnionLayout);
             checkField(foo2Layout, "i", C_INT);
             checkField(foo2Layout, "l", C_LONG);
 
@@ -74,7 +76,7 @@ public class Test8240811 extends JextractToolRunner {
             Class<?> barCls = loader.loadClass("bar");
             MemoryLayout barLayout = findLayout(barCls);
             assertNotNull(barLayout);
-            assertTrue(((GroupLayout)barLayout).isStruct());
+            assertTrue(barLayout instanceof StructLayout);
             checkField(barLayout, "f1", C_FLOAT);
             checkField(barLayout, "f2", C_FLOAT);
 
@@ -85,7 +87,7 @@ public class Test8240811 extends JextractToolRunner {
             Class<?> bar2Cls = loader.loadClass("bar2");
             MemoryLayout bar2Layout = findLayout(bar2Cls);
             assertNotNull(bar2Layout);
-            assertTrue(((GroupLayout)bar2Layout).isUnion());
+            assertTrue(bar2Layout instanceof UnionLayout);
             checkField(bar2Layout, "f", C_FLOAT);
             checkField(bar2Layout, "d", C_DOUBLE);
         } finally {

--- a/test/testng/org/openjdk/jextract/test/toolprovider/UniondeclTest.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/UniondeclTest.java
@@ -28,6 +28,7 @@ import testlib.TestUtils;
 import org.testng.annotations.Test;
 import java.nio.file.Path;
 import java.lang.foreign.GroupLayout;
+import java.lang.foreign.UnionLayout;
 import testlib.JextractToolRunner;
 
 import static org.testng.Assert.assertNotNull;
@@ -47,7 +48,7 @@ public class UniondeclTest extends JextractToolRunner {
             Class<?> intOrFloatCls = loader.loadClass("IntOrFloat");
             GroupLayout intOrFloatLayout = (GroupLayout)findLayout(intOrFloatCls);
             assertNotNull(intOrFloatLayout);
-            assertTrue(intOrFloatLayout.isUnion());
+            assertTrue(intOrFloatLayout instanceof UnionLayout);
             checkField(intOrFloatLayout, "i",  C_INT);
             checkField(intOrFloatLayout, "f", C_FLOAT);
         } finally {


### PR DESCRIPTION
Missed isStruct, isUnion changes in tests

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Issue
 * [CODETOOLS-7903269](https://bugs.openjdk.org/browse/CODETOOLS-7903269): jextract test failures after Layout updates change


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract pull/64/head:pull/64` \
`$ git checkout pull/64`

Update a local copy of the PR: \
`$ git checkout pull/64` \
`$ git pull https://git.openjdk.org/jextract pull/64/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 64`

View PR using the GUI difftool: \
`$ git pr show -t 64`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/64.diff">https://git.openjdk.org/jextract/pull/64.diff</a>

</details>
