### PR TITLE
Code formatting

### DIFF
--- a/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
@@ -93,7 +93,7 @@ abstract class HeaderFileBuilder extends ClassSourceBuilder {
     public void addFunction(String javaName, String nativeName, FunctionDescriptor descriptor, boolean isVarargs, List<String> parameterNames) {
         emitWithConstantClass(constantBuilder -> {
             Constant mhConstant = constantBuilder.addMethodHandle(javaName, nativeName, descriptor, isVarargs, false)
-                    .emitGetter(this, MEMBER_MODS, Constant.QUALIFIED_NAME, nativeName);
+                    .emitGetter(this, "private static", Constant.QUALIFIED_NAME, nativeName);
             MethodType downcallType = Linker.methodType(descriptor);
             boolean needsAllocator = descriptor.returnLayout().isPresent() &&
                     descriptor.returnLayout().get() instanceof GroupLayout;
@@ -157,7 +157,7 @@ abstract class HeaderFileBuilder extends ClassSourceBuilder {
     }
 
     private List<String> emitFunctionWrapperDecl(String javaName, MethodType methodType, boolean isVarargs, List<String> paramNames) {
-        append(methodType.returnType().getSimpleName() + " " + javaName + " (");
+        append(methodType.returnType().getSimpleName() + " " + javaName + "(");
         String delim = "";
         List<String> pExprs = new ArrayList<>();
         final int numParams = paramNames.size();
@@ -168,7 +168,7 @@ abstract class HeaderFileBuilder extends ClassSourceBuilder {
             }
             pExprs.add(pName);
             Class<?> pType = methodType.parameterType(i);
-            append(delim + " " + pType.getSimpleName() + " " + pName);
+            append(delim + pType.getSimpleName() + " " + pName);
             delim = ", ";
         }
         if (isVarargs) {

--- a/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
@@ -93,7 +93,7 @@ abstract class HeaderFileBuilder extends ClassSourceBuilder {
     public void addFunction(String javaName, String nativeName, FunctionDescriptor descriptor, boolean isVarargs, List<String> parameterNames) {
         emitWithConstantClass(constantBuilder -> {
             Constant mhConstant = constantBuilder.addMethodHandle(javaName, nativeName, descriptor, isVarargs, false)
-                    .emitGetter(this, "private static", Constant.QUALIFIED_NAME, nativeName);
+                    .emitGetter(this, MEMBER_MODS, Constant.QUALIFIED_NAME, nativeName);
             MethodType downcallType = Linker.methodType(descriptor);
             boolean needsAllocator = descriptor.returnLayout().isPresent() &&
                     descriptor.returnLayout().get() instanceof GroupLayout;


### PR DESCRIPTION
xxxx$MH methods should be declared private to reduce cluttering in end users' IDEs and elsewhere.
 
 This PR also solves esthetic issues in the generated code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Reviewers
 * [Athijegannathan Sundararajan](https://openjdk.org/census#sundar) (@sundararajana - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract pull/67/head:pull/67` \
`$ git checkout pull/67`

Update a local copy of the PR: \
`$ git checkout pull/67` \
`$ git pull https://git.openjdk.org/jextract pull/67/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 67`

View PR using the GUI difftool: \
`$ git pr show -t 67`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/67.diff">https://git.openjdk.org/jextract/pull/67.diff</a>

</details>
