### PR TITLE
7903293: sync jextract for SymbolLookup.find change

### DIFF
--- a/samples/libjimage/org/openjdk/RuntimeHelper.java
+++ b/samples/libjimage/org/openjdk/RuntimeHelper.java
@@ -46,7 +46,7 @@ final class RuntimeHelper {
             libPath = "/lib/libjimage.so"; // some Unix
         }
         SymbolLookup loaderLookup = SymbolLookup.libraryLookup(libPath, MemorySession.global());
-        SYMBOL_LOOKUP = name -> loaderLookup.lookup(name).or(() -> LINKER.defaultLookup().lookup(name));
+        SYMBOL_LOOKUP = name -> loaderLookup.find(name).or(() -> LINKER.defaultLookup().find(name));
     }
 
     static <T> T requireNonNull(T obj, String symbolName) {
@@ -59,11 +59,11 @@ final class RuntimeHelper {
     private final static SegmentAllocator THROWING_ALLOCATOR = (x, y) -> { throw new AssertionError("should not reach here"); };
 
     static final MemorySegment lookupGlobalVariable(String name, MemoryLayout layout) {
-        return SYMBOL_LOOKUP.lookup(name).map(symbol -> MemorySegment.ofAddress(symbol.address(), layout.byteSize(), symbol.session())).orElse(null);
+        return SYMBOL_LOOKUP.find(name).map(symbol -> MemorySegment.ofAddress(symbol.address(), layout.byteSize(), symbol.session())).orElse(null);
     }
 
     static final MethodHandle downcallHandle(String name, FunctionDescriptor fdesc) {
-        return SYMBOL_LOOKUP.lookup(name).
+        return SYMBOL_LOOKUP.find(name).
                 map(addr -> LINKER.downcallHandle(addr, fdesc)).
                 orElse(null);
     }
@@ -73,7 +73,7 @@ final class RuntimeHelper {
     }
 
     static final MethodHandle downcallHandleVariadic(String name, FunctionDescriptor fdesc) {
-        return SYMBOL_LOOKUP.lookup(name).
+        return SYMBOL_LOOKUP.find(name).
                 map(addr -> VarargsInvoker.make(addr, fdesc)).
                 orElse(null);
     }

--- a/src/main/java/org/openjdk/jextract/clang/LibClang.java
+++ b/src/main/java/org/openjdk/jextract/clang/LibClang.java
@@ -56,7 +56,7 @@ public class LibClang {
             try {
                 Linker linker = Linker.nativeLinker();
                 String putenv = IS_WINDOWS ? "_putenv" : "putenv";
-                MethodHandle PUT_ENV = linker.downcallHandle(linker.defaultLookup().lookup(putenv).get(),
+                MethodHandle PUT_ENV = linker.downcallHandle(linker.defaultLookup().find(putenv).get(),
                                 FunctionDescriptor.of(C_INT, C_POINTER));
                 int res = (int) PUT_ENV.invokeExact((MemorySegment)disableCrashRecovery);
             } catch (Throwable ex) {

--- a/src/main/java/org/openjdk/jextract/clang/libclang/RuntimeHelper.java
+++ b/src/main/java/org/openjdk/jextract/clang/libclang/RuntimeHelper.java
@@ -65,7 +65,7 @@ final class RuntimeHelper {
         System.loadLibrary(libName);
 
         SymbolLookup loaderLookup = SymbolLookup.loaderLookup();
-        SYMBOL_LOOKUP = name -> loaderLookup.lookup(name).or(() -> LINKER.defaultLookup().lookup(name));
+        SYMBOL_LOOKUP = name -> loaderLookup.find(name).or(() -> LINKER.defaultLookup().find(name));
     }
 
     static <T> T requireNonNull(T obj, String symbolName) {
@@ -78,11 +78,11 @@ final class RuntimeHelper {
     private final static SegmentAllocator THROWING_ALLOCATOR = (x, y) -> { throw new AssertionError("should not reach here"); };
 
     static final MemorySegment lookupGlobalVariable(String name, MemoryLayout layout) {
-        return SYMBOL_LOOKUP.lookup(name).map(symbol -> MemorySegment.ofAddress(symbol.address(), layout.byteSize(), symbol.session())).orElse(null);
+        return SYMBOL_LOOKUP.find(name).map(symbol -> MemorySegment.ofAddress(symbol.address(), layout.byteSize(), symbol.session())).orElse(null);
     }
 
     static final MethodHandle downcallHandle(String name, FunctionDescriptor fdesc) {
-        return SYMBOL_LOOKUP.lookup(name).
+        return SYMBOL_LOOKUP.find(name).
                 map(addr -> LINKER.downcallHandle(addr, fdesc)).
                 orElse(null);
     }
@@ -92,7 +92,7 @@ final class RuntimeHelper {
     }
 
     static final MethodHandle downcallHandleVariadic(String name, FunctionDescriptor fdesc) {
-        return SYMBOL_LOOKUP.lookup(name).
+        return SYMBOL_LOOKUP.find(name).
                 map(addr -> VarargsInvoker.make(addr, fdesc)).
                 orElse(null);
     }

--- a/src/main/resources/org/openjdk/jextract/impl/resources/RuntimeHelper.java.template
+++ b/src/main/resources/org/openjdk/jextract/impl/resources/RuntimeHelper.java.template
@@ -36,7 +36,7 @@ final class RuntimeHelper {
     static {
         #LOAD_LIBRARIES#
         SymbolLookup loaderLookup = SymbolLookup.loaderLookup();
-        SYMBOL_LOOKUP = name -> loaderLookup.lookup(name).or(() -> LINKER.defaultLookup().lookup(name));
+        SYMBOL_LOOKUP = name -> loaderLookup.find(name).or(() -> LINKER.defaultLookup().find(name));
     }
 
     static <T> T requireNonNull(T obj, String symbolName) {
@@ -49,11 +49,11 @@ final class RuntimeHelper {
     private final static SegmentAllocator THROWING_ALLOCATOR = (x, y) -> { throw new AssertionError("should not reach here"); };
 
     static final MemorySegment lookupGlobalVariable(String name, MemoryLayout layout) {
-        return SYMBOL_LOOKUP.lookup(name).map(symbol -> MemorySegment.ofAddress(symbol.address(), layout.byteSize(), symbol.session())).orElse(null);
+        return SYMBOL_LOOKUP.find(name).map(symbol -> MemorySegment.ofAddress(symbol.address(), layout.byteSize(), symbol.session())).orElse(null);
     }
 
     static final MethodHandle downcallHandle(String name, FunctionDescriptor fdesc) {
-        return SYMBOL_LOOKUP.lookup(name).
+        return SYMBOL_LOOKUP.find(name).
                 map(addr -> LINKER.downcallHandle(addr, fdesc)).
                 orElse(null);
     }
@@ -63,7 +63,7 @@ final class RuntimeHelper {
     }
 
     static final MethodHandle downcallHandleVariadic(String name, FunctionDescriptor fdesc) {
-        return SYMBOL_LOOKUP.lookup(name).
+        return SYMBOL_LOOKUP.find(name).
                 map(addr -> VarargsInvoker.make(addr, fdesc)).
                 orElse(null);
     }


### PR DESCRIPTION
synced API method name change. All tests and samples fine on macOS

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Issue
 * [CODETOOLS-7903293](https://bugs.openjdk.org/browse/CODETOOLS-7903293): sync jextract for SymbolLookup.find change


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract pull/71/head:pull/71` \
`$ git checkout pull/71`

Update a local copy of the PR: \
`$ git checkout pull/71` \
`$ git pull https://git.openjdk.org/jextract pull/71/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 71`

View PR using the GUI difftool: \
`$ git pr show -t 71`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/71.diff">https://git.openjdk.org/jextract/pull/71.diff</a>

</details>
