### PR TITLE
Fix jextract/panama to reflect latest API changes

### DIFF
--- a/samples/libffmpeg/LibffmpegMain.java
+++ b/samples/libffmpeg/LibffmpegMain.java
@@ -76,7 +76,7 @@ public class LibffmpegMain {
 
         try (var session = MemorySession.openConfined()) {
             // AVFormatContext *ppFormatCtx;
-            var ppFormatCtx = MemorySegment.allocateNative(C_POINTER, session);
+            var ppFormatCtx = session.allocate(C_POINTER);
             // char* fileName;
             var fileName = session.allocateUtf8String(args[0]);
 
@@ -190,7 +190,7 @@ public class LibffmpegMain {
             // ACPacket packet;
             var packet = AVPacket.allocate(session);
             // int* pFrameFinished;
-            var pFrameFinished = MemorySegment.allocateNative(C_INT, session);
+            var pFrameFinished = session.allocate(C_INT);
 
             while (av_read_frame(pFormatCtx, packet) >= 0) {
                 // Is this a packet from the video stream?

--- a/samples/libjimage/org/openjdk/RuntimeHelper.java
+++ b/samples/libjimage/org/openjdk/RuntimeHelper.java
@@ -45,7 +45,7 @@ final class RuntimeHelper {
         } else {
             libPath = "/lib/libjimage.so"; // some Unix
         }
-        SymbolLookup loaderLookup = SymbolLookup.libraryLookup(libPath, MemorySession.global()); 
+        SymbolLookup loaderLookup = SymbolLookup.libraryLookup(libPath, MemorySession.global());
         SYMBOL_LOOKUP = name -> loaderLookup.find(name).or(() -> LINKER.defaultLookup().find(name));
     }
 

--- a/samples/libjimage/org/openjdk/RuntimeHelper.java
+++ b/samples/libjimage/org/openjdk/RuntimeHelper.java
@@ -32,7 +32,7 @@ final class RuntimeHelper {
     private final static SymbolLookup SYMBOL_LOOKUP;
 
     final static SegmentAllocator CONSTANT_ALLOCATOR =
-            (size, align) -> MemorySegment.allocateNative(size, align, MemorySession.openImplicit());
+            (size, align) -> MemorySegment.allocateNative(size, align);
 
     static {
         // manual change
@@ -45,7 +45,7 @@ final class RuntimeHelper {
         } else {
             libPath = "/lib/libjimage.so"; // some Unix
         }
-        SymbolLookup loaderLookup = SymbolLookup.libraryLookup(libPath, MemorySession.global());
+        SymbolLookup loaderLookup = SymbolLookup.libraryLookup(libPath, MemorySession.global()); 
         SYMBOL_LOOKUP = name -> loaderLookup.find(name).or(() -> LINKER.defaultLookup().find(name));
     }
 
@@ -80,7 +80,7 @@ final class RuntimeHelper {
 
     static final <Z> MemorySegment upcallStub(Class<Z> fi, Z z, FunctionDescriptor fdesc, MemorySession session) {
         try {
-            MethodHandle handle = MH_LOOKUP.findVirtual(fi, "apply", Linker.methodType(fdesc));
+            MethodHandle handle = MH_LOOKUP.findVirtual(fi, "apply", fdesc.toMethodType());
             handle = handle.bindTo(z);
             return LINKER.upcallStub(handle, fdesc, session);
         } catch (Throwable ex) {

--- a/src/main/java/org/openjdk/jextract/clang/LibClang.java
+++ b/src/main/java/org/openjdk/jextract/clang/LibClang.java
@@ -44,7 +44,7 @@ public class LibClang {
     // crash recovery is not an issue on Windows, so enable it there by default to work around a libclang issue with reparseTranslationUnit
     private static final boolean CRASH_RECOVERY = IS_WINDOWS || Boolean.getBoolean("libclang.crash_recovery");
 
-    private static final SegmentAllocator IMPLICIT_ALLOCATOR = (size, align) -> MemorySegment.allocateNative(size, align, MemorySession.openImplicit());
+    private static final SegmentAllocator IMPLICIT_ALLOCATOR = (size, align) -> MemorySegment.allocateNative(size, align);
 
     private final static MemorySegment disableCrashRecovery =
             IMPLICIT_ALLOCATOR.allocateUtf8String("LIBCLANG_DISABLE_CRASH_RECOVERY=" + CRASH_RECOVERY);
@@ -87,7 +87,7 @@ public class LibClang {
      * conversion. The size of the prefix segment is set to 256, which should be enough to hold a CXString.
      */
     public final static SegmentAllocator STRING_ALLOCATOR = SegmentAllocator.prefixAllocator(
-            MemorySegment.allocateNative(CXString.sizeof(), 8, MemorySession.openImplicit()));
+            MemorySegment.allocateNative(CXString.sizeof(), 8));
 
     public static String version() {
         var clangVersion = Index_h.clang_getClangVersion(STRING_ALLOCATOR);

--- a/src/main/java/org/openjdk/jextract/clang/libclang/RuntimeHelper.java
+++ b/src/main/java/org/openjdk/jextract/clang/libclang/RuntimeHelper.java
@@ -57,7 +57,7 @@ final class RuntimeHelper {
     private final static SymbolLookup SYMBOL_LOOKUP;
 
     final static SegmentAllocator CONSTANT_ALLOCATOR =
-            (size, align) -> MemorySegment.allocateNative(size, align, MemorySession.openImplicit());
+            (size, align) -> MemorySegment.allocateNative(size, align);
 
     static {
         // Manual change to handle platform specific library name difference
@@ -99,7 +99,7 @@ final class RuntimeHelper {
 
     static final <Z> MemorySegment upcallStub(Class<Z> fi, Z z, FunctionDescriptor fdesc, MemorySession session) {
         try {
-            MethodHandle handle = MH_LOOKUP.findVirtual(fi, "apply", Linker.methodType(fdesc));
+            MethodHandle handle = MH_LOOKUP.findVirtual(fi, "apply", fdesc.toMethodType());
             handle = handle.bindTo(z);
             return LINKER.upcallStub(handle, fdesc, session);
         } catch (Throwable ex) {

--- a/src/main/java/org/openjdk/jextract/impl/FunctionalInterfaceBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/FunctionalInterfaceBuilder.java
@@ -48,8 +48,8 @@ public class FunctionalInterfaceBuilder extends ClassSourceBuilder {
     FunctionalInterfaceBuilder(JavaSourceBuilder enclosing, String className,
                                FunctionDescriptor descriptor, Optional<List<String>> parameterNames) {
         super(enclosing, Kind.INTERFACE, className);
-        this.fiType = Linker.methodType(descriptor);
-        this.downcallType = Linker.methodType(descriptor);
+        this.fiType = descriptor.toMethodType();
+        this.downcallType = descriptor.toMethodType();
         this.fiDesc = descriptor;
         this.parameterNames = parameterNames;
     }

--- a/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
@@ -94,7 +94,7 @@ abstract class HeaderFileBuilder extends ClassSourceBuilder {
         emitWithConstantClass(constantBuilder -> {
             Constant mhConstant = constantBuilder.addMethodHandle(javaName, nativeName, descriptor, isVarargs, false)
                     .emitGetter(this, MEMBER_MODS, Constant.QUALIFIED_NAME, nativeName);
-            MethodType downcallType = Linker.methodType(descriptor);
+            MethodType downcallType = descriptor.toMethodType();
             boolean needsAllocator = descriptor.returnLayout().isPresent() &&
                     descriptor.returnLayout().get() instanceof GroupLayout;
             emitFunctionWrapper(mhConstant, javaName, nativeName, downcallType, needsAllocator, isVarargs, parameterNames);

--- a/src/main/resources/org/openjdk/jextract/impl/resources/RuntimeHelper.java.template
+++ b/src/main/resources/org/openjdk/jextract/impl/resources/RuntimeHelper.java.template
@@ -31,7 +31,7 @@ final class RuntimeHelper {
     private final static SymbolLookup SYMBOL_LOOKUP;
 
     final static SegmentAllocator CONSTANT_ALLOCATOR =
-            (size, align) -> MemorySegment.allocateNative(size, align, MemorySession.openImplicit());
+            (size, align) -> MemorySegment.allocateNative(size, align);
 
     static {
         #LOAD_LIBRARIES#
@@ -70,7 +70,7 @@ final class RuntimeHelper {
 
     static final <Z> MemorySegment upcallStub(Class<Z> fi, Z z, FunctionDescriptor fdesc, MemorySession session) {
         try {
-            MethodHandle handle = MH_LOOKUP.findVirtual(fi, "apply", Linker.methodType(fdesc));
+            MethodHandle handle = MH_LOOKUP.findVirtual(fi, "apply", fdesc.toMethodType());
             handle = handle.bindTo(z);
             return LINKER.upcallStub(handle, fdesc, session);
         } catch (Throwable ex) {


### PR DESCRIPTION
This patch tweaks the jextract implementation to take into account two API changes:

* `MemorySegment.allocateNative` no longer accepts a session parameter (in all cases we were passing an implicit session, so that's ok)
* `Linker.methodType` has been moved to `FunctionDescriptor::toMethodType`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Reviewers
 * [Athijegannathan Sundararajan](https://openjdk.org/census#sundar) (@sundararajana - Committer) ⚠️ Review applies to [910ab267](https://git.openjdk.org/jextract/pull/72/files/910ab267c961f08fa3a3438b5dc84e092964a42e)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract pull/72/head:pull/72` \
`$ git checkout pull/72`

Update a local copy of the PR: \
`$ git checkout pull/72` \
`$ git pull https://git.openjdk.org/jextract pull/72/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 72`

View PR using the GUI difftool: \
`$ git pr show -t 72`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/72.diff">https://git.openjdk.org/jextract/pull/72.diff</a>

</details>
