### PR TITLE
Add Dockerfile, zero-dep reproducible builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,57 @@
+FROM ubuntu:22.10 AS builder
+
+# Allow configuring JDK version
+# COMPILE_VERSION will be used with the gradle build task
+# RUNTIME_VERSION will be passed to the "-Pjdk19_home" gradle property
+ARG SDKMAN_JAVA_COMPILE_VERSION=17-open
+ARG SDKMAN_JAVA_RUNTIME_VERSION=19-open
+
+# Allow configuring LLVM download URL
+ARG LLVM_DOWNLOAD_URL=https://github.com/llvm/llvm-project/releases/download/llvmorg-14.0.0/clang+llvm-14.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz
+
+SHELL ["/bin/bash", "-c"]
+
+# Install dependencies
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y \
+    git \
+    curl \
+    wget \
+    bash \
+    unzip \
+    zip \
+    xz-utils
+
+# Install sdkman
+RUN curl -s "https://get.sdkman.io" | bash
+
+# Use sdkman to install JDK 19
+RUN source "$HOME/.sdkman/bin/sdkman-init.sh" \
+    && sdk install java ${SDKMAN_JAVA_COMPILE_VERSION} \
+    && sdk install java ${SDKMAN_JAVA_RUNTIME_VERSION} \
+    && sdk use java ${SDKMAN_JAVA_COMPILE_VERSION}
+
+# Add sdkman to PATH
+ENV SDKMAN_PATH="/root/.sdkman/candidates"
+ENV PATH="${SDKMAN_PATH}/java/${SDKMAN_JAVA_COMPILE_VERSION}/bin:$PATH"
+
+# Convenience variable
+ENV LLVM_HOME="/tmp/llvm"
+
+# Download and extract LLVM
+RUN wget -q -O llvm.tar.xz $LLVM_DOWNLOAD_URL \
+    && mkdir -p ${LLVM_HOME} \
+    && tar -xf llvm.tar.xz -C ${LLVM_HOME} --strip-components=1
+
+# Download, extract and build jextract
+RUN git clone https://github.com/openjdk/jextract.git /tmp/jextract \
+    && cd /tmp/jextract \
+    && java -version \
+    && sh ./gradlew \
+        -Pjdk19_home="${SDKMAN_PATH}/java/${SDKMAN_JAVA_RUNTIME_VERSION}" \
+        -Pllvm_home=${LLVM_HOME} \
+        clean verify
+
+# Copy the built jextract sources to a fresh slim OpenJDK 19 image
+FROM openjdk:19-slim
+COPY --from=builder /tmp/jextract/build/jextract /usr/local/jextract
+ENTRYPOINT ["/usr/local/jextract/bin/jextract"]

--- a/README.md
+++ b/README.md
@@ -22,6 +22,24 @@
 $ sh ./gradlew -Pjdk19_home=<jdk19_home_dir> -Pllvm_home=<libclang_dir> clean verify
 ```
 
+`jextract` can also be built using the `Dockerfile` located in this directory, by running:
+```sh
+$ docker build -t jextract:latest -f Dockerfile .
+```
+
+It can then be used through the Docker CLI:
+```sh
+$ echo "struct Foo { int a; long b; }; int use_foo(struct Foo foo);" >> sample.h
+
+$ docker run --rm -it -v ${PWD}:/tmp/jextract \
+    jextract:latest \
+    -I /tmp/jextract \
+    --source \
+    -l libfoo \
+    --output /tmp/jextract/generated \
+    --target-package com.example \
+    /tmp/jextract/sample.h
+```
 
 > <details><summary><strong>Using a local installation of LLVM</strong></summary>
 > 


### PR DESCRIPTION
As title says, adds a Dockerfile that will fetch all necessary deps and build `jextract` for you on Ubuntu 22.10

It would be nice if some official JDK organization could put this on their Dockerhub, so that users could just do:

```sh
$ docker run --rm -it openjdk/jextract:latest
```

I've pushed it to my personal Dockerhub, so if anyone would like to test it out, you can use the README directions but prepend `gavinray/` before the image name:

```sh
$ echo "struct Foo { int a; long b; }; int use_foo(struct Foo foo);" >> sample.h

$ docker run --rm -it -v ${PWD}:/tmp/jextract \
    gavinray/jextract:latest \
    -I /tmp/jextract \
    --source \
    -l libfoo \
    --output /tmp/jextract/generated \
    --target-package com.example \
    /tmp/jextract/sample.h

$ tree ./generated
generated/
└── com
    └── example
        ├── Constants$root.java
        ├── Foo.java
        ├── RuntimeHelper.java
        ├── constants$0.java
        └── sample_h.java
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/74/head:pull/74` \
`$ git checkout pull/74`

Update a local copy of the PR: \
`$ git checkout pull/74` \
`$ git pull https://git.openjdk.org/jextract.git pull/74/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 74`

View PR using the GUI difftool: \
`$ git pr show -t 74`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/74.diff">https://git.openjdk.org/jextract/pull/74.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/74#issuecomment-1264033814)