### PR TITLE
added a note on JDK version to use for Gradle build.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,7 @@
 `jextract` can be built using `gradle`, as follows (on Windows, `gradlew.bat` should be used instead).
 
 (**Note**: Run the Gradle build with a Java version appropriate for the Gradle version. For example, Gradle 7.5.1
-supports JDK 18. Please checkout the Gradle release notes page for the appropate JDK version needed for
-builds)
+supports JDK 18. Please checkout the [Gradle compatibility matrix](https://docs.gradle.org/current/userguide/compatibility.html#java) for the appropate JDK version needed for builds)
 
 
 


### PR DESCRIPTION
Added missing note to README.md on JDK version required for Gradle version.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract pull/75/head:pull/75` \
`$ git checkout pull/75`

Update a local copy of the PR: \
`$ git checkout pull/75` \
`$ git pull https://git.openjdk.org/jextract pull/75/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 75`

View PR using the GUI difftool: \
`$ git pr show -t 75`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/75.diff">https://git.openjdk.org/jextract/pull/75.diff</a>

</details>
