### PR TITLE
7903335: jextract test TestSplit.java fails

### DIFF
--- a/src/main/java/org/openjdk/jextract/impl/ToplevelBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/ToplevelBuilder.java
@@ -174,8 +174,13 @@ class ToplevelBuilder extends JavaSourceBuilder {
         }
 
         @Override
-        String mods() {
-            return "final ";
+        boolean isClassFinal() {
+            return false;
+        }
+
+        @Override
+        void emitConstructor() {
+            // None...
         }
     }
 
@@ -183,11 +188,6 @@ class ToplevelBuilder extends JavaSourceBuilder {
 
         FirstHeader(String name) {
             super(name, "#{SUPER}");
-        }
-
-        @Override
-        String mods() {
-            return "public final ";
         }
 
         @Override


### PR DESCRIPTION
making class final and constructors private breaks header split classes. Turning off these for split header classes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Issue
 * [CODETOOLS-7903335](https://bugs.openjdk.org/browse/CODETOOLS-7903335): jextract test TestSplit.java fails


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract pull/79/head:pull/79` \
`$ git checkout pull/79`

Update a local copy of the PR: \
`$ git checkout pull/79` \
`$ git pull https://git.openjdk.org/jextract pull/79/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 79`

View PR using the GUI difftool: \
`$ git pr show -t 79`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/79.diff">https://git.openjdk.org/jextract/pull/79.diff</a>

</details>
