### PR TITLE
7903339: unsigned typedefs are not extracted

### DIFF
--- a/src/main/java/org/openjdk/jextract/impl/OutputFactory.java
+++ b/src/main/java/org/openjdk/jextract/impl/OutputFactory.java
@@ -310,6 +310,18 @@ public class OutputFactory implements Declaration.Visitor<Void, Declaration> {
         }
     }
 
+    Type.Primitive getAsSignedOrUnsigned(Type type) {
+        if (type instanceof Type.Delegated delegated &&
+            delegated.type() instanceof Type.Primitive primitive) {
+            var kind = delegated.kind();
+            if (kind == Type.Delegated.Kind.SIGNED ||
+                kind == Type.Delegated.Kind.UNSIGNED) {
+                return primitive;
+            }
+        }
+        return null;
+    }
+
     @Override
     public Void visitTypedef(Declaration.Typedef tree, Declaration parent) {
         if (!includeHelper.isIncluded(tree)) {
@@ -350,7 +362,7 @@ public class OutputFactory implements Declaration.Visitor<Void, Declaration> {
                 }
             }
         } else if (type instanceof Type.Primitive) {
-             toplevelBuilder.addTypedef(tree.name(), null, type);
+            toplevelBuilder.addTypedef(tree.name(), null, type);
         } else {
             Type.Function func = getAsFunctionPointer(type);
             if (func != null) {
@@ -360,6 +372,11 @@ public class OutputFactory implements Declaration.Visitor<Void, Declaration> {
                 }
             } else if (((TypeImpl)type).isPointer()) {
                 toplevelBuilder.addTypedef(tree.name(), null, type);
+            } else {
+                Type.Primitive primitive = getAsSignedOrUnsigned(type);
+                if (primitive != null) {
+                    toplevelBuilder.addTypedef(tree.name(), null, primitive);
+                }
             }
         }
         return null;

--- a/test/testng/org/openjdk/jextract/test/toolprovider/Test7903339.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/Test7903339.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package org.openjdk.jextract.test.toolprovider;
+
+import java.nio.file.Path;
+
+import testlib.TestUtils;
+import org.testng.annotations.Test;
+import testlib.JextractToolRunner;
+
+import static org.testng.Assert.assertNotNull;
+
+public class Test7903339 extends JextractToolRunner {
+    @Test
+    public void testPrimitiveTypedefs() {
+        Path test7903339Output = getOutputFilePath("test7903339gen");
+        Path test7903339H = getInputFilePath("test7903339.h");
+        run("--output", test7903339Output.toString(), test7903339H.toString()).checkSuccess();
+        try(TestUtils.Loader loader = TestUtils.classLoader(test7903339Output)) {
+            Class<?> headerCls = loader.loadClass("test7903339_h");
+            assertNotNull(findField(headerCls, "S_SHORT"));
+            assertNotNull(findField(headerCls, "U_SHORT"));
+            assertNotNull(findField(headerCls, "S_INT"));
+            assertNotNull(findField(headerCls, "U_INT"));
+            assertNotNull(findField(headerCls, "S_LONG"));
+            assertNotNull(findField(headerCls, "U_LONG"));
+            assertNotNull(findField(headerCls, "S_LONG_LONG"));
+            assertNotNull(findField(headerCls, "U_LONG_LONG"));
+            assertNotNull(findField(headerCls, "SIGNED"));
+            assertNotNull(findField(headerCls, "UNSIGNED"));
+        } finally {
+            TestUtils.deleteDir(test7903339Output);
+        }
+    }
+}

--- a/test/testng/org/openjdk/jextract/test/toolprovider/test7903339.h
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/test7903339.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+typedef signed short S_SHORT;
+typedef unsigned short U_SHORT;
+typedef signed int S_INT;
+typedef unsigned int U_INT;
+typedef signed S_LONG;
+typedef unsigned long U_LONG;
+typedef signed long long S_LONG_LONG;
+typedef unsigned long long U_LONG_LONG;
+typedef signed SIGNED;
+typedef unsigned UNSIGNED;


### PR DESCRIPTION
unsigned, signed primitive types were not handled in OutputFactory.visitTypedef.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Issue
 * [CODETOOLS-7903339](https://bugs.openjdk.org/browse/CODETOOLS-7903339): unsigned typedefs are not extracted


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract pull/80/head:pull/80` \
`$ git checkout pull/80`

Update a local copy of the PR: \
`$ git checkout pull/80` \
`$ git pull https://git.openjdk.org/jextract pull/80/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 80`

View PR using the GUI difftool: \
`$ git pr show -t 80`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/80.diff">https://git.openjdk.org/jextract/pull/80.diff</a>

</details>
