### PR TITLE
7903347: add long name option for all single letter options and expand help on default values for various options

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ A complete list of all the supported options is given below:
 | `-D --define-macro <macro>=<value>`                          | define <macro> to <value> (or 1 if <value> omitted)          |
 | `--header-class-name <name>`                                 | name of the generated header class. If this option is not specified, then header class name is derived from the header file name. For example, class "foo_h" for header "foo.h". |
 | `-t, --target-package <package>`                             | target package name for the generated classes. If this option is not specified, then unnamed package is used.  |
-| `-I, --include-dir <dir>`                                    | add directory to the end of the list of include search paths |
+| `-I, --include-dir <dir>`                                    | append directory to the include search paths. Include search paths are searched in order. For example, if `-I foo -I bar` is specified, header files will be searched in "foo" first, then (if nothing is found) in "bar".|
 | `-l, --library <name \| path>`                               | specify a library by platform-independent name (e.g. "GL") or by absolute path ("/usr/lib/libGL.so") that will be loaded by the generated class. |
 | `--output <path>`                                            | specify where to place generated files                       |
 | `--source`                                                   | generate java sources instead of classfiles                  |

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ In other words, the `jextract` tool has generated all the required supporting co
 
 #### Command line options
 
-The `jextract` tool includes several customization options. Users can select in which package the generated code should be emitted, and what the name of the main extracted class should be. If no package is specified, classes are generated in unnamed package. If no name is specified for the main header class, then header class name is
+The `jextract` tool includes several customization options. Users can select in which package the generated code should be emitted, and what the name of the main extracted class should be. If no package is specified, classes are generated in the unnamed package. If no name is specified for the main header class, then the header class name is
 derived from the header file name. For example, if jextract is run on foo.h, then foo_h will be the name of the main header class.
 
 A complete list of all the supported options is given below:

--- a/README.md
+++ b/README.md
@@ -127,15 +127,19 @@ In other words, the `jextract` tool has generated all the required supporting co
 
 #### Command line options
 
-The `jextract` tool includes several customization options. Users can select in which package the generated code should be emitted, and what the name of the main extracted class should be. A complete list of all the supported options is given below:
+The `jextract` tool includes several customization options. Users can select in which package the generated code should be emitted, and what the name of the main extracted class should be. If no package is specified, classes are generated in unnamed package. If no name is specified for the main header class, then header class name is
+derived from the header file name. For example, if jextract is run on foo.h, then foo_h will be the name of the main header class.
+
+A complete list of all the supported options is given below:
 
 | Option                                                       | Meaning                                                      |
 | :----------------------------------------------------------- | ------------------------------------------------------------ |
-| `-D <macro>`                                                 | define a C preprocessor macro                                |
+| `-D --define-macro <macro>=<value>`                          |  define <macro> to <value> (or 1 if <value> omitted)         |
 | `--header-class-name <name>`                                 | specify the name of the main header class                    |
 | `-t, --target-package <package>`                             | specify target package for the generated bindings            |
-| `-I <path>`                                                  | specify include files path for the clang parser              |
-| `-l <library>`                                               | specify a library that will be loaded by the generated bindings |
+| `-I, --include-dir <dir>`                                    | add directory to the end of the list of include search paths |
+| `-I <dir>`                                                   | add directory to the end of the list of include search paths |
+| `-l, --library <library>`                                    | specify a library that will be loaded by the generated bindings |
 | `--output <path>`                                            | specify where to place generated files                       |
 | `--source`                                                   | generate java sources instead of classfiles                  |
 | `--dump-includes <String>`                                   | dump included symbols into specified file (see below)        |

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ A complete list of all the supported options is given below:
 | Option                                                       | Meaning                                                      |
 | :----------------------------------------------------------- | ------------------------------------------------------------ |
 | `-D --define-macro <macro>=<value>`                          | define <macro> to <value> (or 1 if <value> omitted)          |
-| `--header-class-name <name>`                                 | name of the generated header class. If this option is not specified, then header class name is derived from the header file name. For example, class 'foo_h' for header 'foo.h'. |
+| `--header-class-name <name>`                                 | name of the generated header class. If this option is not specified, then header class name is derived from the header file name. For example, class "foo_h" for header "foo.h". |
 | `-t, --target-package <package>`                             | target package name for the generated classes. If this option is not specified, then unnamed package is used.  |
 | `-I, --include-dir <dir>`                                    | add directory to the end of the list of include search paths |
 | `-l, --library <name \| path>`                               | specify a library by platform-independent name (e.g. "GL") or by absolute path ("/usr/lib/libGL.so") that will be loaded by the generated class. |

--- a/README.md
+++ b/README.md
@@ -134,12 +134,11 @@ A complete list of all the supported options is given below:
 
 | Option                                                       | Meaning                                                      |
 | :----------------------------------------------------------- | ------------------------------------------------------------ |
-| `-D --define-macro <macro>=<value>`                          |  define <macro> to <value> (or 1 if <value> omitted)         |
-| `--header-class-name <name>`                                 | specify the name of the main header class                    |
-| `-t, --target-package <package>`                             | specify target package for the generated bindings            |
+| `-D --define-macro <macro>=<value>`                          | define <macro> to <value> (or 1 if <value> omitted)          |
+| `--header-class-name <name>`                                 | name of the generated header class. If this option is not specified, then header class name is derived from the header file name. For example, class 'foo_h' for header 'foo.h'. |
+| `-t, --target-package <package>`                             | target package name for the generated classes. If this option is not specified, then unnamed package is used.  |
 | `-I, --include-dir <dir>`                                    | add directory to the end of the list of include search paths |
-| `-I <dir>`                                                   | add directory to the end of the list of include search paths |
-| `-l, --library <library>`                                    | specify a library that will be loaded by the generated bindings |
+| `-l, --library <name \| path>`                               | specify a library by name or absolute path that will be loaded by the generated class. |
 | `--output <path>`                                            | specify where to place generated files                       |
 | `--source`                                                   | generate java sources instead of classfiles                  |
 | `--dump-includes <String>`                                   | dump included symbols into specified file (see below)        |

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ A complete list of all the supported options is given below:
 | `--header-class-name <name>`                                 | name of the generated header class. If this option is not specified, then header class name is derived from the header file name. For example, class 'foo_h' for header 'foo.h'. |
 | `-t, --target-package <package>`                             | target package name for the generated classes. If this option is not specified, then unnamed package is used.  |
 | `-I, --include-dir <dir>`                                    | add directory to the end of the list of include search paths |
-| `-l, --library <name \| path>`                               | specify a library by name or absolute path that will be loaded by the generated class. |
+| `-l, --library <name \| path>`                               | specify a library by platform-independent name (e.g. "GL") or by absolute path ("/usr/lib/libGL.so") that will be loaded by the generated class. |
 | `--output <path>`                                            | specify where to place generated files                       |
 | `--source`                                                   | generate java sources instead of classfiles                  |
 | `--dump-includes <String>`                                   | dump included symbols into specified file (see below)        |

--- a/src/main/java/org/openjdk/jextract/JextractTool.java
+++ b/src/main/java/org/openjdk/jextract/JextractTool.java
@@ -333,15 +333,15 @@ public final class JextractTool {
         }
 
         OptionParser parser = new OptionParser();
-        parser.accepts("-D", format("help.D"), true);
+        parser.accepts("-D", List.of("--define-macro"), format("help.D"), true);
         parser.accepts("--dump-includes", format("help.dump-includes"), true);
         for (IncludeHelper.IncludeKind includeKind : IncludeHelper.IncludeKind.values()) {
             parser.accepts("--" + includeKind.optionName(), format("help." + includeKind.optionName()), true);
         }
         parser.accepts("-h", List.of("-?", "--help"), format("help.h"), false);
         parser.accepts("--header-class-name", format("help.header-class-name"), true);
-        parser.accepts("-I", format("help.I"), true);
-        parser.accepts("-l", format("help.l"), true);
+        parser.accepts("-I", List.of("--include-dir"), format("help.I"), true);
+        parser.accepts("-l", List.of("--library"), format("help.l"), true);
         parser.accepts("--output", format("help.output"), true);
         parser.accepts("--source", format("help.source"), false);
         parser.accepts("-t", List.of("--target-package"), format("help.t"), true);

--- a/src/main/resources/org/openjdk/jextract/impl/resources/Messages.properties
+++ b/src/main/resources/org/openjdk/jextract/impl/resources/Messages.properties
@@ -54,18 +54,20 @@ Option                             Description                                  
 -D --define-macro <macro>=<value>  define <macro> to <value> (or 1 if <value> omitted)          \n\
 -I, --include-dir <dir>            add directory to the end of the list of include search paths \n\
 --dump-includes <file>             dump included symbols into specified file                    \n\
---header-class-name <name>         name of the header class. If this option is not specified,   \n\
-\                                   then header class name for header 'foo.h' is 'foo_h'.       \n\
+--header-class-name <name>         name of the generated header class. If this option is not    \n\
+\                                   specified, then header class name is derived from the header\n\
+\                                   file name. For example, class 'foo_h' for header 'foo.h'.   \n\
 --include-function <name>          name of function to include                                  \n\
 --include-macro <name>             name of constant macro to include                            \n\
 --include-struct <name>            name of struct definition to include                         \n\
 --include-typedef <name>           name of type definition to include                           \n\
 --include-union <name>             name of union definition to include                          \n\
 --include-var <name>               name of global variable to include                           \n\
--l, --library <library>            specify a library name or absolute library path              \n\
+-l, --library <name | path>        specify a library by name or absolute path that will be      \n\
+\                                   loaded by the generated class.                              \n\
 --output <path>                    specify the directory to place generated files. If this      \n\
 \                                   option is not specified, then current directory is used.    \n\
 --source                           generate java sources                                        \n\
--t, --target-package <package>     target package for specified header files. If this option is \n\
-\                                   not specified, then unnamed package is used.                \n\
+-t, --target-package <package>     target package name for the generated classes. If this option\n\
+\                                   is not specified, then unnamed package is used.             \n\
 --version                          print version information and exit                           \n

--- a/src/main/resources/org/openjdk/jextract/impl/resources/Messages.properties
+++ b/src/main/resources/org/openjdk/jextract/impl/resources/Messages.properties
@@ -56,7 +56,7 @@ Option                             Description                                  
 --dump-includes <file>             dump included symbols into specified file                    \n\
 --header-class-name <name>         name of the generated header class. If this option is not    \n\
 \                                   specified, then header class name is derived from the header\n\
-\                                   file name. For example, class 'foo_h' for header 'foo.h'.   \n\
+\                                   file name. For example, class "foo_h" for header "foo.h".   \n\
 --include-function <name>          name of function to include                                  \n\
 --include-macro <name>             name of constant macro to include                            \n\
 --include-struct <name>            name of struct definition to include                         \n\

--- a/src/main/resources/org/openjdk/jextract/impl/resources/Messages.properties
+++ b/src/main/resources/org/openjdk/jextract/impl/resources/Messages.properties
@@ -46,23 +46,26 @@ help.t=target package for specified header files
 help.version=print version information and exit
 help.non.option=header file
 jextract.usage=\
-Usage: jextract <options> <header file>                                  \n\
-                                                                         \n\
-Option                         Description                               \n\
-------                         -----------                               \n\
--?, -h, --help                 print help                                \n\
--D <macro>                     define a C preprocessor macro             \n\
--I <path>                      specify include files path                \n\
---dump-includes <file>         dump included symbols into specified file \n\
---header-class-name <name>     name of the header class                  \n\
---include-function <name>      name of function to include               \n\
---include-macro <name>         name of constant macro to include         \n\
---include-struct <name>        name of struct definition to include      \n\
---include-typedef <name>       name of type definition to include        \n\
---include-union <name>         name of union definition to include       \n\
---include-var <name>           name of global variable to include        \n\
--l <library>                   specify a library name or absolute library path   \n\
---output <path>                specify the directory to place generated files    \n\
---source                       generate java sources                     \n\
--t, --target-package <package> target package for specified header files \n\
---version                      print version information and exit        \n
+Usage: jextract <options> <header file>                                                         \n\
+                                                                                                \n\
+Option                             Description                                                  \n\
+------                             -----------                                                  \n\
+-?, -h, --help                     print help                                                   \n\
+-D --define-macro <macro>=<value>  define <macro> to <value> (or 1 if <value> omitted)          \n\
+-I, --include-dir <dir>            add directory to the end of the list of include search paths \n\
+--dump-includes <file>             dump included symbols into specified file                    \n\
+--header-class-name <name>         name of the header class. If this option is not specified,   \n\
+\                                   then header class name for header 'foo.h' is 'foo_h'.       \n\
+--include-function <name>          name of function to include                                  \n\
+--include-macro <name>             name of constant macro to include                            \n\
+--include-struct <name>            name of struct definition to include                         \n\
+--include-typedef <name>           name of type definition to include                           \n\
+--include-union <name>             name of union definition to include                          \n\
+--include-var <name>               name of global variable to include                           \n\
+-l, --library <library>            specify a library name or absolute library path              \n\
+--output <path>                    specify the directory to place generated files. If this      \n\
+\                                   option is not specified, then current directory is used.    \n\
+--source                           generate java sources                                        \n\
+-t, --target-package <package>     target package for specified header files. If this option is \n\
+\                                   not specified, then unnamed package is used.                \n\
+--version                          print version information and exit                           \n

--- a/src/main/resources/org/openjdk/jextract/impl/resources/Messages.properties
+++ b/src/main/resources/org/openjdk/jextract/impl/resources/Messages.properties
@@ -63,7 +63,8 @@ Option                             Description                                  
 --include-typedef <name>           name of type definition to include                           \n\
 --include-union <name>             name of union definition to include                          \n\
 --include-var <name>               name of global variable to include                           \n\
--l, --library <name | path>        specify a library by name or absolute path that will be      \n\
+-l, --library <name | path>        specify a library by platform-independent name (e.g. "GL")   \n\
+\                                   or by absolute path ("/usr/lib/libGL.so") that will be      \n\
 \                                   loaded by the generated class.                              \n\
 --output <path>                    specify the directory to place generated files. If this      \n\
 \                                   option is not specified, then current directory is used.    \n\

--- a/test/jtreg/generator/test7903347/LibTest7903347Test.java
+++ b/test/jtreg/generator/test7903347/LibTest7903347Test.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import org.testng.annotations.Test;
+import static test.jextract.test7903347.test7903347_h.*;
+
+/*
+ * @test id=classes
+ * @bug 7903347
+ * @summary add long name option for all single letter options and expand help on default values for various options
+ * @library /lib
+ * @run main/othervm JtregJextract --library Test7903347 -t test.jextract.test7903347 test7903347.h
+ * @run testng/othervm --enable-native-access=ALL-UNNAMED LibTest7903347Test
+ */
+/*
+ * @test id=sources
+ * @bug 7903347
+ * @summary add long name option for all single letter options and expand help on default values for various options
+ * @library /lib
+ * @run main/othervm JtregJextractSources --library Test7903347 -t test.jextract.test7903347 test7903347.h
+ * @run testng/othervm --enable-native-access=ALL-UNNAMED LibTest7903347Test
+ */
+public class LibTest7903347Test {
+    @Test
+    public void test() {
+        print_point(34, 56);
+    }
+}

--- a/test/jtreg/generator/test7903347/libTest7903347.c
+++ b/test/jtreg/generator/test7903347/libTest7903347.c
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include "test7903347.h"
+#include <stdio.h>
+
+EXPORT void print_point(int x, int y) {
+   printf("(%d\t%d)\n", x, y);
+}

--- a/test/jtreg/generator/test7903347/test7903347.h
+++ b/test/jtreg/generator/test7903347/test7903347.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+#ifdef _WIN64
+#define EXPORT __declspec(dllexport)
+#else
+#define EXPORT
+#endif
+
+EXPORT void print_point(int x, int y);
+
+#ifdef __cplusplus
+}
+#endif // __cplusplus

--- a/test/testng/org/openjdk/jextract/test/toolprovider/JextractToolProviderTest.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/JextractToolProviderTest.java
@@ -175,4 +175,34 @@ public class JextractToolProviderTest extends JextractToolRunner {
             TestUtils.deleteDir(helloOutput);
         }
     }
+
+    @Test
+    public void tesIncludeDirOption() {
+        Path includerOutput = getOutputFilePath("includergen");
+        Path includerH = getInputFilePath("includer.h");
+        run("-I", includerH.getParent().resolve("inc").toString(),
+            "--output", includerOutput.toString(), includerH.toString()).checkSuccess();
+        try(TestUtils.Loader loader = TestUtils.classLoader(includerOutput)) {
+            Class<?> cls = loader.loadClass("includer_h");
+            // check a method for "void included_func(int)"
+            assertNotNull(findMethod(cls, "included_func", int.class));
+        } finally {
+            TestUtils.deleteDir(includerOutput);
+        }
+    }
+
+    @Test
+    public void tesIncludeDirOption2() {
+        Path includerOutput = getOutputFilePath("includergen2");
+        Path includerH = getInputFilePath("includer.h");
+        run("--include-dir", includerH.getParent().resolve("inc").toString(),
+            "--output", includerOutput.toString(), includerH.toString()).checkSuccess();
+        try(TestUtils.Loader loader = TestUtils.classLoader(includerOutput)) {
+            Class<?> cls = loader.loadClass("includer_h");
+            // check a method for "void included_func(int)"
+            assertNotNull(findMethod(cls, "included_func", int.class));
+        } finally {
+            TestUtils.deleteDir(includerOutput);
+        }
+    }
 }

--- a/test/testng/org/openjdk/jextract/test/toolprovider/Test7903164.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/Test7903164.java
@@ -58,4 +58,18 @@ public class Test7903164 extends JextractToolRunner {
             TestUtils.deleteDir(output);
         }
     }
+
+    @Test
+    public void testWithMacro2() {
+        Path output = getOutputFilePath("7903164gen_withmacro2");
+        Path outputH = getInputFilePath("test7903164.h");
+        run("--define-macro", "FOO", "--output", output.toString(), outputH.toString()).checkSuccess();
+        try(TestUtils.Loader loader = TestUtils.classLoader(output)) {
+            assertNotNull(loader.loadClass("test7903164_h"));
+            assertNotNull(loader.loadClass("func"));
+            assertNotNull(loader.loadClass("func2"));
+        } finally {
+            TestUtils.deleteDir(output);
+        }
+    }
 }

--- a/test/testng/org/openjdk/jextract/test/toolprovider/inc/includer_impl.h
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/inc/includer_impl.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+void included_func(int);

--- a/test/testng/org/openjdk/jextract/test/toolprovider/includer.h
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/includer.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include "includer_impl.h"


### PR DESCRIPTION
* long option names for -I, -l, -D (--include-dir, --library, --define-macro)
* documented default values for header class name, target package and output directory
* explanation for -l / --library option.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Issue
 * [CODETOOLS-7903347](https://bugs.openjdk.org/browse/CODETOOLS-7903347): add long name option for all single letter options and expand help on default values for various options


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - no project role) ⚠️ Review applies to [560ec003](https://git.openjdk.org/jextract/pull/83/files/560ec003ac4f813c8d42066376f1e4f20cd993af)
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - Committer) ⚠️ Review applies to [a4b74767](https://git.openjdk.org/jextract/pull/83/files/a4b74767340d3649090348be418c553ba1083322)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract pull/83/head:pull/83` \
`$ git checkout pull/83`

Update a local copy of the PR: \
`$ git checkout pull/83` \
`$ git pull https://git.openjdk.org/jextract pull/83/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 83`

View PR using the GUI difftool: \
`$ git pr show -t 83`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/83.diff">https://git.openjdk.org/jextract/pull/83.diff</a>

</details>
