### PR TITLE
7903257: jextract should generate javadoc comments

### DIFF
--- a/samples/libffmpeg/compilesource.sh
+++ b/samples/libffmpeg/compilesource.sh
@@ -1,6 +1,6 @@
 jextract --source -t libffmpeg \
   -I /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include \
-  -I /usr/local/Cellar/ffmpeg@4/4.4.2_3/include \
+  -I /usr/local/Cellar/ffmpeg@4/4.4.2_4/include \
   -l avcodec \
   -l avformat \
   -l avutil \

--- a/src/main/java/org/openjdk/jextract/impl/CDeclarationPrinter.java
+++ b/src/main/java/org/openjdk/jextract/impl/CDeclarationPrinter.java
@@ -197,6 +197,8 @@ final class CDeclarationPrinter implements Declaration.Visitor<Void, Void> {
                     return prefixedType("signed", t);
                 case VOLATILE:
                     return prefixedType("volatile", t);
+                case COMPLEX:
+                    return prefixedType("complex", t);
                 case default:
                     return new TypeVisitorResult(false, t.name().get());
             }

--- a/src/main/java/org/openjdk/jextract/impl/CDeclarationPrinter.java
+++ b/src/main/java/org/openjdk/jextract/impl/CDeclarationPrinter.java
@@ -1,0 +1,257 @@
+/*
+ *  Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ *  This code is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License version 2 only, as
+ *  published by the Free Software Foundation.  Oracle designates this
+ *  particular file as subject to the "Classpath" exception as provided
+ *  by Oracle in the LICENSE file that accompanied this code.
+ *
+ *  This code is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ *  version 2 for more details (a copy is included in the LICENSE file that
+ *  accompanied this code).
+ *
+ *  You should have received a copy of the GNU General Public License version
+ *  2 along with this work; if not, write to the Free Software Foundation,
+ *  Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *   Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ *  or visit www.oracle.com if you need additional information or have any
+ *  questions.
+ *
+ */
+
+package org.openjdk.jextract.impl;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import org.openjdk.jextract.Declaration;
+import org.openjdk.jextract.Type;
+
+final class CDeclarationPrinter implements Declaration.Visitor<Void, Void> {
+    private static String SPACES = " ".repeat(92);
+    private int align = 0;
+    private String prefix;
+
+    private void incr() {
+        align += 4;
+    }
+
+    private void decr() {
+        align -= 4;
+    }
+
+    private CDeclarationPrinter(String prefix) {
+        this.prefix = prefix;
+    }
+
+    private void indent() {
+        builder.append(prefix);
+        builder.append(SPACES.substring(0, align));
+    }
+
+    private final StringBuilder builder = new StringBuilder();
+
+    private String print(Declaration decl) {
+        decl.accept(this, null);
+        return builder.toString();
+    }
+
+    // Return C source style signature for the given declaration.
+    // The prefix is emitted for every line. This can be used
+    // to prefix per line comment character "*" in generated javadoc.
+    static String declaration(Declaration decl, String prefix) {
+        Objects.requireNonNull(decl);
+        Objects.requireNonNull(prefix);
+        return new CDeclarationPrinter(prefix).print(decl);
+    }
+
+    static String declaration(Type.Function funcType, String name) {
+        return nameAndType(funcType, "*" + name);
+    }
+
+    @Override
+    public Void visitScoped(Declaration.Scoped d, Void ignored) {
+        indent();
+        var tag = typeTag(d);
+        if (!tag.isEmpty()) {
+            builder.append(tag);
+            if (!d.name().isEmpty()) {
+                builder.append(" " + d.name());
+            }
+            builder.append(" {");
+            builder.append("\n");
+            incr();
+        }
+        d.members().forEach(m -> m.accept(this, null));
+        if (!tag.isEmpty()) {
+            decr();
+            indent();
+            builder.append("};\n");
+        }
+        return null;
+    }
+
+    @Override
+    public Void visitFunction(Declaration.Function d, Void ignored) {
+        indent();
+        var ftype = d.type();
+        var rtype = ftype.returnType();
+        builder.append(nameAndType(rtype, ""));
+        builder.append(" ");
+        builder.append(d.name());
+        builder.append("(");
+        builder.append(
+            d.parameters().
+                stream().
+                map(p -> nameAndType(p.type(), p.name())).
+                collect(Collectors.joining(", "))
+        );
+        if (d.type().varargs()) {
+            builder.append(",...");
+        }
+        builder.append(");\n");
+        return null;
+    }
+
+    @Override
+    public Void visitVariable(Declaration.Variable d, Void ignored) {
+        indent();
+        builder.append(nameAndType(d.type(), d.name()));
+        builder.append(";\n");
+        return null;
+    }
+
+    @Override
+    public Void visitConstant(Declaration.Constant d, Void ignored) {
+        indent();
+        builder.append(nameAndType(d.type(), d.name()));
+        builder.append(" = ");
+        Object value = d.value();
+        if (value instanceof String str) {
+            builder.append("\"" + Utils.quote(str) + "\"");
+        } else {
+            builder.append(value);
+        }
+        builder.append(";\n");
+        return null;
+    }
+
+    @Override
+    public Void visitTypedef(Declaration.Typedef d, Void ignored) {
+        indent();
+        builder.append("typedef ");
+        builder.append(nameAndType(d.type(), d.name()));
+        builder.append(";\n");
+        return null;
+    }
+
+    // In few cases, C type signature 'embeds' name.
+    // Examples:
+    //     int a[3]; // 'a' in between int and []
+    //     int (*func)(int); // 'func' is inside paren after '*'
+    // TypeVisitor accepts name and includes it in the appropriate
+    // place as needed. If not included, boolean flag is set to false
+    // in the result.
+
+    private static String nameAndType(Type type, String name) {
+        var result = type.accept(typeVisitor, name);
+        var typeStr = result.typeStr();
+        return result.nameIncluded() || name.isEmpty() ?
+            typeStr : (typeStr + " " + name);
+    }
+
+    // result type for Type.Visitor
+    private record TypeVisitorResult(boolean nameIncluded, String typeStr) {}
+
+    private static Type.Visitor<TypeVisitorResult, String> typeVisitor = new Type.Visitor<>() {
+        @Override
+        public TypeVisitorResult visitPrimitive(Type.Primitive t, String context) {
+            return new TypeVisitorResult(false, t.kind().typeName());
+        }
+
+        private TypeVisitorResult prefixedType(String prefix, Type.Delegated delegated) {
+            return new TypeVisitorResult(false,
+                    prefix + " " + delegated.type().accept(this, "").typeStr());
+        }
+
+        @Override
+        public TypeVisitorResult visitDelegated(Type.Delegated t, String context) {
+            switch (t.kind()) {
+                case POINTER: {
+                    var result = t.type().accept(this, "*" + context);
+                    if (result.nameIncluded()) {
+                        return new TypeVisitorResult(true, result.typeStr());
+                    } else {
+                        return new TypeVisitorResult(false, result.typeStr() + "*");
+                    }
+                }
+                case UNSIGNED:
+                    return prefixedType("unsigned", t);
+                case SIGNED:
+                    return prefixedType("signed", t);
+                case VOLATILE:
+                    return prefixedType("volatile", t);
+                case default:
+                    return new TypeVisitorResult(false, t.name().get());
+            }
+        }
+
+        @Override
+        public TypeVisitorResult visitFunction(Type.Function t, String context) {
+            String argsStr;
+            // Function type may optionally have parameter names.
+            // Include parameter names if available.
+            var optParameterNames = t.parameterNames();
+            if (optParameterNames.isPresent()) {
+                List<Type> argTypes = t.argumentTypes();
+                List<String> argNames = optParameterNames.get();
+                int numArgs = argTypes.size();
+                List<String> args = new ArrayList<>(numArgs);
+                for (int i = 0; i < numArgs; i++) {
+                    args.add(nameAndType(argTypes.get(i), argNames.get(i)));
+                }
+                argsStr = args.stream()
+                    .collect(Collectors.joining(",", "(", ")"));
+            } else {
+                argsStr = t.argumentTypes().stream()
+                    .map(a -> a.accept(this, "").typeStr())
+                    .collect(Collectors.joining(",", "(", ")"));
+            }
+            String res = t.returnType().accept(this, "").typeStr();
+            return new TypeVisitorResult(true, res + " (" + context + ")" + argsStr);
+        }
+
+        @Override
+        public TypeVisitorResult visitDeclared(Type.Declared t, String context) {
+            Declaration.Scoped scoped = t.tree();
+            return new TypeVisitorResult(false, typeTag(scoped) + " " + scoped.name());
+        }
+
+        @Override
+        public TypeVisitorResult visitArray(Type.Array t, String context) {
+            String brackets = String.format(" %s[%s]", context,
+                t.elementCount().isPresent() ? t.elementCount().getAsLong() : "");
+            return new TypeVisitorResult(true, t.elementType().accept(this, "").typeStr() + brackets);
+        }
+
+        @Override
+        public TypeVisitorResult visitType(Type t, String context) {
+            return new TypeVisitorResult(false, t.getClass().getName());
+        }
+    };
+
+    private static String typeTag(Declaration.Scoped scoped) {
+        return switch (scoped.kind()) {
+            case STRUCT -> "struct";
+            case UNION -> "union";
+            case ENUM -> "enum";
+            default -> "";
+        };
+    }
+}

--- a/src/main/java/org/openjdk/jextract/impl/CDeclarationPrinter.java
+++ b/src/main/java/org/openjdk/jextract/impl/CDeclarationPrinter.java
@@ -200,7 +200,9 @@ final class CDeclarationPrinter implements Declaration.Visitor<Void, Void> {
                 case COMPLEX:
                     return prefixedType("complex", t);
                 case default:
-                    return new TypeVisitorResult(false, t.name().get());
+                    // defensive. If no name is present, we don't want to crash
+                    return new TypeVisitorResult(false,
+                        t.name().isPresent()? t.name().get() : t.toString());
             }
         }
 

--- a/src/main/java/org/openjdk/jextract/impl/ClassSourceBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/ClassSourceBuilder.java
@@ -28,6 +28,8 @@ import javax.tools.JavaFileObject;
 import java.lang.constant.ClassDesc;
 import java.util.List;
 import java.util.function.Consumer;
+import org.openjdk.jextract.Declaration;
+import org.openjdk.jextract.Type;
 
 /**
  * Superclass for .java source generator classes.
@@ -106,6 +108,7 @@ abstract class ClassSourceBuilder extends JavaSourceBuilder {
         emitPackagePrefix();
         emitImportSection();
 
+        classDeclBegin();
         indent();
         append(mods());
         append(kind.kindName + " " + className());
@@ -118,6 +121,8 @@ abstract class ClassSourceBuilder extends JavaSourceBuilder {
             emitConstructor();
         }
     }
+
+    void classDeclBegin() {}
 
     void emitConstructor() {
         incrAlign();
@@ -187,6 +192,35 @@ abstract class ClassSourceBuilder extends JavaSourceBuilder {
     String build() {
         String s = sb.toString();
         return s;
+    }
+
+    void emitDocComment(Declaration decl) {
+        emitDocComment(decl, "");
+    }
+
+    void emitDocComment(Declaration decl, String header) {
+        indent();
+        append("/**\n");
+        if (!header.isEmpty()) {
+            indent();
+            append(" * ");
+            append(header);
+            append("\n");
+        }
+        append(CDeclarationPrinter.declaration(decl, " ".repeat(align*4) + " * "));
+        indent();
+        append(" */\n");
+    }
+
+    void emitDocComment(Type.Function funcType, String name) {
+        indent();
+        append("/**\n");
+        indent();
+        append(" * ");
+        append(CDeclarationPrinter.declaration(funcType, name));
+        append(";\n");
+        indent();
+        append(" */\n");
     }
 
     // is the name enclosed enclosed by a class of the same name?

--- a/src/main/java/org/openjdk/jextract/impl/ClassSourceBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/ClassSourceBuilder.java
@@ -207,7 +207,11 @@ abstract class ClassSourceBuilder extends JavaSourceBuilder {
             append(header);
             append("\n");
         }
+        indent();
+        append(" * {@snippet :\n");
         append(CDeclarationPrinter.declaration(decl, " ".repeat(align*4) + " * "));
+        indent();
+        append(" * }\n");
         indent();
         append(" */\n");
     }
@@ -216,9 +220,12 @@ abstract class ClassSourceBuilder extends JavaSourceBuilder {
         indent();
         append("/**\n");
         indent();
+        append(" * {@snippet :\n");
         append(" * ");
         append(CDeclarationPrinter.declaration(funcType, name));
         append(";\n");
+        indent();
+        append(" * }\n");
         indent();
         append(" */\n");
     }

--- a/src/main/java/org/openjdk/jextract/impl/EnumConstantLifter.java
+++ b/src/main/java/org/openjdk/jextract/impl/EnumConstantLifter.java
@@ -28,13 +28,20 @@ import org.openjdk.jextract.Declaration;
 import org.openjdk.jextract.Type;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 /*
  * This visitor lifts enum constants to the top level and removes enum Trees.
  */
 final class EnumConstantLifter implements TreeTransformer, Declaration.Visitor<Void, Void> {
+    private static final String ENUM_NAME = "enum-name";
+
     private final List<Declaration> decls = new ArrayList<>();
     EnumConstantLifter() {
+    }
+
+    static Optional<String> enumName(Declaration.Constant constant) {
+        return constant.getAttribute(ENUM_NAME).map(attrs -> attrs.get(0).toString());
     }
 
     @Override
@@ -76,7 +83,10 @@ final class EnumConstantLifter implements TreeTransformer, Declaration.Visitor<V
     private boolean liftEnumConstants(Declaration.Scoped scoped) {
         boolean isEnum = scoped.kind() == Declaration.Scoped.Kind.ENUM;
         if (isEnum) {
-            scoped.members().forEach(fieldTree -> fieldTree.accept(this, null));
+            // add the name of the enum as an attribute.
+            scoped.members().forEach(fieldTree -> fieldTree
+                .withAttribute(ENUM_NAME, scoped.name())
+                .accept(this, null));
         }
         return isEnum;
     }

--- a/src/main/java/org/openjdk/jextract/impl/FunctionalInterfaceBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/FunctionalInterfaceBuilder.java
@@ -41,6 +41,7 @@ public class FunctionalInterfaceBuilder extends ClassSourceBuilder {
 
     private static final String MEMBER_MODS = "static";
 
+    private final Type.Function funcType;
     private final MethodType fiType;
     private final MethodType downcallType;
     private final FunctionDescriptor fiDesc;
@@ -49,10 +50,16 @@ public class FunctionalInterfaceBuilder extends ClassSourceBuilder {
     FunctionalInterfaceBuilder(JavaSourceBuilder enclosing, Type.Function funcType, String className,
                                FunctionDescriptor descriptor, Optional<List<String>> parameterNames) {
         super(enclosing, Kind.INTERFACE, className);
+        this.funcType = funcType;
         this.fiType = descriptor.toMethodType();
         this.downcallType = descriptor.toMethodType();
         this.fiDesc = descriptor;
         this.parameterNames = parameterNames;
+    }
+
+    @Override
+    void classDeclBegin() {
+        emitDocComment(funcType, className());
     }
 
     @Override
@@ -64,7 +71,6 @@ public class FunctionalInterfaceBuilder extends ClassSourceBuilder {
     }
 
     // private generation
-
     private String parameterName(int i) {
         String name = "";
         if (parameterNames.isPresent()) {

--- a/src/main/java/org/openjdk/jextract/impl/StructBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/StructBuilder.java
@@ -48,15 +48,17 @@ class StructBuilder extends ConstantBuilder {
 
     private static final String MEMBER_MODS = "public static";
 
+    private final Declaration.Scoped structTree;
     private final GroupLayout structLayout;
     private final Type structType;
     private final Deque<String> prefixElementNames;
 
-    StructBuilder(JavaSourceBuilder enclosing, Declaration.Scoped tree,
+    StructBuilder(JavaSourceBuilder enclosing, Declaration.Scoped structTree,
         String name, GroupLayout structLayout) {
         super(enclosing, name);
+        this.structTree = structTree;
         this.structLayout = structLayout;
-        this.structType = Type.declared(tree);
+        this.structType = Type.declared(structTree);
         prefixElementNames = new ArrayDeque<>();
     }
 
@@ -84,6 +86,13 @@ class StructBuilder extends ConstantBuilder {
             super.classBegin();
             addLayout(layoutField(), ((Type.Declared) structType).tree().layout().orElseThrow())
                     .emitGetter(this, MEMBER_MODS, Constant.SUFFIX_ONLY);
+        }
+    }
+
+    @Override
+    void classDeclBegin() {
+        if (!inAnonymousNested()) {
+            emitDocComment(structTree);
         }
     }
 

--- a/src/main/java/org/openjdk/jextract/impl/StructBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/StructBuilder.java
@@ -154,7 +154,9 @@ class StructBuilder extends ConstantBuilder {
         } else if (layout instanceof ValueLayout valueLayout) {
             Constant vhConstant = addFieldVarHandle(javaName, nativeName, valueLayout, layoutField(), prefixNamesList())
                     .emitGetter(this, MEMBER_MODS, Constant.QUALIFIED_NAME);
+            emitFieldDocComment(varTree, "Getter for field:");
             emitFieldGetter(vhConstant, javaName, valueLayout.carrier());
+            emitFieldDocComment(varTree, "Setter for field:");
             emitFieldSetter(vhConstant, javaName, valueLayout.carrier());
             emitIndexedFieldGetter(vhConstant, javaName, valueLayout.carrier());
             emitIndexedFieldSetter(vhConstant, javaName, valueLayout.carrier());
@@ -162,6 +164,12 @@ class StructBuilder extends ConstantBuilder {
                 emitFunctionalInterfaceGetter(fiName.get(), javaName);
             }
         }
+    }
+
+    private void emitFieldDocComment(Declaration.Variable varTree, String header) {
+        incrAlign();
+        emitDocComment(varTree, header);
+        decrAlign();
     }
 
     private void emitFunctionalInterfaceGetter(String fiName, String javaName) {

--- a/src/main/java/org/openjdk/jextract/impl/ToplevelBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/ToplevelBuilder.java
@@ -115,12 +115,12 @@ class ToplevelBuilder extends JavaSourceBuilder {
         String superClass, Type type) {
         if (type instanceof Type.Primitive primitive) {
             // primitive
-            nextHeader().emitPrimitiveTypedef(primitive, javaName);
+            nextHeader().emitPrimitiveTypedef(typedefTree, primitive, javaName);
         } else if (((TypeImpl)type).isPointer()) {
             // pointer typedef
-            nextHeader().emitPointerTypedef(javaName);
+            nextHeader().emitPointerTypedef(typedefTree, javaName);
         } else {
-            TypedefBuilder builder = new TypedefBuilder(this, javaName, superClass);
+            TypedefBuilder builder = new TypedefBuilder(this, typedefTree, javaName, superClass);
             builders.add(builder);
             builder.classBegin();
             builder.classEnd();

--- a/src/main/java/org/openjdk/jextract/impl/TypedefBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/TypedefBuilder.java
@@ -25,18 +25,27 @@
 
 package org.openjdk.jextract.impl;
 
-public class TypedefBuilder extends ClassSourceBuilder {
+import org.openjdk.jextract.Declaration;
 
+public class TypedefBuilder extends ClassSourceBuilder {
+    private final Declaration.Typedef typedefTree;
     private final String superClass;
 
-    public TypedefBuilder(JavaSourceBuilder enclosing, String name, String superClass) {
+    public TypedefBuilder(JavaSourceBuilder enclosing,
+        Declaration.Typedef typedefTree, String name, String superClass) {
         super(enclosing, Kind.CLASS, name);
+        this.typedefTree = typedefTree;
         this.superClass = superClass;
     }
 
     @Override
     String superClass() {
         return superClass;
+    }
+
+    @Override
+    void classDeclBegin() {
+        emitDocComment(typedefTree);
     }
 
     @Override

--- a/test/testng/org/openjdk/jextract/test/toolprovider/Test7903257/TestDocComments.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/Test7903257/TestDocComments.java
@@ -114,14 +114,24 @@ public class TestDocComments extends JextractToolRunner {
     public void testStruct() throws IOException {
         var comments = getDocComments("structs.h", "Point.java");
         assertEquals(comments, List.of(
-            "struct Point { int x; int y; };"));
+            "struct Point { int x; int y; };",
+            "Getter for field: int x;",
+            "Setter for field: int x;",
+            "Getter for field: int y;",
+            "Setter for field: int y;"));
     }
 
     @Test
     public void testStruct2() throws IOException {
         var comments = getDocComments("structs.h", "Point3D.java");
         assertEquals(comments, List.of(
-            "struct Point3D { int x; int y; int z; };"));
+            "struct Point3D { int x; int y; int z; };",
+            "Getter for field: int x;",
+            "Setter for field: int x;",
+            "Getter for field: int y;",
+            "Setter for field: int y;",
+            "Getter for field: int z;",
+            "Setter for field: int z;"));
     }
 
     @Test

--- a/test/testng/org/openjdk/jextract/test/toolprovider/Test7903257/TestDocComments.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/Test7903257/TestDocComments.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package org.openjdk.jextract.test.toolprovider.Test7903257;
+
+import testlib.JextractToolRunner;
+import testlib.TestUtils;
+import org.testng.annotations.Test;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.regex.Pattern;
+import static org.testng.Assert.assertEquals;
+
+public class TestDocComments extends JextractToolRunner {
+    // Regular expression for javadoc comment text
+    //
+    //   (?s)     dot matches all including newlines
+    //   /\*\*    doc comment start
+    //   (.*?)    comment text as a group (reluctant match)
+    //   \*/      doc comment end
+    private static final Pattern JAVADOC_COMMENT = Pattern.compile("(?s)/\\*\\*(.*?)\\*/");
+
+    @Test
+    public void testMacros() throws IOException {
+        var comments = getDocComments("macros.h", "macros_h.java");
+        assertEquals(comments, Set.of(
+            "int FOO = 42;", "char* MSG = \"Hello\";"));
+    }
+
+    @Test
+    public void testEnumConstants() throws IOException {
+        var comments = getDocComments("enums.h", "enums_h.java");
+        assertEquals(comments, Set.of(
+            "int RED = 0;",
+            "int GREEN = 1;",
+            "int BLUE = 2;",
+            "int club = 1;",
+            "int diamonds = 2;",
+            "int hearts = 3;",
+            "int spades = 4;"));
+    }
+
+    @Test
+    public void testTypedefs() throws IOException {
+        var comments = getDocComments("typedefs.h", "typedefs_h.java");
+        assertEquals(comments, Set.of(
+            "typedef unsigned long size_t;",
+            "typedef int INT_32;",
+            "typedef int* INT_PTR;",
+            "typedef struct Foo* OPAQUE_PTR;"));
+    }
+
+    @Test
+    public void testArrays() throws IOException {
+        var comments = getDocComments("arrays.h", "arrays_h.java");
+        assertEquals(comments, Set.of(
+            "int abc[10];",
+            "float numbers[3];",
+            "char* msg[5];"));
+    }
+
+    @Test
+    public void testFunctions() throws IOException {
+        var comments = getDocComments("functions.h", "functions_h.java");
+        assertEquals(comments, Set.of(
+            "int func(int* fp);",
+            "double distance(struct Point p);",
+            "int printf(char* fmt,...);"));
+    }
+
+    @Test
+    public void testFunctionPointer() throws IOException {
+        var comments = getDocComments("funcptrs.h", "funcptr.java");
+        assertEquals(comments, Set.of(
+            "void (*funcptr)(int*,int);"
+        ));
+    }
+
+    @Test
+    public void testVariables() throws IOException {
+        var comments = getDocComments("variables.h", "variables_h.java");
+        assertEquals(comments, Set.of(
+            "Getter for variable: int abc;",
+            "Setter for variable: int abc;",
+            "Getter for variable: char* msg;",
+            "Setter for variable: char* msg;"
+        ));
+    }
+
+    @Test
+    public void testStruct() throws IOException {
+        var comments = getDocComments("structs.h", "Point.java");
+        assertEquals(comments, Set.of(
+            "struct Point { int x; int y; };"));
+    }
+
+    @Test
+    public void testStruct2() throws IOException {
+        var comments = getDocComments("structs.h", "Point3D.java");
+        assertEquals(comments, Set.of(
+            "struct Point3D { int x; int y; int z; };"));
+    }
+
+    @Test
+    public void testStructTypdef() throws IOException {
+        var comments = getDocComments("structs.h", "Point_t.java");
+        assertEquals(comments, Set.of(
+            "typedef struct Point Point_t;"));
+    }
+
+    private Set<String> getDocComments(String header, String outputFile)
+            throws IOException {
+        var output = getOutputFilePath("7903257-parse-" + header);
+        var outputH = getInputFilePath(header);
+        run("--source", "--output",
+            output.toString(), outputH.toString()).checkSuccess();
+        try {
+            return findDocComments(Files.readString(output.resolve(outputFile)));
+        } finally {
+            TestUtils.deleteDir(output);
+        }
+    }
+
+    // get doc comments from the given the source content
+    private static Set<String> findDocComments(String content) {
+        var matcher = JAVADOC_COMMENT.matcher(content);
+        var strings = new HashSet<String>();
+        while (matcher.find()) {
+            // doc comment text is matched in group 1
+            String rawComment = matcher.group(1);
+
+            // sanitize raw comment for test asserts
+            strings.add(rawComment
+                // remove \n followed by whitespaces and then *
+                .replaceAll("\n\\s+\\*", "")
+
+                // replace one or more whitespaces as single whitespace
+                .replaceAll("\\s+", " ")
+
+                // remove trailing and leading whitespaces
+                .trim());
+        }
+        return strings;
+    }
+}

--- a/test/testng/org/openjdk/jextract/test/toolprovider/Test7903257/TestDocComments.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/Test7903257/TestDocComments.java
@@ -47,20 +47,20 @@ public class TestDocComments extends JextractToolRunner {
     public void testMacros() throws IOException {
         var comments = getDocComments("macros.h", "macros_h.java");
         assertEquals(comments, Set.of(
-            "int FOO = 42;", "char* MSG = \"Hello\";"));
+            "#define FOO 42", "#define MSG \"Hello\""));
     }
 
     @Test
     public void testEnumConstants() throws IOException {
         var comments = getDocComments("enums.h", "enums_h.java");
         assertEquals(comments, Set.of(
-            "int RED = 0;",
-            "int GREEN = 1;",
-            "int BLUE = 2;",
-            "int club = 1;",
-            "int diamonds = 2;",
-            "int hearts = 3;",
-            "int spades = 4;"));
+            "enum Color.RED = 0;",
+            "enum Color.GREEN = 1;",
+            "enum Color.BLUE = 2;",
+            "enum Suit.club = 1;",
+            "enum Suit.diamonds = 2;",
+            "enum Suit.hearts = 3;",
+            "enum Suit.spades = 4;"));
     }
 
     @Test

--- a/test/testng/org/openjdk/jextract/test/toolprovider/Test7903257/TestDocComments.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/Test7903257/TestDocComments.java
@@ -157,10 +157,15 @@ public class TestDocComments extends JextractToolRunner {
                 // remove \n followed by whitespaces and then *
                 .replaceAll("\n\\s+\\*", "")
 
+                // get rid of "{@snippet :" prefix
+                .replaceAll("\\{@snippet :", "")
+
                 // replace one or more whitespaces as single whitespace
                 .replaceAll("\\s+", " ")
 
-                // remove trailing and leading whitespaces
+                // get rid of last "}" suffix closing the snippet
+                .replaceAll("\\s+}\\s+$", "")
+
                 .trim());
         }
         return strings;

--- a/test/testng/org/openjdk/jextract/test/toolprovider/Test7903257/TestDocComments.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/Test7903257/TestDocComments.java
@@ -29,8 +29,8 @@ import org.testng.annotations.Test;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.regex.Pattern;
 import static org.testng.Assert.assertEquals;
 
@@ -46,14 +46,14 @@ public class TestDocComments extends JextractToolRunner {
     @Test
     public void testMacros() throws IOException {
         var comments = getDocComments("macros.h", "macros_h.java");
-        assertEquals(comments, Set.of(
+        assertEquals(comments, List.of(
             "#define FOO 42", "#define MSG \"Hello\""));
     }
 
     @Test
     public void testEnumConstants() throws IOException {
         var comments = getDocComments("enums.h", "enums_h.java");
-        assertEquals(comments, Set.of(
+        assertEquals(comments, List.of(
             "enum Color.RED = 0;",
             "enum Color.GREEN = 1;",
             "enum Color.BLUE = 2;",
@@ -66,7 +66,7 @@ public class TestDocComments extends JextractToolRunner {
     @Test
     public void testTypedefs() throws IOException {
         var comments = getDocComments("typedefs.h", "typedefs_h.java");
-        assertEquals(comments, Set.of(
+        assertEquals(comments, List.of(
             "typedef unsigned long size_t;",
             "typedef int INT_32;",
             "typedef int* INT_PTR;",
@@ -76,7 +76,7 @@ public class TestDocComments extends JextractToolRunner {
     @Test
     public void testArrays() throws IOException {
         var comments = getDocComments("arrays.h", "arrays_h.java");
-        assertEquals(comments, Set.of(
+        assertEquals(comments, List.of(
             "int abc[10];",
             "float numbers[3];",
             "char* msg[5];"));
@@ -85,7 +85,7 @@ public class TestDocComments extends JextractToolRunner {
     @Test
     public void testFunctions() throws IOException {
         var comments = getDocComments("functions.h", "functions_h.java");
-        assertEquals(comments, Set.of(
+        assertEquals(comments, List.of(
             "int func(int* fp);",
             "double distance(struct Point p);",
             "int printf(char* fmt,...);"));
@@ -94,7 +94,7 @@ public class TestDocComments extends JextractToolRunner {
     @Test
     public void testFunctionPointer() throws IOException {
         var comments = getDocComments("funcptrs.h", "funcptr.java");
-        assertEquals(comments, Set.of(
+        assertEquals(comments, List.of(
             "void (*funcptr)(int*,int);"
         ));
     }
@@ -102,7 +102,7 @@ public class TestDocComments extends JextractToolRunner {
     @Test
     public void testVariables() throws IOException {
         var comments = getDocComments("variables.h", "variables_h.java");
-        assertEquals(comments, Set.of(
+        assertEquals(comments, List.of(
             "Getter for variable: int abc;",
             "Setter for variable: int abc;",
             "Getter for variable: char* msg;",
@@ -113,25 +113,25 @@ public class TestDocComments extends JextractToolRunner {
     @Test
     public void testStruct() throws IOException {
         var comments = getDocComments("structs.h", "Point.java");
-        assertEquals(comments, Set.of(
+        assertEquals(comments, List.of(
             "struct Point { int x; int y; };"));
     }
 
     @Test
     public void testStruct2() throws IOException {
         var comments = getDocComments("structs.h", "Point3D.java");
-        assertEquals(comments, Set.of(
+        assertEquals(comments, List.of(
             "struct Point3D { int x; int y; int z; };"));
     }
 
     @Test
     public void testStructTypdef() throws IOException {
         var comments = getDocComments("structs.h", "Point_t.java");
-        assertEquals(comments, Set.of(
+        assertEquals(comments, List.of(
             "typedef struct Point Point_t;"));
     }
 
-    private Set<String> getDocComments(String header, String outputFile)
+    private List<String> getDocComments(String header, String outputFile)
             throws IOException {
         var output = getOutputFilePath("7903257-parse-" + header);
         var outputH = getInputFilePath(header);
@@ -145,9 +145,9 @@ public class TestDocComments extends JextractToolRunner {
     }
 
     // get doc comments from the given the source content
-    private static Set<String> findDocComments(String content) {
+    private static List<String> findDocComments(String content) {
         var matcher = JAVADOC_COMMENT.matcher(content);
-        var strings = new HashSet<String>();
+        var strings = new ArrayList<String>();
         while (matcher.find()) {
             // doc comment text is matched in group 1
             String rawComment = matcher.group(1);

--- a/test/testng/org/openjdk/jextract/test/toolprovider/Test7903257/arrays.h
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/Test7903257/arrays.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+int abc[10];
+float numbers[3];
+char* msg[5];

--- a/test/testng/org/openjdk/jextract/test/toolprovider/Test7903257/enums.h
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/Test7903257/enums.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+enum Color { RED, GREEN, BLUE };
+
+/* enum with init values */
+enum Suit {
+    club = 1,
+    diamonds = 2,
+    hearts = 3,
+    spades = 4
+};
+

--- a/test/testng/org/openjdk/jextract/test/toolprovider/Test7903257/funcptrs.h
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/Test7903257/funcptrs.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+void (*funcptr)(int x[], int numelements);

--- a/test/testng/org/openjdk/jextract/test/toolprovider/Test7903257/functions.h
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/Test7903257/functions.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+int func(int* fp);
+struct Point {
+  int x; int y;
+};
+
+double distance(struct Point p);
+int printf(char* fmt,...);

--- a/test/testng/org/openjdk/jextract/test/toolprovider/Test7903257/macros.h
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/Test7903257/macros.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#define FOO 42
+#define MSG "Hello"

--- a/test/testng/org/openjdk/jextract/test/toolprovider/Test7903257/structs.h
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/Test7903257/structs.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+struct Point {
+   int x;
+   int y;
+};
+
+struct Point3D {
+   int x;
+   int y;
+   int z;
+};
+
+typedef struct Point Point_t;

--- a/test/testng/org/openjdk/jextract/test/toolprovider/Test7903257/typedefs.h
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/Test7903257/typedefs.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+typedef unsigned long size_t;
+typedef int INT_32;
+typedef int* INT_PTR;
+typedef struct Foo* OPAQUE_PTR;

--- a/test/testng/org/openjdk/jextract/test/toolprovider/Test7903257/variables.h
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/Test7903257/variables.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+int abc;
+char* msg;


### PR DESCRIPTION
Generating C signature as doc comments.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Issue
 * [CODETOOLS-7903257](https://bugs.openjdk.org/browse/CODETOOLS-7903257): jextract should generate javadoc comments


### Reviewers
 * @minborg (no known github.com user name / role) ⚠️ Review applies to [deb57bf1](https://git.openjdk.org/jextract/pull/85/files/deb57bf1bc301ea4286b1ac1f9a17269be00feb3)
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - Committer)
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - no project role) ⚠️ Review applies to [3af5a8cc](https://git.openjdk.org/jextract/pull/85/files/3af5a8cc51013881f89623f8d94d6ca9ac8ffeac)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract pull/85/head:pull/85` \
`$ git checkout pull/85`

Update a local copy of the PR: \
`$ git checkout pull/85` \
`$ git pull https://git.openjdk.org/jextract pull/85/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 85`

View PR using the GUI difftool: \
`$ git pr show -t 85`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/85.diff">https://git.openjdk.org/jextract/pull/85.diff</a>

</details>
