### PR TITLE
7903349: int parameter in generated allocateArray method should be long

### DIFF
--- a/src/main/java/org/openjdk/jextract/impl/CDeclarationPrinter.java
+++ b/src/main/java/org/openjdk/jextract/impl/CDeclarationPrinter.java
@@ -220,8 +220,7 @@ final class CDeclarationPrinter implements Declaration.Visitor<Void, Void> {
                     return prefixedType("complex", t);
                 case default:
                     // defensive. If no name is present, we don't want to crash
-                    return new TypeVisitorResult(false,
-                        t.name().isPresent()? t.name().get() : t.toString());
+                    return new TypeVisitorResult(false, t.name().orElse(defaultName(t)));
             }
         }
 
@@ -265,7 +264,11 @@ final class CDeclarationPrinter implements Declaration.Visitor<Void, Void> {
 
         @Override
         public TypeVisitorResult visitType(Type t, String context) {
-            return new TypeVisitorResult(false, t.getClass().getName());
+            return new TypeVisitorResult(false, defaultName(t));
+        }
+
+        private String defaultName(Type t) {
+            return t.toString();
         }
     };
 

--- a/src/main/java/org/openjdk/jextract/impl/StructBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/StructBuilder.java
@@ -266,7 +266,7 @@ class StructBuilder extends ConstantBuilder {
         incrAlign();
         indent();
         append(MEMBER_MODS);
-        append(" MemorySegment allocateArray(int len, SegmentAllocator allocator) {\n");
+        append(" MemorySegment allocateArray(long len, SegmentAllocator allocator) {\n");
         incrAlign();
         indent();
         append("return allocator.allocate(MemoryLayout.sequenceLayout(len, $LAYOUT()));\n");


### PR DESCRIPTION
Changing "int" param to "long" in generated allocateArray method for struct classes.

Piggybacking couple of code review suggestions missed during review for CODETOOLS-7903257

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Issue
 * [CODETOOLS-7903349](https://bugs.openjdk.org/browse/CODETOOLS-7903349): int parameter in generated allocateArray method should be long


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract pull/86/head:pull/86` \
`$ git checkout pull/86`

Update a local copy of the PR: \
`$ git checkout pull/86` \
`$ git pull https://git.openjdk.org/jextract pull/86/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 86`

View PR using the GUI difftool: \
`$ git pr show -t 86`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/86.diff">https://git.openjdk.org/jextract/pull/86.diff</a>

</details>
