### PR TITLE
7903358: jextract does not generate correct signature for multidimensional arrays in doc comments

### DIFF
--- a/src/main/java/org/openjdk/jextract/impl/CDeclarationPrinter.java
+++ b/src/main/java/org/openjdk/jextract/impl/CDeclarationPrinter.java
@@ -259,7 +259,12 @@ final class CDeclarationPrinter implements Declaration.Visitor<Void, Void> {
         public TypeVisitorResult visitArray(Type.Array t, String context) {
             String brackets = String.format(" %s[%s]", context,
                 t.elementCount().isPresent() ? t.elementCount().getAsLong() : "");
-            return new TypeVisitorResult(true, t.elementType().accept(this, "").typeStr() + brackets);
+            var result = t.elementType().accept(this, brackets);
+            if (result.nameIncluded()) {
+                return new TypeVisitorResult(true, result.typeStr());
+            } else {
+                return new TypeVisitorResult(true, result.typeStr() + brackets);
+            }
         }
 
         @Override

--- a/test/testng/org/openjdk/jextract/test/toolprovider/Test7903257/TestDocComments.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/Test7903257/TestDocComments.java
@@ -79,7 +79,9 @@ public class TestDocComments extends JextractToolRunner {
         assertEquals(comments, List.of(
             "int abc[10];",
             "float numbers[3];",
-            "char* msg[5];"));
+            "char* msg[5];",
+            "int pixels[200][100];",
+            "int points[10][20][30];"));
     }
 
     @Test

--- a/test/testng/org/openjdk/jextract/test/toolprovider/Test7903257/arrays.h
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/Test7903257/arrays.h
@@ -24,3 +24,5 @@
 int abc[10];
 float numbers[3];
 char* msg[5];
+int pixels[200][100];
+int points[10][20][30];


### PR DESCRIPTION
"context" was not properly handled in nested array type case.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Issue
 * [CODETOOLS-7903358](https://bugs.openjdk.org/browse/CODETOOLS-7903358): jextract does not generate correct signature for multidimensional arrays in doc comments


### Reviewers
 * @minborg (no known github.com user name / role)
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract pull/89/head:pull/89` \
`$ git checkout pull/89`

Update a local copy of the PR: \
`$ git checkout pull/89` \
`$ git pull https://git.openjdk.org/jextract pull/89/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 89`

View PR using the GUI difftool: \
`$ git pr show -t 89`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/89.diff">https://git.openjdk.org/jextract/pull/89.diff</a>

</details>
