### PR TITLE
7903360: jextract does not handle function pointer return type properly

### DIFF
--- a/src/main/java/org/openjdk/jextract/impl/NameMangler.java
+++ b/src/main/java/org/openjdk/jextract/impl/NameMangler.java
@@ -130,6 +130,11 @@ final class NameMangler implements Declaration.Visitor<Void, Declaration> {
         return Objects.requireNonNull(declFiNames.get(nameAndDecl));
     }
 
+    String getReturnFiName(Declaration.Function func) {
+        Objects.requireNonNull(func);
+        return funcReturnID(func);
+    }
+
     String getFiName(Declaration parent, Declaration decl) {
         Objects.requireNonNull(decl);
         if (declFiNames.containsKey(decl)) {
@@ -142,6 +147,10 @@ final class NameMangler implements Declaration.Visitor<Void, Declaration> {
     }
 
     // Internals below this point
+
+    private static String funcReturnID(Declaration.Function func) {
+        return func.name() + "$return";
+    }
 
     private static String funcParamID(Declaration.Function func, int paramNum) {
         return func.name() + "$" + paramNum;
@@ -209,6 +218,7 @@ final class NameMangler implements Declaration.Visitor<Void, Declaration> {
             }
             putJavaName(param, makeJavaName(param));
         }
+
         return null;
     }
 

--- a/src/main/java/org/openjdk/jextract/impl/OutputFactory.java
+++ b/src/main/java/org/openjdk/jextract/impl/OutputFactory.java
@@ -246,6 +246,7 @@ public class OutputFactory implements Declaration.Visitor<Void, Declaration> {
             return null;
         }
 
+        // check for function pointer type arguments
         int i = 0;
         for (Declaration.Variable param : funcTree.parameters()) {
             Type.Function f = Utils.getAsFunctionPointer(param.type());
@@ -256,6 +257,14 @@ public class OutputFactory implements Declaration.Visitor<Void, Declaration> {
                 }
                 i++;
             }
+        }
+
+        // return type could be a function pointer type
+        Type.Function returnFunc = Utils.getAsFunctionPointer(funcTree.type().returnType());
+        if (returnFunc != null) {
+             if (! generateFunctionalInterface(returnFunc, nameMangler.getReturnFiName(funcTree))) {
+                 return null;
+             }
         }
 
         toplevelBuilder.addFunction(funcTree, descriptor, nameMangler.getJavaName(parent, funcTree),

--- a/test/testng/org/openjdk/jextract/test/toolprovider/Test7903257/TestDocComments.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/Test7903257/TestDocComments.java
@@ -102,6 +102,32 @@ public class TestDocComments extends JextractToolRunner {
     }
 
     @Test
+    public void testFunctionPointer2() throws IOException {
+        var comments = getDocComments("funcptrs.h", "signal$func.java");
+        assertEquals(comments, List.of(
+            "void (*signal$func)(int);"
+        ));
+    }
+
+    @Test
+    public void testFunctionPointer3() throws IOException {
+        var comments = getDocComments("funcptrs.h", "signal$return.java");
+        assertEquals(comments, List.of(
+            "void (*signal$return)(int);"
+        ));
+    }
+
+    @Test
+    public void testFunctionPointer4() throws IOException {
+        var comments = getDocComments("funcptrs.h", "funcptrs_h.java");
+        assertEquals(comments, List.of(
+            "Getter for variable: void (*funcptr)(int*,int);",
+            "Setter for variable: void (*funcptr)(int*,int);",
+            "void (*signal(int sig, void (*func)(int)))(int);"
+        ));
+    }
+
+    @Test
     public void testVariables() throws IOException {
         var comments = getDocComments("variables.h", "variables_h.java");
         assertEquals(comments, List.of(

--- a/test/testng/org/openjdk/jextract/test/toolprovider/Test7903257/funcptrs.h
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/Test7903257/funcptrs.h
@@ -22,3 +22,4 @@
  */
 
 void (*funcptr)(int x[], int numelements);
+void (*signal(int sig, void (*func)(int)))(int);


### PR DESCRIPTION
* generating functional interface for pointer to function return types
* taking care of javadoc comment by using nameAndType function uniformly

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Issue
 * [CODETOOLS-7903360](https://bugs.openjdk.org/browse/CODETOOLS-7903360): jextract does not handle function pointer return type properly


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract pull/90/head:pull/90` \
`$ git checkout pull/90`

Update a local copy of the PR: \
`$ git checkout pull/90` \
`$ git pull https://git.openjdk.org/jextract pull/90/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 90`

View PR using the GUI difftool: \
`$ git pr show -t 90`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/90.diff">https://git.openjdk.org/jextract/pull/90.diff</a>

</details>
