### PR TITLE
7903362: rename --include-macro option to be --include-constant

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ A complete list of all the supported options is given below:
 | `--output <path>`                                            | specify where to place generated files                       |
 | `--source`                                                   | generate java sources instead of classfiles                  |
 | `--dump-includes <String>`                                   | dump included symbols into specified file (see below)        |
-| `--include-[function,macro,struct,union,typedef,var]<String>` | Include a symbol of the given name and kind in the generated bindings (see below). When one of these options is specified, any symbol that is not matched by any specified filters is omitted from the generated bindings. |
+| `--include-[function,constant,struct,union,typedef,var]<String>` | Include a symbol of the given name and kind in the generated bindings (see below). When one of these options is specified, any symbol that is not matched by any specified filters is omitted from the generated bindings. |
 | `--version`                                                  | print version information and exit                           |
 
 

--- a/src/main/java/org/openjdk/jextract/impl/IncludeHelper.java
+++ b/src/main/java/org/openjdk/jextract/impl/IncludeHelper.java
@@ -46,7 +46,7 @@ import java.util.stream.Collectors;
 public class IncludeHelper {
 
     public enum IncludeKind {
-        MACRO,
+        CONSTANT,
         VAR,
         FUNCTION,
         TYPEDEF,
@@ -59,7 +59,7 @@ public class IncludeHelper {
 
         static IncludeKind fromDeclaration(Declaration d) {
             if (d instanceof Declaration.Constant) {
-                return MACRO;
+                return CONSTANT;
             } else if (d instanceof Declaration.Variable) {
                 return VAR;
             } else if (d instanceof Declaration.Function) {
@@ -100,7 +100,7 @@ public class IncludeHelper {
     }
 
     public boolean isIncluded(Declaration.Constant constant) {
-        return checkIncludedAndAddIfNeeded(IncludeKind.MACRO, constant);
+        return checkIncludedAndAddIfNeeded(IncludeKind.CONSTANT, constant);
     }
 
     public boolean isIncluded(Declaration.Typedef typedef) {

--- a/src/main/resources/org/openjdk/jextract/impl/resources/Messages.properties
+++ b/src/main/resources/org/openjdk/jextract/impl/resources/Messages.properties
@@ -29,7 +29,7 @@ l.option.value.invalid=option value for -l option should be a name or an absolut
 
 # help messages for options
 help.I=specify include files path
-help.include-macro=name of constant macro to include
+help.include-constant=name of macro or enum constant to include
 help.include-var=name of global variable to include
 help.include-function=name of function to include
 help.include-typedef=name of type definition to include
@@ -58,7 +58,7 @@ Option                             Description                                  
 \                                   specified, then header class name is derived from the header\n\
 \                                   file name. For example, class "foo_h" for header "foo.h".   \n\
 --include-function <name>          name of function to include                                  \n\
---include-macro <name>             name of constant macro to include                            \n\
+--include-constant <name>          name of macro or enum constant to include                    \n\
 --include-struct <name>            name of struct definition to include                         \n\
 --include-typedef <name>           name of type definition to include                           \n\
 --include-union <name>             name of union definition to include                          \n\

--- a/test/testng/org/openjdk/jextract/test/toolprovider/TestFilters.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/TestFilters.java
@@ -89,7 +89,8 @@ public class TestFilters extends JextractToolRunner {
     enum FilterKind {
         VAR("_global", "--include-var"),
         FUNCTION("_function", "--include-function"),
-        CONSTANT("_constant", "--include-macro"),
+        MACRO_CONSTANT("_constant", "--include-constant"),
+        ENUM_CONSTANT("RED", "--include-constant"),
         TYPEDEF("_typedef", "--include-typedef"),
         STRUCT("_struct", "--include-struct"),
         UNION("_union", "--include-union");
@@ -104,7 +105,7 @@ public class TestFilters extends JextractToolRunner {
 
         Object get(Class<?> headerClass) {
             return switch (this) {
-                case FUNCTION, CONSTANT -> findMethod(headerClass, symbolName);
+                case FUNCTION, MACRO_CONSTANT, ENUM_CONSTANT -> findMethod(headerClass, symbolName);
                 case VAR -> findMethod(headerClass, symbolName + "$get");
                 case TYPEDEF -> findField(headerClass, symbolName);
                 case STRUCT, UNION -> {

--- a/test/testng/org/openjdk/jextract/test/toolprovider/filters.h
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/filters.h
@@ -43,6 +43,10 @@ struct _struct { int x; };
 
 union _union { int y; };
 
+enum Color {
+    RED, GREEN, BLUE
+};
+
 #ifdef __cplusplus
 }
 #endif // __cplusplus


### PR DESCRIPTION
Option renamed. Test added for enum constant filtering.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Issue
 * [CODETOOLS-7903362](https://bugs.openjdk.org/browse/CODETOOLS-7903362): rename --include-macro option to be --include-constant


### Reviewers
 * [Per Minborg](https://openjdk.org/census#pminborg) (@minborg - no project role)
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract pull/91/head:pull/91` \
`$ git checkout pull/91`

Update a local copy of the PR: \
`$ git checkout pull/91` \
`$ git pull https://git.openjdk.org/jextract pull/91/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 91`

View PR using the GUI difftool: \
`$ git pr show -t 91`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/91.diff">https://git.openjdk.org/jextract/pull/91.diff</a>

</details>
