### PR TITLE
7903380: sync jextract for memory session a pure lifetime abstraction panama api change

### DIFF
--- a/samples/cblas/TestBlas.java
+++ b/samples/cblas/TestBlas.java
@@ -30,7 +30,7 @@
  */
 
 import java.lang.foreign.SegmentAllocator;
-import java.lang.foreign.MemorySession;
+import java.lang.foreign.Arena;
 import blas.*;
 import static blas.cblas_h.*;
 
@@ -53,17 +53,17 @@ public class TestBlas {
         alpha = 1;
         beta = 0;
 
-        try (var session = MemorySession.openConfined()) {
-            var a = session.allocateArray(C_DOUBLE,
+        try (var arena = Arena.openConfined()) {
+            var a = arena.allocateArray(C_DOUBLE,
                 1.0, 2.0, 3.0, 4.0,
                 1.0, 1.0, 1.0, 1.0,
                 3.0, 4.0, 5.0, 6.0,
                 5.0, 6.0, 7.0, 8.0
             );
-            var x = session.allocateArray(C_DOUBLE,
+            var x = arena.allocateArray(C_DOUBLE,
                 1.0, 2.0, 1.0, 1.0
             );
-            var y = session.allocateArray(C_DOUBLE, n);
+            var y = arena.allocateArray(C_DOUBLE, n);
 
             cblas_dgemv(Layout, transa, m, n, alpha, a, lda, x, incx, beta, y, incy);
             /* Print y */

--- a/samples/lapack/TestLapack.java
+++ b/samples/lapack/TestLapack.java
@@ -31,7 +31,7 @@
 
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.SegmentAllocator;
-import java.lang.foreign.MemorySession;
+import java.lang.foreign.Arena;
 import lapack.*;
 import static lapack.lapacke_h.*;
 
@@ -39,11 +39,11 @@ public class TestLapack {
     public static void main(String[] args) {
 
         /* Locals */
-        try (var session = MemorySession.openConfined()) {
-            var A = session.allocateArray(C_DOUBLE,
+        try (var arena = Arena.openConfined()) {
+            var A = arena.allocateArray(C_DOUBLE,
                     1, 2, 3, 4, 5, 1, 3, 5, 2, 4, 1, 4, 2, 5, 3
             );
-            var b = session.allocateArray(C_DOUBLE,
+            var b = arena.allocateArray(C_DOUBLE,
                     -10, 12, 14, 16, 18, -3, 14, 12, 16, 16
             );
             int info, m, n, lda, ldb, nrhs;

--- a/samples/libclang/ASTPrinter.java
+++ b/samples/libclang/ASTPrinter.java
@@ -47,10 +47,10 @@ public class ASTPrinter {
             System.exit(1);
         }
 
-        try (var session = MemorySession.openConfined()) {
+        try (var arena = Arena.openConfined()) {
             // parse the C header/source passed from the command line
             var index = clang_createIndex(0, 0);
-            var tu = clang_parseTranslationUnit(index, session.allocateUtf8String(args[0]),
+            var tu = clang_parseTranslationUnit(index, arena.allocateUtf8String(args[0]),
                     NULL, 0, NULL, 0, CXTranslationUnit_None());
             // array trick to update within lambda
             var level = new int[1];
@@ -59,12 +59,12 @@ public class ASTPrinter {
             // clang Cursor visitor callback
             visitor[0] = CXCursorVisitor.allocate((cursor, parent, data) -> {
                 var kind = clang_getCursorKind(cursor);
-                var name = asJavaString(clang_getCursorSpelling(session, cursor));
-                var kindName = asJavaString(clang_getCursorKindSpelling(session, kind));
+                var name = asJavaString(clang_getCursorSpelling(arena, cursor));
+                var kindName = asJavaString(clang_getCursorKindSpelling(arena, kind));
                 System.out.printf("%s %s %s", " ".repeat(level[0]), kindName, name);
-                var type = clang_getCursorType(session, cursor);
+                var type = clang_getCursorType(arena, cursor);
                 if (CXType.kind$get(type) != CXType_Invalid()) {
-                    var typeName = asJavaString(clang_getTypeSpelling(session, type));
+                    var typeName = asJavaString(clang_getTypeSpelling(arena, type));
                     System.out.printf(" <%s>", typeName);
                 }
                 System.out.println();
@@ -75,10 +75,10 @@ public class ASTPrinter {
                 level[0]--;
 
                 return CXChildVisit_Continue();
-            }, session);
+            }, arena.session());
 
             // get the AST root and visit it
-            var root = clang_getTranslationUnitCursor(session, tu);
+            var root = clang_getTranslationUnitCursor(arena, tu);
             clang_visitChildren(root, visitor[0], NULL);
 
             clang_disposeTranslationUnit(tu);

--- a/samples/libcurl/CurlMain.java
+++ b/samples/libcurl/CurlMain.java
@@ -29,7 +29,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import java.lang.foreign.MemorySession;
+import java.lang.foreign.Arena;
 import java.lang.foreign.SegmentAllocator;
 import static java.lang.foreign.MemorySegment.NULL;
 import static org.jextract.curl_h.*;
@@ -41,8 +41,8 @@ public class CurlMain {
        curl_global_init(CURL_GLOBAL_DEFAULT());
        var curl = curl_easy_init();
        if(!curl.equals(NULL)) {
-           try (var session = MemorySession.openConfined()) {
-               var url = session.allocateUtf8String(urlStr);
+           try (var arena = Arena.openConfined()) {
+               var url = arena.allocateUtf8String(urlStr);
                curl_easy_setopt(curl, CURLOPT_URL(), url.address());
                int res = curl_easy_perform(curl);
                if (res != CURLE_OK()) {

--- a/samples/libffmpeg/LibffmpegMain.java
+++ b/samples/libffmpeg/LibffmpegMain.java
@@ -78,7 +78,7 @@ public class LibffmpegMain {
             // AVFormatContext *ppFormatCtx;
             var ppFormatCtx = session.allocate(C_POINTER);
             // char* fileName;
-            var fileName = session.allocateUtf8String(args[0]);
+            var fileName = arena.allocateUtf8String(args[0]);
 
             // open video file
             if (avformat_open_input(ppFormatCtx, fileName, NULL, NULL) != 0) {
@@ -93,7 +93,7 @@ public class LibffmpegMain {
                 throw new ExitException(1, "Could not find stream information");
             }
 
-            session.addCloseAction(()-> {
+            arena.addCloseAction(()-> {
                 // Close the video file
                 avformat_close_input(ppFormatCtx);
             });

--- a/samples/libffmpeg/compile.sh
+++ b/samples/libffmpeg/compile.sh
@@ -1,6 +1,6 @@
 jextract -t libffmpeg \
   -I /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include \
-  -I /usr/local/Cellar/ffmpeg@4/4.4.2_4/include \
+  -I /usr/local/Cellar/ffmpeg@4/4.4.3/include \
   -l avcodec \
   -l avformat \
   -l avutil \

--- a/samples/libffmpeg/compilesource.sh
+++ b/samples/libffmpeg/compilesource.sh
@@ -1,6 +1,6 @@
 jextract --source -t libffmpeg \
   -I /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include \
-  -I /usr/local/Cellar/ffmpeg@4/4.4.2_4/include \
+  -I /usr/local/Cellar/ffmpeg@4/4.4.3/include \
   -l avcodec \
   -l avformat \
   -l avutil \

--- a/samples/libffmpeg/run.sh
+++ b/samples/libffmpeg/run.sh
@@ -1,3 +1,3 @@
 java --enable-native-access=ALL-UNNAMED \
    --enable-preview --source=20 \
-   -Djava.library.path=/usr/local/Cellar/ffmpeg@4/4.4.2_4/lib LibffmpegMain.java $*
+   -Djava.library.path=/usr/local/Cellar/ffmpeg@4/4.4.3/lib LibffmpegMain.java $*

--- a/samples/libgit2/GitClone.java
+++ b/samples/libgit2/GitClone.java
@@ -30,7 +30,7 @@
  */
 
 import java.lang.foreign.SegmentAllocator;
-import java.lang.foreign.MemorySession;
+import java.lang.foreign.Arena;
 import static com.github.git2_h.*;
 import static java.lang.foreign.MemorySegment.NULL;
 import com.github.*;
@@ -42,10 +42,10 @@ public class GitClone {
               System.exit(1);
           }
           git_libgit2_init();
-          try (var session = MemorySession.openConfined()) {
-              var repo = session.allocate(C_POINTER);
-              var url = session.allocateUtf8String(args[0]);
-              var path = session.allocateUtf8String(args[1]);
+          try (var arena = Arena.openConfined()) {
+              var repo = arena.allocate(C_POINTER);
+              var url = arena.allocateUtf8String(args[0]);
+              var path = arena.allocateUtf8String(args[1]);
               System.out.println(git_clone(repo, url, path, NULL));
           }
           git_libgit2_shutdown();

--- a/samples/libjimage/JImageFile.java
+++ b/samples/libjimage/JImageFile.java
@@ -29,7 +29,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import java.lang.foreign.MemorySession;
+import java.lang.foreign.Arena;
 import java.lang.foreign.SegmentAllocator;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -46,9 +46,9 @@ public class JImageFile {
            System.err.println(modPath + " not found, please check if your java.home");
            return;
         }
-        try (var session = MemorySession.openConfined()) {
-            var jintResPtr = session.allocate(jint);
-            var moduleFilePath = session.allocateUtf8String(javaHome + "/lib/modules");
+        try (var arena = Arena.openConfined()) {
+            var jintResPtr = arena.allocate(jint);
+            var moduleFilePath = arena.allocateUtf8String(javaHome + "/lib/modules");
             var jimageFile = JIMAGE_Open(moduleFilePath, jintResPtr);
 
             if (jimageFile == NULL) {
@@ -56,7 +56,7 @@ public class JImageFile {
                 return;
             }
             var mod = JIMAGE_PackageToModule(jimageFile,
-                session.allocateUtf8String("java/util"));
+                arena.allocateUtf8String("java/util"));
             System.out.println(mod);
 
             // const char* module_name, const char* version, const char* package,
@@ -68,7 +68,7 @@ public class JImageFile {
                    System.out.println("package " + package_name.getUtf8String(0));
                    System.out.println("name " + name.getUtf8String(0));
                    return 1;
-                }, session);
+                }, arena.session());
 
             JIMAGE_ResourceIterator(jimageFile, visitor, NULL);
 

--- a/samples/libjimage/org/openjdk/RuntimeHelper.java
+++ b/samples/libjimage/org/openjdk/RuntimeHelper.java
@@ -32,7 +32,7 @@ final class RuntimeHelper {
     private final static SymbolLookup SYMBOL_LOOKUP;
 
     final static SegmentAllocator CONSTANT_ALLOCATOR =
-            (size, align) -> MemorySegment.allocateNative(size, align);
+            (size, align) -> MemorySegment.allocateNative(size, align, MemorySession.implicit());
 
     static {
         // manual change

--- a/samples/libproc/LibprocMain.java
+++ b/samples/libproc/LibprocMain.java
@@ -30,7 +30,7 @@
  */
 
 import java.lang.foreign.MemorySegment;
-import java.lang.foreign.MemorySession;
+import java.lang.foreign.Arena;
 import java.lang.foreign.SegmentAllocator;
 import org.unix.*;
 import static java.lang.foreign.MemorySegment.NULL;
@@ -40,17 +40,17 @@ public class LibprocMain {
     private static final int NAME_BUF_MAX = 256;
 
     public static void main(String[] args) {
-        try (var session = MemorySession.openConfined()) {
+        try (var arena = Arena.openConfined()) {
             // get the number of processes
             int numPids = proc_listallpids(NULL, 0);
             // allocate an array
-            var pids = session.allocateArray(C_INT, numPids);
+            var pids = arena.allocateArray(C_INT, numPids);
             // list all the pids into the native array
             proc_listallpids(pids, numPids);
             // convert native array to java array
             int[] jpids = pids.toArray(C_INT);
             // buffer for process name
-            var nameBuf = session.allocateArray(C_CHAR, NAME_BUF_MAX);
+            var nameBuf = arena.allocateArray(C_CHAR, NAME_BUF_MAX);
             for (int i = 0; i < jpids.length; i++) {
                 int pid = jpids[i];
                 // get the process name

--- a/samples/libzstd/LibzstdMain.java
+++ b/samples/libzstd/LibzstdMain.java
@@ -83,11 +83,11 @@ public class LibzstdMain {
         System.out.println(TEXT);
         System.out.println();
 
-        try (var session = MemorySession.openConfined()) {
+        try (var arena = Arena.openConfined()) {
             // Compress
-            var uncompressedText = session.allocateUtf8String(TEXT);
+            var uncompressedText = arena.allocateUtf8String(TEXT);
             // At least, the compressed text should not be larger than the uncompressed text.
-            var compressedText = session.allocate(TEXT.length());
+            var compressedText = arena.allocate(TEXT.length());
             long compressResult = ZSTD_compress(compressedText, compressedText.byteSize(), uncompressedText, uncompressedText.byteSize(), ZSTD_defaultCLevel());
             if (ZSTD_isError(compressResult) != 0) {
                 System.out.println("Error compressing: " + errorMessage(compressResult));
@@ -99,7 +99,7 @@ public class LibzstdMain {
             System.out.println();
 
             // Decompress again
-            var decompressed = session.allocate(TEXT.length() * 2, 64); // Needs extra space to decompress
+            var decompressed = arena.allocate(TEXT.length() * 2, 64); // Needs extra space to decompress
             long decompressResult = ZSTD_decompress(decompressed, decompressed.byteSize(), compressedText, compressResult);
             if (ZSTD_isError(decompressResult) != 0) {
                 System.out.println("Error decompressing: " + errorMessage(decompressResult));

--- a/samples/lp_solve/LpSolveDemo.java
+++ b/samples/lp_solve/LpSolveDemo.java
@@ -47,9 +47,9 @@ class LpSolveDemo {
              return;
         }
 
-        try (var session = MemorySession.openConfined()) {
-            var colno = session.allocateArray(C_INT, Ncol);
-            var row = session.allocateArray(C_DOUBLE, Ncol);
+        try (var arena = Arena.openConfined()) {
+            var colno = arena.allocateArray(C_INT, Ncol);
+            var row = arena.allocateArray(C_DOUBLE, Ncol);
 
             // makes building the model faster if it is done rows by row
             set_add_rowmode(lp, TRUE);

--- a/samples/pcre2/PcreCheck.java
+++ b/samples/pcre2/PcreCheck.java
@@ -40,7 +40,7 @@ class PcreCheck {
       System.exit(1);
     }
 
-    try (var session = MemorySession.openConfined()) {
+    try (var session = Arena.openConfined()) {
       // given regex to C string
       var pattern = session.allocateUtf8String(args[0]);
       var patternSize = args[0].length();

--- a/samples/python3/PythonMain.java
+++ b/samples/python3/PythonMain.java
@@ -29,7 +29,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import java.lang.foreign.MemorySession;
+import java.lang.foreign.Arena;
 import java.lang.foreign.SegmentAllocator;
 import static java.lang.foreign.MemorySegment.NULL;
 // import jextracted python 'header' class
@@ -41,8 +41,8 @@ public class PythonMain {
         String script = "print(sum([33, 55, 66])); print('Hello from Python!')\n";
 
         Py_Initialize();
-        try (var session = MemorySession.openConfined()) {
-            var str = session.allocateUtf8String(script);
+        try (var arena = Arena.openConfined()) {
+            var str = arena.allocateUtf8String(script);
             PyRun_SimpleStringFlags(str, NULL);
             Py_Finalize();
         }

--- a/samples/readline/Readline.java
+++ b/samples/readline/Readline.java
@@ -29,15 +29,15 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import java.lang.foreign.MemorySession;
+import java.lang.foreign.Arena;
 import java.lang.foreign.SegmentAllocator;
 import static org.unix.readline_h.*;
 import org.unix.*;
 
 public class Readline {
     public static void main(String[] args) {
-       try (var session = MemorySession.openConfined()) {
-            var url = session.allocateUtf8String("name? ");
+       try (var arena = Arena.openConfined()) {
+            var url = arena.allocateUtf8String("name? ");
 
             // call "readline" API
             var p = readline(url);

--- a/samples/sqlite/SqliteMain.java
+++ b/samples/sqlite/SqliteMain.java
@@ -30,7 +30,7 @@
  */
 
 import java.lang.foreign.MemorySegment;
-import java.lang.foreign.MemorySession;
+import java.lang.foreign.Arena;
 import java.lang.foreign.SegmentAllocator;
 import org.sqlite.*;
 import static java.lang.foreign.MemorySegment.NULL;
@@ -38,14 +38,14 @@ import static org.sqlite.sqlite3_h.*;
 
 public class SqliteMain {
    public static void main(String[] args) throws Exception {
-        try (var session = MemorySession.openConfined()) {
+        try (var arena = Arena.openConfined()) {
             // char** errMsgPtrPtr;
-            var errMsgPtrPtr = session.allocate(C_POINTER);
+            var errMsgPtrPtr = arena.allocate(C_POINTER);
 
             // sqlite3** dbPtrPtr;
-            var dbPtrPtr = session.allocate(C_POINTER);
+            var dbPtrPtr = arena.allocate(C_POINTER);
 
-            int rc = sqlite3_open(session.allocateUtf8String("employee.db"), dbPtrPtr);
+            int rc = sqlite3_open(arena.allocateUtf8String("employee.db"), dbPtrPtr);
             if (rc != 0) {
                 System.err.println("sqlite3_open failed: " + rc);
                 return;
@@ -57,7 +57,7 @@ public class SqliteMain {
             var dbPtr = dbPtrPtr.get(C_POINTER, 0);
 
             // create a new table
-            var sql = session.allocateUtf8String(
+            var sql = arena.allocateUtf8String(
                 "CREATE TABLE EMPLOYEE ("  +
                 "  ID INT PRIMARY KEY NOT NULL," +
                 "  NAME TEXT NOT NULL,"    +
@@ -74,7 +74,7 @@ public class SqliteMain {
             }
 
             // insert two rows
-            sql = session.allocateUtf8String(
+            sql = arena.allocateUtf8String(
                 "INSERT INTO EMPLOYEE (ID,NAME,SALARY) " +
                     "VALUES (134, 'Xyz', 200000.0); " +
                 "INSERT INTO EMPLOYEE (ID,NAME,SALARY) " +
@@ -95,8 +95,8 @@ public class SqliteMain {
             var callback = sqlite3_exec$callback.allocate((a, argc, argv, columnNames) -> {
                 System.out.println("Row num: " + rowNum[0]++);
                 System.out.println("numColumns = " + argc);
-                var argv_seg = MemorySegment.ofAddress(argv.address(), C_POINTER.byteSize() * argc, session);
-                var columnNames_seg = MemorySegment.ofAddress(columnNames.address(), C_POINTER.byteSize() * argc, session);
+                var argv_seg = MemorySegment.ofAddress(argv.address(), C_POINTER.byteSize() * argc, arena.session());
+                var columnNames_seg = MemorySegment.ofAddress(columnNames.address(), C_POINTER.byteSize() * argc, arena.session());
                 for (int i = 0; i < argc; i++) {
                      String name = columnNames_seg.getAtIndex(C_POINTER, i).getUtf8String(0);
                      String value = argv_seg.getAtIndex(C_POINTER, i).getUtf8String(0);
@@ -104,10 +104,10 @@ public class SqliteMain {
                      System.out.printf("%s = %s\n", name, value);
                 }
                 return 0;
-            }, session);
+            }, arena.session());
 
             // select query
-            sql = session.allocateUtf8String("SELECT * FROM EMPLOYEE");
+            sql = arena.allocateUtf8String("SELECT * FROM EMPLOYEE");
             rc = sqlite3_exec(dbPtr, sql, callback, NULL, errMsgPtrPtr);
 
             if (rc != 0) {

--- a/samples/tcl/TCLMain.java
+++ b/samples/tcl/TCLMain.java
@@ -29,7 +29,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import java.lang.foreign.MemorySession;
+import java.lang.foreign.Arena;
 import java.lang.foreign.SegmentAllocator;
 import static java.lang.foreign.MemorySegment.NULL;
 // import jextracted tcl 'header' class
@@ -53,8 +53,8 @@ public class TCLMain {
             puts "Full name: $name(first) $name(last)"
         """;
 
-        try (var session = MemorySession.openConfined()) {
-            var str = session.allocateUtf8String(script);
+        try (var arena = Arena.openConfined()) {
+            var str = arena.allocateUtf8String(script);
             Tcl_Eval(interp, str);
         }
 

--- a/samples/tensorflow/TensorflowLoadSavedModel.java
+++ b/samples/tensorflow/TensorflowLoadSavedModel.java
@@ -45,14 +45,13 @@ public class TensorflowLoadSavedModel {
             System.exit(1);
         }
 
-        try (var session = MemorySession.openConfined()) {
-            var allocator = SegmentAllocator.newNativeArena(session);
+        try (var arena = Arena.openConfined()) {
             var graph = TF_NewGraph();
             var status = TF_NewStatus();
             var sessionOpts = TF_NewSessionOptions();
 
-            var savedModelDir = allocator.allocateUtf8String(args[0]);
-            var tags = allocator.allocate(C_POINTER, allocator.allocateUtf8String("serve"));
+            var savedModelDir = arena.allocateUtf8String(args[0]);
+            var tags = arena.allocate(C_POINTER, arena.allocateUtf8String("serve"));
             var tf_session = TF_LoadSessionFromSavedModel(sessionOpts, NULL, savedModelDir, tags, 1, graph, NULL, status);
 
             if (TF_GetCode(status) != TF_OK()) {
@@ -63,7 +62,7 @@ public class TensorflowLoadSavedModel {
             }
 
             // print operations
-            var size = allocator.allocate(C_LONG_LONG);
+            var size = arena.allocate(C_LONG_LONG);
             var operation = NULL;
             while (!(operation = TF_GraphNextOperation(graph, size)).equals(NULL)) {
                 System.out.printf("%s : %s\n",

--- a/samples/time/PanamaTime.java
+++ b/samples/time/PanamaTime.java
@@ -36,9 +36,9 @@ import org.unix.*;
 
 public class PanamaTime {
     public static void main(String[] args) {
-        try (var session = MemorySession.openConfined()) {
-            var now = session.allocate(C_LONG, System.currentTimeMillis() / 1000);
-            MemorySegment time = tm.allocate(session);
+        try (var arena = Arena.openConfined()) {
+            var now = arena.allocate(C_LONG, System.currentTimeMillis() / 1000);
+            MemorySegment time = tm.allocate(arena);
             localtime_r(now, time);
             System.err.printf("Time = %d:%02d\n", tm.tm_hour$get(time), tm.tm_min$get(time));
         }

--- a/src/main/java/org/openjdk/jextract/clang/ClangDisposable.java
+++ b/src/main/java/org/openjdk/jextract/clang/ClangDisposable.java
@@ -26,6 +26,7 @@
 
 package org.openjdk.jextract.clang;
 
+import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.MemorySession;
 import java.lang.foreign.SegmentAllocator;
@@ -38,14 +39,11 @@ import java.lang.foreign.SegmentAllocator;
  */
 public abstract class ClangDisposable implements SegmentAllocator, AutoCloseable {
     protected final MemorySegment ptr;
-    protected final MemorySession session;
-    protected final SegmentAllocator arena;
+    protected final Arena arena;
 
     public ClangDisposable(MemorySegment ptr, long size, Runnable cleanup) {
-        this.session = MemorySession.openConfined();
-        this.ptr = MemorySegment.ofAddress(ptr.address(), size, session).asReadOnly();
-        session.addCloseAction(cleanup);
-        this.arena = SegmentAllocator.newNativeArena(session);
+        this.arena = Arena.openConfined();
+        this.ptr = MemorySegment.ofAddress(ptr.address(), size, arena.session(), cleanup).asReadOnly();
     }
 
     public ClangDisposable(MemorySegment ptr, Runnable cleanup) {
@@ -54,7 +52,7 @@ public abstract class ClangDisposable implements SegmentAllocator, AutoCloseable
 
     @Override
     public void close() {
-        session.close();
+        arena.close();
     }
 
     @Override

--- a/src/main/java/org/openjdk/jextract/clang/Cursor.java
+++ b/src/main/java/org/openjdk/jextract/clang/Cursor.java
@@ -26,6 +26,7 @@
 
 package org.openjdk.jextract.clang;
 
+import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.MemorySession;
 import org.openjdk.jextract.clang.libclang.CXCursorVisitor;
@@ -119,8 +120,8 @@ public final class Cursor extends ClangDisposable.Owned {
 
     public SourceLocation getSourceLocation() {
         MemorySegment loc = Index_h.clang_getCursorLocation(owner, segment);
-        try (MemorySession session = MemorySession.openConfined()) {
-            if (Index_h.clang_equalLocations(loc, Index_h.clang_getNullLocation(session)) != 0) {
+        try (Arena arena = Arena.openConfined()) {
+            if (Index_h.clang_equalLocations(loc, Index_h.clang_getNullLocation(arena)) != 0) {
                 return null;
             }
         }

--- a/src/main/java/org/openjdk/jextract/clang/Index.java
+++ b/src/main/java/org/openjdk/jextract/clang/Index.java
@@ -26,6 +26,7 @@
 
 package org.openjdk.jextract.clang;
 
+import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.MemorySession;
 import java.lang.foreign.SegmentAllocator;
@@ -70,14 +71,13 @@ public class Index extends ClangDisposable {
 
     public TranslationUnit parseTU(String file, Consumer<Diagnostic> dh, int options, String... args)
             throws ParsingFailedException {
-        try (MemorySession session = MemorySession.openConfined()) {
-            SegmentAllocator allocator = SegmentAllocator.newNativeArena(session);
-            MemorySegment src = allocator.allocateUtf8String(file);
-            MemorySegment cargs = args.length == 0 ? null : allocator.allocateArray(C_POINTER, args.length);
+        try (Arena arena = Arena.openConfined()) {
+            MemorySegment src = arena.allocateUtf8String(file);
+            MemorySegment cargs = args.length == 0 ? null : arena.allocateArray(C_POINTER, args.length);
             for (int i = 0 ; i < args.length ; i++) {
-                cargs.set(C_POINTER, i * C_POINTER.byteSize(), allocator.allocateUtf8String(args[i]));
+                cargs.set(C_POINTER, i * C_POINTER.byteSize(), arena.allocateUtf8String(args[i]));
             }
-            MemorySegment outAddress = allocator.allocate(C_POINTER);
+            MemorySegment outAddress = arena.allocate(C_POINTER);
             ErrorCode code = ErrorCode.valueOf(Index_h.clang_parseTranslationUnit2(
                     ptr,
                     src,

--- a/src/main/java/org/openjdk/jextract/clang/LibClang.java
+++ b/src/main/java/org/openjdk/jextract/clang/LibClang.java
@@ -44,7 +44,7 @@ public class LibClang {
     // crash recovery is not an issue on Windows, so enable it there by default to work around a libclang issue with reparseTranslationUnit
     private static final boolean CRASH_RECOVERY = IS_WINDOWS || Boolean.getBoolean("libclang.crash_recovery");
 
-    private static final SegmentAllocator IMPLICIT_ALLOCATOR = (size, align) -> MemorySegment.allocateNative(size, align);
+    private static final SegmentAllocator IMPLICIT_ALLOCATOR = (size, align) -> MemorySegment.allocateNative(size, align, MemorySession.implicit());
 
     private final static MemorySegment disableCrashRecovery =
             IMPLICIT_ALLOCATOR.allocateUtf8String("LIBCLANG_DISABLE_CRASH_RECOVERY=" + CRASH_RECOVERY);
@@ -87,7 +87,7 @@ public class LibClang {
      * conversion. The size of the prefix segment is set to 256, which should be enough to hold a CXString.
      */
     public final static SegmentAllocator STRING_ALLOCATOR = SegmentAllocator.prefixAllocator(
-            MemorySegment.allocateNative(CXString.sizeof(), 8));
+            MemorySegment.allocateNative(CXString.sizeof(), 8, MemorySession.implicit()));
 
     public static String version() {
         var clangVersion = Index_h.clang_getClangVersion(STRING_ALLOCATOR);

--- a/src/main/java/org/openjdk/jextract/clang/SourceLocation.java
+++ b/src/main/java/org/openjdk/jextract/clang/SourceLocation.java
@@ -25,6 +25,7 @@
  */
 package org.openjdk.jextract.clang;
 
+import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import org.openjdk.jextract.clang.libclang.Index_h;
 
@@ -54,11 +55,11 @@ public class SourceLocation extends ClangDisposable.Owned {
 
     @SuppressWarnings("unchecked")
     private Location getLocation(LocationFactory fn) {
-        try (var session = MemorySession.openConfined()) {
-             MemorySegment file = session.allocate(C_POINTER);
-             MemorySegment line = session.allocate(C_INT);
-             MemorySegment col = session.allocate(C_INT);
-             MemorySegment offset = session.allocate(C_INT);
+        try (var arena = Arena.openConfined()) {
+             MemorySegment file = arena.allocate(C_POINTER);
+             MemorySegment line = arena.allocate(C_INT);
+             MemorySegment col = arena.allocate(C_INT);
+             MemorySegment offset = arena.allocate(C_INT);
 
             fn.get(loc, file, line, col, offset);
             MemorySegment fname = file.get(C_POINTER, 0);

--- a/src/main/java/org/openjdk/jextract/clang/Type.java
+++ b/src/main/java/org/openjdk/jextract/clang/Type.java
@@ -26,6 +26,7 @@
 
 package org.openjdk.jextract.clang;
 
+import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.MemorySession;
 
@@ -105,8 +106,8 @@ public final class Type extends ClangDisposable.Owned {
 
     // Struct/RecordType
     private long getOffsetOf0(String fieldName) {
-        try (MemorySession session = MemorySession.openConfined()) {
-            MemorySegment cfname = session.allocateUtf8String(fieldName);
+        try (Arena arena = Arena.openConfined()) {
+            MemorySegment cfname = arena.allocateUtf8String(fieldName);
             return Index_h.clang_Type_getOffsetOf(segment, cfname);
         }
     }

--- a/src/main/java/org/openjdk/jextract/clang/libclang/RuntimeHelper.java
+++ b/src/main/java/org/openjdk/jextract/clang/libclang/RuntimeHelper.java
@@ -54,8 +54,9 @@ final class RuntimeHelper {
     private final static ClassLoader LOADER = RuntimeHelper.class.getClassLoader();
     private final static MethodHandles.Lookup MH_LOOKUP = MethodHandles.lookup();
     private final static SymbolLookup SYMBOL_LOOKUP;
+
     final static SegmentAllocator CONSTANT_ALLOCATOR =
-            (size, align) -> MemorySegment.allocateNative(size, align);
+            (size, align) -> MemorySegment.allocateNative(size, align, MemorySession.implicit());
 
     static {
         // Manual change to handle platform specific library name difference

--- a/src/main/resources/org/openjdk/jextract/impl/resources/RuntimeHelper.java.template
+++ b/src/main/resources/org/openjdk/jextract/impl/resources/RuntimeHelper.java.template
@@ -31,7 +31,7 @@ final class RuntimeHelper {
     private static final SegmentAllocator THROWING_ALLOCATOR = (x, y) -> { throw new AssertionError("should not reach here"); };
 
     final static SegmentAllocator CONSTANT_ALLOCATOR =
-            (size, align) -> MemorySegment.allocateNative(size, align);
+            (size, align) -> MemorySegment.allocateNative(size, align, MemorySession.implicit());
 
     static {
         #LOAD_LIBRARIES#

--- a/test/jtreg/generator/funcPointerInvokers/TestFuncPointerInvokers.java
+++ b/test/jtreg/generator/funcPointerInvokers/TestFuncPointerInvokers.java
@@ -21,6 +21,7 @@
  * questions.
  */
 
+import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.MemorySession;
@@ -48,31 +49,31 @@ import test.jextract.funcpointers.*;
 public class TestFuncPointerInvokers {
     @Test
     public void testStructFieldTypedef() {
-        try (MemorySession session = MemorySession.openConfined()) {
+        try (Arena arena = Arena.openConfined()) {
             AtomicInteger val = new AtomicInteger(-1);
-            MemorySegment bar = Bar.allocate(session);
-            Bar.foo$set(bar, Foo.allocate((i) -> val.set(i), session));
-            Bar.foo(bar, session).apply(42);
+            MemorySegment bar = Bar.allocate(arena);
+            Bar.foo$set(bar, Foo.allocate((i) -> val.set(i), arena.session()));
+            Bar.foo(bar, arena.session()).apply(42);
             assertEquals(val.get(), 42);
         }
     }
 
     @Test
     public void testStructFieldFITypedef() {
-        try (MemorySession session = MemorySession.openConfined()) {
+        try (Arena arena = Arena.openConfined()) {
             AtomicInteger val = new AtomicInteger(-1);
-            MemorySegment bar = Bar.allocate(session);
-            Bar.foo$set(bar, Foo.allocate((i) -> val.set(i), session));
-            Foo.ofAddress(Bar.foo$get(bar), session).apply(42);
+            MemorySegment bar = Bar.allocate(arena);
+            Bar.foo$set(bar, Foo.allocate((i) -> val.set(i), arena.session()));
+            Foo.ofAddress(Bar.foo$get(bar), arena.session()).apply(42);
             assertEquals(val.get(), 42);
         }
     }
 
     @Test
     public void testGlobalTypedef() {
-        try (MemorySession session = MemorySession.openConfined()) {
+        try (Arena arena = Arena.openConfined()) {
             AtomicInteger val = new AtomicInteger(-1);
-            f$set(Foo.allocate((i) -> val.set(i), session));
+            f$set(Foo.allocate((i) -> val.set(i), arena.session()));
             f().apply(42);
             assertEquals(val.get(), 42);
         }
@@ -80,41 +81,41 @@ public class TestFuncPointerInvokers {
 
     @Test
     public void testGlobalFITypedef() {
-        try (MemorySession session = MemorySession.openConfined()) {
+        try (Arena arena = Arena.openConfined()) {
             AtomicInteger val = new AtomicInteger(-1);
-            f$set(Foo.allocate((i) -> val.set(i), session));
-            Foo.ofAddress(f$get(), session).apply(42);
+            f$set(Foo.allocate((i) -> val.set(i), arena.session()));
+            Foo.ofAddress(f$get(), arena.session()).apply(42);
             assertEquals(val.get(), 42);
         }
     }
 
     @Test
     public void testStructFieldFunctionPointer() {
-        try (MemorySession session = MemorySession.openConfined()) {
+        try (Arena arena = Arena.openConfined()) {
             AtomicInteger val = new AtomicInteger(-1);
-            MemorySegment baz = Baz.allocate(session);
-            Baz.fp$set(baz, Baz.fp.allocate((i) -> val.set(i), session));
-            Baz.fp(baz, session).apply(42);
+            MemorySegment baz = Baz.allocate(arena);
+            Baz.fp$set(baz, Baz.fp.allocate((i) -> val.set(i), arena.session()));
+            Baz.fp(baz, arena.session()).apply(42);
             assertEquals(val.get(), 42);
         }
     }
 
     @Test
     public void testStructFieldFIFunctionPointer() {
-        try (MemorySession session = MemorySession.openConfined()) {
+        try (Arena arena = Arena.openConfined()) {
             AtomicInteger val = new AtomicInteger(-1);
-            MemorySegment baz = Baz.allocate(session);
-            Baz.fp$set(baz, Baz.fp.allocate((i) -> val.set(i), session));
-            Baz.fp.ofAddress(Baz.fp$get(baz), session).apply(42);
+            MemorySegment baz = Baz.allocate(arena);
+            Baz.fp$set(baz, Baz.fp.allocate((i) -> val.set(i), arena.session()));
+            Baz.fp.ofAddress(Baz.fp$get(baz), arena.session()).apply(42);
             assertEquals(val.get(), 42);
         }
     }
 
     @Test
     public void testGlobalFunctionPointer() {
-        try (MemorySession session = MemorySession.openConfined()) {
+        try (Arena arena = Arena.openConfined()) {
             AtomicInteger val = new AtomicInteger(-1);
-            fp$set(fp.allocate((i) -> val.set(i), session));
+            fp$set(fp.allocate((i) -> val.set(i), arena.session()));
             fp().apply(42);
             assertEquals(val.get(), 42);
         }
@@ -122,19 +123,19 @@ public class TestFuncPointerInvokers {
 
     @Test
     public void testGlobalFIFunctionPointer() {
-        try (MemorySession session = MemorySession.openConfined()) {
+        try (Arena arena = Arena.openConfined()) {
             AtomicInteger val = new AtomicInteger(-1);
-            fp$set(fp.allocate((i) -> val.set(i), session));
-            fp.ofAddress(fp$get(), session).apply(42);
+            fp$set(fp.allocate((i) -> val.set(i), arena.session()));
+            fp.ofAddress(fp$get(), arena.session()).apply(42);
             assertEquals(val.get(), 42);
         }
     }
 
     @Test
     public void testGlobalFIFunctionPointerAddress() {
-        try (MemorySession session = MemorySession.openConfined()) {
-            fp_addr$set(fp_addr.allocate((addr) -> MemorySegment.ofAddress(addr.address() + 1), session));
-            assertEquals(fp_addr.ofAddress(fp_addr$get(), session).apply(MemorySegment.ofAddress(42)), MemorySegment.ofAddress(43));
+        try (Arena arena = Arena.openConfined()) {
+            fp_addr$set(fp_addr.allocate((addr) -> MemorySegment.ofAddress(addr.address() + 1), arena.session()));
+            assertEquals(fp_addr.ofAddress(fp_addr$get(), arena.session()).apply(MemorySegment.ofAddress(42)), MemorySegment.ofAddress(43));
         }
     }
 }

--- a/test/jtreg/generator/test8244412/LibTest8244412Test.java
+++ b/test/jtreg/generator/test8244412/LibTest8244412Test.java
@@ -22,8 +22,8 @@
  */
 
 
+import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
-import java.lang.foreign.MemorySession;
 
 import org.testng.annotations.Test;
 import static org.testng.Assert.assertEquals;
@@ -51,8 +51,8 @@ import static test.jextract.test8244412.test8244412_h.*;
 public class LibTest8244412Test {
     @Test
     public void test() {
-        try (var session = MemorySession.openConfined()) {
-            var addr = session.allocate(mysize_t, 0L);
+        try (var arena = Arena.openConfined()) {
+            var addr = arena.allocate(mysize_t, 0L);
             assertEquals(addr.get(C_LONG_LONG, 0), 0L);
             addr.set(C_LONG_LONG, 0, 13455566L);
             assertEquals(addr.get(C_LONG_LONG, 0), 13455566L);

--- a/test/jtreg/generator/test8244938/Test8244938.java
+++ b/test/jtreg/generator/test8244938/Test8244938.java
@@ -22,6 +22,8 @@
  */
 
 import org.testng.annotations.Test;
+
+import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySession;
 import static org.testng.Assert.assertEquals;
 import static test.jextract.test8244938.test8244938_h.*;
@@ -47,8 +49,8 @@ import test.jextract.test8244938.*;
 public class Test8244938 {
     @Test
     public void testNestedStructReturn() {
-         try (MemorySession session = MemorySession.openConfined()) {
-             var seg = func(session);
+         try (Arena arena = Arena.openConfined()) {
+             var seg = func(arena);
              assertEquals(seg.byteSize(), Point.sizeof());
              assertEquals(Point.k$get(seg), 44);
              var point2dSeg = Point.point2d$slice(seg);

--- a/test/jtreg/generator/test8244959/Test8244959.java
+++ b/test/jtreg/generator/test8244959/Test8244959.java
@@ -21,6 +21,7 @@
  * questions.
  */
 
+import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySession;
 import org.testng.annotations.Test;
 
@@ -49,10 +50,10 @@ import static java.lang.foreign.Linker.*;
 public class Test8244959 {
     @Test
     public void testsPrintf() {
-        try (MemorySession session = MemorySession.openConfined()) {
-            MemorySegment s = session.allocate(1024);
+        try (Arena arena = Arena.openConfined()) {
+            MemorySegment s = arena.allocate(1024);
             my_sprintf(s,
-                    session.allocateUtf8String("%hhd %c %.2f %.2f %lld %lld %d %hd %d %d %lld %c"), 12,
+                    arena.allocateUtf8String("%hhd %c %.2f %.2f %lld %lld %d %hd %d %d %lld %c"), 12,
                     (byte) 1, 'b', -1.25f, 5.5d, -200L, Long.MAX_VALUE, (byte) -2, (short) 2, 3, (short) -4, 5L, 'a');
             String str = s.getUtf8String(0);
             assertEquals(str, "1 b -1.25 5.50 -200 " + Long.MAX_VALUE + " -2 2 3 -4 5 a");

--- a/test/jtreg/generator/test8246341/LibTest8246341Test.java
+++ b/test/jtreg/generator/test8246341/LibTest8246341Test.java
@@ -21,6 +21,7 @@
  * questions.
  */
 
+import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.MemorySession;
@@ -51,7 +52,7 @@ public class LibTest8246341Test {
     @Test
     public void testPointerArray() {
         boolean[] callbackCalled = new boolean[1];
-        try (MemorySession session = MemorySession.openConfined()) {
+        try (Arena arena = Arena.openConfined()) {
             var callback = func$callback.allocate((argc, argv) -> {
                 callbackCalled[0] = true;
                 assertEquals(argc, 4);
@@ -59,7 +60,7 @@ public class LibTest8246341Test {
                 assertEquals(argv.get(C_POINTER, C_POINTER.byteSize() * 1).getUtf8String(0), "python");
                 assertEquals(argv.get(C_POINTER, C_POINTER.byteSize() * 2).getUtf8String(0), "javascript");
                 assertEquals(argv.get(C_POINTER, C_POINTER.byteSize() * 3).getUtf8String(0), "c++");
-            }, session);
+            }, arena.session());
             func(callback);
         }
         assertTrue(callbackCalled[0]);
@@ -67,8 +68,8 @@ public class LibTest8246341Test {
 
     @Test
     public void testPointerAllocate() {
-        try (var session = MemorySession.openConfined()) {
-            var addr = session.allocate(C_POINTER);
+        try (var arena = Arena.openConfined()) {
+            var addr = arena.allocate(C_POINTER);
             addr.set(C_POINTER, 0, MemorySegment.NULL);
             fillin(addr);
             assertEquals(addr.get(C_POINTER, 0).getUtf8String(0), "hello world");

--- a/test/jtreg/generator/test8246400/LibTest8246400Test.java
+++ b/test/jtreg/generator/test8246400/LibTest8246400Test.java
@@ -21,6 +21,7 @@
  * questions.
  */
 
+import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.MemorySession;
 import org.testng.annotations.Test;
@@ -49,16 +50,16 @@ public class LibTest8246400Test {
     @Test
     public void testSegmentRegister() {
         MemorySegment sum = null;
-        try (MemorySession session = MemorySession.openConfined()) {
-            var v1 = Vector.allocate(session);
+        try (Arena arena = Arena.openConfined()) {
+            var v1 = Vector.allocate(arena);
             Vector.x$set(v1, 1.0);
             Vector.y$set(v1, 0.0);
 
-            var v2 = Vector.allocate(session);
+            var v2 = Vector.allocate(arena);
             Vector.x$set(v2, 0.0);
             Vector.y$set(v2, 1.0);
 
-            sum = add(session, v1, v2);
+            sum = add(arena, v1, v2);
 
             assertEquals(Vector.x$get(sum), 1.0, 0.1);
             assertEquals(Vector.y$get(sum), 1.0, 0.1);
@@ -66,7 +67,7 @@ public class LibTest8246400Test {
             MemorySegment callback = cosine_similarity$dot.allocate((a, b) -> {
                 return (Vector.x$get(a) * Vector.x$get(b)) +
                     (Vector.y$get(a) * Vector.y$get(b));
-            }, session);
+            }, arena.session());
 
             var value = cosine_similarity(v1, v2, callback);
             assertEquals(value, 0.0, 0.1);

--- a/test/jtreg/generator/test8252016/Test8252016.java
+++ b/test/jtreg/generator/test8252016/Test8252016.java
@@ -21,6 +21,7 @@
  * questions.
  */
 
+import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySession;
 import java.lang.foreign.SegmentAllocator;
 import java.lang.foreign.VaList;
@@ -50,15 +51,15 @@ import static test.jextract.vsprintf.vsprintf_h.*;
 public class Test8252016 {
     @Test
     public void testsVsprintf() {
-        try (MemorySession session = MemorySession.openConfined()) {
-            MemorySegment s = session.allocate(1024);
+        try (Arena arena = Arena.openConfined()) {
+            MemorySegment s = arena.allocate(1024);
             VaList vaList = VaList.make(b -> {
                 b.addVarg(C_INT, 12);
                 b.addVarg(C_DOUBLE, 5.5d);
                 b.addVarg(C_LONG_LONG, -200L);
                 b.addVarg(C_LONG_LONG, Long.MAX_VALUE);
-            }, session);
-            my_vsprintf(s, session.allocateUtf8String("%hhd %.2f %lld %lld"), vaList.segment());
+            }, arena.session());
+            my_vsprintf(s, arena.allocateUtf8String("%hhd %.2f %lld %lld"), vaList.segment());
             String str = s.getUtf8String(0);
             assertEquals(str, "12 5.50 -200 " + Long.MAX_VALUE);
        }

--- a/test/jtreg/generator/test8252121/Test8252121.java
+++ b/test/jtreg/generator/test8252121/Test8252121.java
@@ -23,6 +23,7 @@
 
 import org.testng.annotations.Test;
 
+import java.lang.foreign.Arena;
 import java.util.stream.IntStream;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.MemorySession;
@@ -51,9 +52,9 @@ import static test.jextract.arrayparam.arrayparam_h.*;
 public class Test8252121 {
     @Test
     public void test() {
-        try (var session = MemorySession.openConfined()) {
+        try (var arena = Arena.openConfined()) {
             int[] array = { 3, 5, 89, 34, -33 };
-            MemorySegment seg = session.allocateArray(C_INT, array);
+            MemorySegment seg = arena.allocateArray(C_INT, array);
             assertEquals(IntStream.of(array).sum(), sum(seg));
             assertEquals(IntStream.of(array).reduce(1, (a,b) -> a*b), mul(seg));
         }

--- a/test/jtreg/generator/test8252465/LibTest8252465Test.java
+++ b/test/jtreg/generator/test8252465/LibTest8252465Test.java
@@ -21,6 +21,7 @@
  * questions.
  */
 
+import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySession;
 import org.testng.annotations.Test;
 import static org.testng.Assert.assertEquals;
@@ -48,11 +49,11 @@ import test.jextract.test8252465.*;
 public class LibTest8252465Test {
     @Test
     public void test() {
-        try (var session = MemorySession.openConfined()) {
-            var foo = Foo.allocate(session);
+        try (var arena = Arena.openConfined()) {
+            var foo = Foo.allocate(arena);
             Foo.x$set(foo, 3.14f);
             assertEquals(Foo.x$get(foo), 3.14f, 0.001f);
-            var bar = Bar.allocate(session);
+            var bar = Bar.allocate(arena);
             Bar.x$set(bar, -42);
             assertEquals(Bar.x$get(bar), -42);
         }

--- a/test/jtreg/generator/test8253102/LibTest8253102Test.java
+++ b/test/jtreg/generator/test8253102/LibTest8253102Test.java
@@ -22,6 +22,8 @@
  */
 
 import org.testng.annotations.Test;
+
+import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.MemorySession;
@@ -49,9 +51,9 @@ import test.jextract.test8253102.*;
 public class LibTest8253102Test {
     @Test
     public void test() {
-        try (MemorySession session = MemorySession.openConfined()) {
+        try (Arena arena = Arena.openConfined()) {
             MemorySegment addr = make(14, 99);
-            MemorySegment seg = Point.ofAddress(addr, session);
+            MemorySegment seg = Point.ofAddress(addr, arena.session());
             assertEquals(Point.x$get(seg), 14);
             assertEquals(Point.y$get(seg), 99);
             freePoint(addr);

--- a/test/jtreg/generator/test8254983/LibTest8254983Test.java
+++ b/test/jtreg/generator/test8254983/LibTest8254983Test.java
@@ -21,6 +21,7 @@
  * questions.
  */
 
+import java.lang.foreign.Arena;
 import java.lang.foreign.GroupLayout;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.MemorySession;
@@ -48,9 +49,9 @@ import test.jextract.test8254983.*;
 public class LibTest8254983Test {
     @Test
     public void testOuterStruct() {
-        try (MemorySession session = MemorySession.openConfined()) {
+        try (Arena arena = Arena.openConfined()) {
             assertEquals(((GroupLayout)Foo._struct.$LAYOUT()).memberLayouts().size(), 1);
-            MemorySegment str = Foo._struct.allocate(session);
+            MemorySegment str = Foo._struct.allocate(arena);
             Foo._struct.x$set(str, 42);
             assertEquals(Foo._struct.x$get(str), 42);
         }
@@ -59,8 +60,8 @@ public class LibTest8254983Test {
     @Test
     public void testInnerStruct() {
         assertEquals(((GroupLayout)Foo._union._struct.$LAYOUT()).memberLayouts().size(), 2);
-        try (MemorySession session = MemorySession.openConfined()) {
-            MemorySegment str = Foo._union._struct.allocate(session);
+        try (Arena arena = Arena.openConfined()) {
+            MemorySegment str = Foo._union._struct.allocate(arena);
             Foo._union._struct.x$set(str, 42);
             assertEquals(Foo._union._struct.x$get(str), 42);
         }

--- a/test/jtreg/generator/test8257892/LibUnsupportedTest.java
+++ b/test/jtreg/generator/test8257892/LibUnsupportedTest.java
@@ -21,6 +21,7 @@
  * questions.
  */
 
+import java.lang.foreign.Arena;
 import java.lang.reflect.Method;
 import java.lang.foreign.GroupLayout;
 import java.lang.foreign.MemoryLayout;
@@ -53,8 +54,8 @@ import test.jextract.unsupported.*;
 public class LibUnsupportedTest {
     @Test
     public void testAllocateFoo() {
-        try (MemorySession session = MemorySession.openConfined()) {
-            var seg = Foo.allocate(session);
+        try (Arena arena = Arena.openConfined()) {
+            var seg = Foo.allocate(arena);
             Foo.i$set(seg, 32);
             Foo.c$set(seg, (byte)'z');
             assertEquals(Foo.i$get(seg), 32);
@@ -64,8 +65,8 @@ public class LibUnsupportedTest {
 
     @Test
     public void testGetFoo() {
-        try (MemorySession session = MemorySession.openConfined()) {
-            var seg = MemorySegment.ofAddress(getFoo().address(), Foo.sizeof(), session);
+        try (Arena arena = Arena.openConfined()) {
+            var seg = MemorySegment.ofAddress(getFoo().address(), Foo.sizeof(), arena.session());
             Foo.i$set(seg, 42);
             Foo.c$set(seg, (byte)'j');
             assertEquals(Foo.i$get(seg), 42);

--- a/test/jtreg/generator/test8258605/LibTest8258605Test.java
+++ b/test/jtreg/generator/test8258605/LibTest8258605Test.java
@@ -21,6 +21,7 @@
  * questions.
  */
 
+import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySession;
 import org.testng.annotations.Test;
 import test.jextract.test8258605.*;
@@ -48,30 +49,30 @@ import static test.jextract.test8258605.funcParam_h.*;
 public class LibTest8258605Test {
     @Test
     public void testFunctionCallback() {
-        try (MemorySession session = MemorySession.openConfined()) {
+        try (Arena arena = Arena.openConfined()) {
              boolean[] callbackReached = new boolean[1];
              f(CB.allocate(i -> {
                  assertTrue(i == 10);
                  callbackReached[0] = true;
-             }, session));
+             }, arena.session()));
              assertTrue(callbackReached[0]);
         }
     }
 
     @Test
     public void testStructFunctionPointerCallback() {
-        try (MemorySession session = MemorySession.openConfined()) {
+        try (Arena arena = Arena.openConfined()) {
              boolean[] callbackReached = new boolean[1];
 
              // get struct Foo instance
-             var foo = getFoo(session);
+             var foo = getFoo(arena);
              // make sure that foo.bar is not NULL
              assertFalse(Foo.bar$get(foo).equals(NULL));
 
              f2(foo, CB.allocate(i -> {
                  assertTrue(i == 42);
                  callbackReached[0] = true;
-             }, session));
+             }, arena.session()));
              assertTrue(callbackReached[0]);
         }
     }

--- a/test/jtreg/generator/test8261511/Test8261511.java
+++ b/test/jtreg/generator/test8261511/Test8261511.java
@@ -22,6 +22,8 @@
  */
 
 import org.testng.annotations.Test;
+
+import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySession;
 import test.jextract.test8261511.*;
 import static org.testng.Assert.assertEquals;
@@ -46,9 +48,9 @@ import static test.jextract.test8261511.test8261511_h.*;
 public class Test8261511 {
     @Test
     public void test() {
-        try (MemorySession session = MemorySession.openConfined()) {
-            var funcPtr = Foo.sum$get(get_foo(session));
-            var sumIface = Foo.sum.ofAddress(funcPtr, session);
+        try (Arena arena = Arena.openConfined()) {
+            var funcPtr = Foo.sum$get(get_foo(arena));
+            var sumIface = Foo.sum.ofAddress(funcPtr, arena.session());
             assertEquals(sumIface.apply(15,20), 35);
             assertEquals(sum(1.2, 4.5), 5.7, 0.001);
         }

--- a/test/jtreg/generator/testFunctionPointer/LibFuncPtrTest.java
+++ b/test/jtreg/generator/testFunctionPointer/LibFuncPtrTest.java
@@ -21,6 +21,7 @@
  * questions.
  */
 
+import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySession;
 import org.testng.annotations.Test;
 
@@ -43,8 +44,8 @@ import test.jextract.fp.*;
 public class LibFuncPtrTest {
     @Test
     public void test() {
-        try (MemorySession session = MemorySession.openConfined()) {
-            var handle = func$f.allocate(x -> x * x, session);
+        try (Arena arena = Arena.openConfined()) {
+            var handle = func$f.allocate(x -> x * x, arena.session());
             assertEquals(func(handle, 35), 35 * 35 + 35);
         }
     }

--- a/test/jtreg/generator/testStruct/LibStructTest.java
+++ b/test/jtreg/generator/testStruct/LibStructTest.java
@@ -21,6 +21,7 @@
  * questions.
  */
 
+import java.lang.foreign.Arena;
 import java.lang.foreign.GroupLayout;
 import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemoryLayout.PathElement;
@@ -49,8 +50,8 @@ import test.jextract.struct.*;
 public class LibStructTest {
     @Test
     public void testMakePoint() {
-        try (MemorySession session = MemorySession.openConfined()) {
-            var seg = makePoint(session, 42, -39);
+        try (Arena arena = Arena.openConfined()) {
+            var seg = makePoint(arena, 42, -39);
             assertEquals(Point.x$get(seg), 42);
             assertEquals(Point.y$get(seg), -39);
         }
@@ -58,8 +59,8 @@ public class LibStructTest {
 
     @Test
     public void testAllocate() {
-        try (MemorySession session = MemorySession.openConfined()) {
-            var seg = Point.allocate(session);
+        try (Arena arena = Arena.openConfined()) {
+            var seg = Point.allocate(arena);
             Point.x$set(seg, 56);
             Point.y$set(seg, 65);
             assertEquals(Point.x$get(seg), 56);
@@ -69,8 +70,8 @@ public class LibStructTest {
 
     @Test
     public void testAllocateArray() {
-        try (MemorySession session = MemorySession.openConfined()) {
-            var seg = Point.allocateArray(3, session);
+        try (Arena arena = Arena.openConfined()) {
+            var seg = Point.allocateArray(3, arena);
             for (int i = 0; i < 3; i++) {
                 Point.x$set(seg, i, 56 + i);
                 Point.y$set(seg, i, 65 + i);

--- a/test/testng/org/openjdk/jextract/test/toolprovider/TestClassGeneration.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/TestClassGeneration.java
@@ -22,6 +22,7 @@
  */
 package org.openjdk.jextract.test.toolprovider;
 
+import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemorySegment;
@@ -185,8 +186,8 @@ public class TestClassGeneration extends JextractToolRunner {
         Class<?> structCls = loader.loadClass("com.acme." + structName);
         Method layout_getter = checkMethod(structCls, "$LAYOUT", MemoryLayout.class);
         MemoryLayout structLayout = (MemoryLayout) layout_getter.invoke(null);
-        try (MemorySession session = MemorySession.openConfined()) {
-            MemorySegment struct = session.allocate(structLayout);
+        try (Arena arena = Arena.openConfined()) {
+            MemorySegment struct = arena.allocate(structLayout);
             Method vh_getter = checkMethod(structCls, memberName + "$VH", VarHandle.class);
             VarHandle vh = (VarHandle) vh_getter.invoke(null);
             assertEquals(vh.varType(), expectedType);

--- a/test/testng/org/openjdk/jextract/test/toolprovider/TestNested.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/TestNested.java
@@ -23,7 +23,7 @@
 
 package org.openjdk.jextract.test.toolprovider;
 
-import java.lang.foreign.MemorySession;
+import java.lang.foreign.Arena;
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Method;
 import java.nio.file.Path;
@@ -155,8 +155,8 @@ public class TestNested extends JextractToolRunner {
             if (type == MemorySegment.class) {
                 Method slicer = cls.getMethod(fieldName + "$slice", MemorySegment.class);
                 assertEquals(slicer.getReturnType(), MemorySegment.class);
-                try (MemorySession session = MemorySession.openConfined()) {
-                    MemorySegment struct = session.allocate(layout);
+                try (Arena arena = Arena.openConfined()) {
+                    MemorySegment struct = arena.allocate(layout);
                     MemorySegment slice = (MemorySegment) slicer.invoke(null, struct);
                     assertEquals(slice.byteSize(), fieldLayout.byteSize());
                 }
@@ -167,8 +167,8 @@ public class TestNested extends JextractToolRunner {
                 assertEquals(setter.getReturnType(), void.class);
 
                 Object zero = MethodHandles.zero(type).invoke();
-                try (MemorySession session = MemorySession.openConfined()) {
-                    MemorySegment struct = session.allocate(layout);
+                try (Arena arena = Arena.openConfined()) {
+                    MemorySegment struct = arena.allocate(layout);
                     setter.invoke(null, struct, zero);
                     Object actual = getter.invoke(null, struct);
                     assertEquals(actual, zero);


### PR DESCRIPTION
syncing for Panama api changes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Issue
 * [CODETOOLS-7903380](https://bugs.openjdk.org/browse/CODETOOLS-7903380): sync jextract for memory session a pure lifetime abstraction panama api change


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract pull/92/head:pull/92` \
`$ git checkout pull/92`

Update a local copy of the PR: \
`$ git checkout pull/92` \
`$ git pull https://git.openjdk.org/jextract pull/92/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 92`

View PR using the GUI difftool: \
`$ git pr show -t 92`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/92.diff">https://git.openjdk.org/jextract/pull/92.diff</a>

</details>
