### PR TITLE
Fix code sample in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ import org.jextract.Point2d;
 
 class TestPoint {
     public static void main(String[] args) {
-        try (var session = MemorySession.openConfined()) {
-           MemorySegment point = MemorySegment.allocateNative(Point2d.$LAYOUT(), session);
+        try (var arena = Arena.openConfined()) {
+           MemorySegment point = arena.allocate(Point2d.$LAYOUT());
            Point2d.x$set(point, 3d);
            Point2d.y$set(point, 4d);
            distance(point);


### PR DESCRIPTION
The Point sample in the README contained a reference to `MemorySession`, which is gone from the 20 API.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract pull/98/head:pull/98` \
`$ git checkout pull/98`

Update a local copy of the PR: \
`$ git checkout pull/98` \
`$ git pull https://git.openjdk.org/jextract pull/98/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 98`

View PR using the GUI difftool: \
`$ git pr show -t 98`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/98.diff">https://git.openjdk.org/jextract/pull/98.diff</a>

</details>
