### PR TITLE
Update code to use address target layouts

### DIFF
--- a/src/main/java/org/openjdk/jextract/clang/libclang/Constants$root.java
+++ b/src/main/java/org/openjdk/jextract/clang/libclang/Constants$root.java
@@ -44,7 +44,8 @@ final class Constants$root {
     static final OfLong C_LONG_LONG$LAYOUT = JAVA_LONG;
     static final OfFloat C_FLOAT$LAYOUT = JAVA_FLOAT;
     static final OfDouble C_DOUBLE$LAYOUT = JAVA_DOUBLE;
-    static final OfAddress C_POINTER$LAYOUT = ADDRESS.withBitAlignment(64).asUnbounded();
+    static final OfAddress C_POINTER$LAYOUT = ADDRESS.withBitAlignment(64)
+            .withTargetLayout(MemoryLayout.sequenceLayout(C_CHAR$LAYOUT));
 }
 
 

--- a/src/main/java/org/openjdk/jextract/impl/ToplevelBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/ToplevelBuilder.java
@@ -31,6 +31,8 @@ import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.ValueLayout;
 import org.openjdk.jextract.Declaration;
 import org.openjdk.jextract.Type;
+import org.openjdk.jextract.Type.Primitive;
+import org.openjdk.jextract.Type.Primitive.Kind;
 
 import javax.tools.JavaFileObject;
 import java.lang.constant.ClassDesc;
@@ -261,7 +263,9 @@ class ToplevelBuilder extends JavaSourceBuilder {
             } else if (vl.carrier() == double.class) {
                 return "JAVA_DOUBLE" + withBitAlignmentIfNeeded(ValueLayout.JAVA_DOUBLE, vl);
             } else if (vl.carrier() == MemorySegment.class) {
-                return "ADDRESS.withBitAlignment(" + vl.bitAlignment() + ").asUnbounded()";
+                return "ADDRESS.withBitAlignment(" + vl.bitAlignment() + ")" +
+                ".withTargetLayout(MemoryLayout.sequenceLayout(" +
+                        resolvePrimitiveLayout((ValueLayout)Primitive.Kind.Char.layout().get()).accessExpression() + "))";
             } else {
                 return "MemoryLayout.paddingLayout(" + vl.bitSize() +  ")";
             }

--- a/src/main/java/org/openjdk/jextract/impl/TypeImpl.java
+++ b/src/main/java/org/openjdk/jextract/impl/TypeImpl.java
@@ -179,7 +179,8 @@ public abstract class TypeImpl implements Type {
     }
 
     public static final class PointerImpl extends DelegatedBase {
-        public static final ValueLayout.OfAddress POINTER_LAYOUT = ADDRESS.withBitAlignment(64).asUnbounded();
+        public static final ValueLayout.OfAddress POINTER_LAYOUT = ADDRESS.withBitAlignment(64)
+                .withTargetLayout(MemoryLayout.sequenceLayout(ValueLayout.JAVA_BYTE));
 
         private final Supplier<Type> pointeeFactory;
 

--- a/test/lib/testlib/JextractToolRunner.java
+++ b/test/lib/testlib/JextractToolRunner.java
@@ -61,7 +61,8 @@ public class JextractToolRunner {
     public static final ValueLayout.OfLong C_LONG_LONG = ValueLayout.JAVA_LONG.withBitAlignment(64);
     public static final ValueLayout.OfFloat C_FLOAT = ValueLayout.JAVA_FLOAT.withBitAlignment(32);
     public static final ValueLayout.OfDouble C_DOUBLE = ValueLayout.JAVA_DOUBLE.withBitAlignment(64);
-    public static final ValueLayout.OfAddress C_POINTER = ValueLayout.ADDRESS.withBitAlignment(ValueLayout.ADDRESS.bitSize()).asUnbounded();
+    public static final ValueLayout.OfAddress C_POINTER = ValueLayout.ADDRESS
+            .withTargetLayout(MemoryLayout.sequenceLayout(C_CHAR));
 
     // (private) exit codes from jextract tool. Copied from JextractTool.
     protected static final int SUCCESS       = 0;


### PR DESCRIPTION
This patch tweaks jextract to replace usages of `OfAddress.asUnbounded` with:

`withTargetLayout(sequenceLayout(JAVA_BYTE))`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract pull/100/head:pull/100` \
`$ git checkout pull/100`

Update a local copy of the PR: \
`$ git checkout pull/100` \
`$ git pull https://git.openjdk.org/jextract pull/100/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 100`

View PR using the GUI difftool: \
`$ git pr show -t 100`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/100.diff">https://git.openjdk.org/jextract/pull/100.diff</a>

</details>
