### PR TITLE
Fix jextract after removal of support for sub-byte layouts

### DIFF
--- a/src/main/java/org/openjdk/jextract/Declaration.java
+++ b/src/main/java/org/openjdk/jextract/Declaration.java
@@ -248,6 +248,22 @@ public interface Declaration {
     }
 
     /**
+     * A bitfield declaration. Same as a variable declaration, but doesn't have a layout. Instead, it has
+     * an offset (relative to the enclosing container) and a width.
+     */
+    interface Bitfield extends Variable {
+        /**
+         * {@return The bitfield offset (relative to the enclosing container)}
+         */
+        long offset();
+
+        /**
+         * {@return The bitfield width (in bits)}
+         */
+        long width();
+    }
+
+    /**
      * A constant value declaration.
      */
     interface Constant extends Declaration {
@@ -354,15 +370,16 @@ public interface Declaration {
     }
 
     /**
-     * Creates a new bitfield declaration with given name, type and layout.
+     * Creates a new bitfield declaration with given name, type, offset and width.
      * @param pos the bitfield declaration position.
      * @param name the bitfield declaration name.
      * @param type the bitfield declaration type.
-     * @param layout the bitfield declaration layout.
+     * @param offset the offset of the bitfield (relative to the enclosing container).
+     * @param width the bitfield width.
      * @return a new bitfield declaration with given name, type and layout.
      */
-    static Declaration.Variable bitfield(Position pos, String name, Type type, MemoryLayout layout) {
-        return new DeclarationImpl.VariableImpl(type, layout, Declaration.Variable.Kind.BITFIELD, name, pos);
+    static Declaration.Variable bitfield(Position pos, String name, Type type, long offset, long width) {
+        return new DeclarationImpl.BitfieldImpl(type, offset, width, name, pos);
     }
 
     /**
@@ -414,13 +431,12 @@ public interface Declaration {
     /**
      * Creates a new bitfields group declaration with given name and layout.
      * @param pos the bitfields group declaration position.
-     * @param layout the bitfields group declaration layout.
      * @param bitfields the bitfields group member declarations.
      * @return a new bitfields group declaration with given name and layout.
      */
-    static Declaration.Scoped bitfields(Position pos, MemoryLayout layout, Declaration.Variable... bitfields) {
+    static Declaration.Scoped bitfields(Position pos, Declaration.Variable... bitfields) {
         List<Declaration> declList = List.of(bitfields);
-        return new DeclarationImpl.ScopedImpl(Declaration.Scoped.Kind.BITFIELDS, layout, declList, "", pos);
+        return new DeclarationImpl.ScopedImpl(Declaration.Scoped.Kind.BITFIELDS, declList, "", pos);
     }
 
     /**

--- a/src/main/java/org/openjdk/jextract/impl/DeclarationImpl.java
+++ b/src/main/java/org/openjdk/jextract/impl/DeclarationImpl.java
@@ -141,7 +141,7 @@ public abstract class DeclarationImpl implements Declaration {
         }
     }
 
-    public static final class VariableImpl extends DeclarationImpl implements Declaration.Variable {
+    public static class VariableImpl extends DeclarationImpl implements Declaration.Variable {
 
         final Variable.Kind kind;
         final Type type;
@@ -204,6 +204,56 @@ public abstract class DeclarationImpl implements Declaration {
         @Override
         public int hashCode() {
             return Objects.hash(super.hashCode(), kind, type);
+        }
+    }
+
+    public static final class BitfieldImpl extends VariableImpl implements Declaration.Bitfield {
+
+        final long offset;
+        final long width;
+
+        private BitfieldImpl(Type type, long offset, long width, String name, Position pos, Map<String, List<Constable>> attrs) {
+            super(type, Optional.<MemoryLayout>empty(), Kind.BITFIELD, name, pos, attrs);
+            this.offset = offset;
+            this.width = width;
+        }
+
+        public BitfieldImpl(Type type, long offset, long width, String name, Position pos) {
+            this(type, offset, width, name, pos, null);
+        }
+
+        @Override
+        public long offset() {
+            return offset;
+        }
+
+        @Override
+        public long width() {
+            return width;
+        }
+
+        @Override
+        public Variable withAttributes(Map<String, List<Constable>> attrs) {
+            return new BitfieldImpl(type, offset, width, name(), pos(), attrs);
+        }
+
+        @Override
+        public Variable stripAttributes() {
+            return new BitfieldImpl(type, offset, width, name(), pos(), null);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof BitfieldImpl bitfield)) return false;
+            if (!super.equals(o)) return false;
+            return offset == bitfield.offset &&
+                    width == bitfield.width;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(super.hashCode(), offset, width);
         }
     }
 

--- a/src/main/java/org/openjdk/jextract/impl/PrettyPrinter.java
+++ b/src/main/java/org/openjdk/jextract/impl/PrettyPrinter.java
@@ -31,6 +31,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.lang.foreign.MemoryLayout;
 import org.openjdk.jextract.Declaration;
+import org.openjdk.jextract.Declaration.Bitfield;
+import org.openjdk.jextract.Declaration.Variable.Kind;
 import org.openjdk.jextract.Position;
 import org.openjdk.jextract.Type;
 
@@ -104,7 +106,12 @@ public class PrettyPrinter implements Declaration.Visitor<Void, Void> {
     @Override
     public Void visitVariable(Declaration.Variable d, Void aVoid) {
         indent();
-        builder.append("Variable: " + d.kind() + " " + d.name() + " type = " + d.type().accept(typeVisitor, null) + ", layout = " + d.layout());
+        if (d instanceof Bitfield bitfield) {
+            builder.append("Bitfield: " + " type = " + d.type().accept(typeVisitor, null) + ", name = " + bitfield.name()
+                    + ", offset = " + bitfield.offset() + ", width = " + bitfield.width());
+        } else {
+            builder.append("Variable: " + d.kind() + " " + d.name() + " type = " + d.type().accept(typeVisitor, null) + ", layout = " + d.layout());
+        }
         builder.append("\n");
         getAttributes(d);
         return null;

--- a/src/main/java/org/openjdk/jextract/impl/RecordLayoutComputer.java
+++ b/src/main/java/org/openjdk/jextract/impl/RecordLayoutComputer.java
@@ -139,7 +139,7 @@ abstract class RecordLayoutComputer {
         if (c.isAnonymousStruct()) {
             addField(((org.openjdk.jextract.Type.Declared)computeAnonymous(typeMaker, offset, parent, c.type(), nextAnonymousName())).tree());
         } else {
-            addField(field(c));
+            addField(field(offset, c));
         }
     }
 
@@ -147,12 +147,11 @@ abstract class RecordLayoutComputer {
         return "$anon$" + anonCount++;
     }
 
-    Declaration field(Cursor c) {
+    Declaration field(long offset, Cursor c) {
         org.openjdk.jextract.Type type = typeMaker.makeType(c.type());
         String name = c.spelling();
         if (c.isBitField()) {
-            MemoryLayout sublayout = MemoryLayout.paddingLayout(c.getBitFieldWidth());
-            return Declaration.bitfield(TreeMaker.CursorPosition.of(c), name, type, sublayout.withName(name));
+            return Declaration.bitfield(TreeMaker.CursorPosition.of(c), name, type, offset, c.getBitFieldWidth());
         } else if (c.isAnonymousStruct() && type instanceof org.openjdk.jextract.Type.Declared decl) {
             return decl.tree();
         } else {
@@ -167,8 +166,8 @@ abstract class RecordLayoutComputer {
         return c.isBitField() ? c.getBitFieldWidth() : c.type().size() * 8;
     }
 
-    Declaration.Scoped bitfield(List<MemoryLayout> sublayouts, Declaration.Variable... declarations) {
-        return Declaration.bitfields(declarations[0].pos(), MemoryLayout.structLayout(sublayouts.toArray(new MemoryLayout[0])), declarations);
+    Declaration.Scoped bitfield(Declaration.Variable... declarations) {
+        return Declaration.bitfields(declarations[0].pos(), declarations);
     }
 
     long offsetOf(Type parent, Cursor c) {

--- a/src/main/java/org/openjdk/jextract/impl/TreeMaker.java
+++ b/src/main/java/org/openjdk/jextract/impl/TreeMaker.java
@@ -98,9 +98,7 @@ class TreeMaker {
         return switch (c.kind()) {
             case EnumDecl -> createEnum(c);
             case EnumConstantDecl -> createEnumConstant(c);
-            case FieldDecl -> c.isBitField() ?
-                        createBitfield(c) :
-                        createVar(c, Declaration.Variable.Kind.FIELD);
+            case FieldDecl -> createVar(c, Declaration.Variable.Kind.FIELD);
             case ParmDecl -> createVar(c, Declaration.Variable.Kind.PARAMETER);
             case FunctionDecl -> createFunction(c);
             case StructDecl -> createRecord(c, Declaration.Scoped.Kind.STRUCT);
@@ -314,13 +312,8 @@ class TreeMaker {
         }
     }
 
-    private Declaration.Variable createBitfield(Cursor c) {
-        checkCursorAny(c, CursorKind.FieldDecl);
-        return Declaration.bitfield(CursorPosition.of(c), c.spelling(), toType(c),
-                MemoryLayout.paddingLayout(c.getBitFieldWidth()));
-    }
-
     private Declaration.Variable createVar(Cursor c, Declaration.Variable.Kind kind) {
+        if (c.isBitField()) throw new AssertionError("Cannot get here!");
         checkCursorAny(c, CursorKind.VarDecl, CursorKind.FieldDecl, CursorKind.ParmDecl);
         Type type;
         try {

--- a/src/main/java/org/openjdk/jextract/impl/UnionLayoutComputer.java
+++ b/src/main/java/org/openjdk/jextract/impl/UnionLayoutComputer.java
@@ -64,12 +64,12 @@ final class UnionLayoutComputer extends RecordLayoutComputer {
     }
 
     @Override
-    Declaration field(Cursor c) {
+    Declaration field(long offset, Cursor c) {
         if (c.isBitField()) {
-            Declaration.Variable var = (Declaration.Variable)super.field(c);
-            return bitfield(List.of(var.layout().get()), var);
+            Declaration.Variable var = (Declaration.Variable)super.field(offset, c);
+            return bitfield(var);
         } else {
-            return super.field(c);
+            return super.field(offset, c);
         }
     }
 

--- a/test/lib/testlib/JextractApiTestBase.java
+++ b/test/lib/testlib/JextractApiTestBase.java
@@ -120,7 +120,7 @@ public class JextractApiTestBase {
     public static Declaration.Variable checkBitField(Declaration.Scoped record, String name, Type type, int size) {
         Declaration.Variable global = checkVariable(record, name, type);
         assertEquals(global.kind(), Declaration.Variable.Kind.BITFIELD);
-        assertEquals(global.layout().get().bitSize(), size);
+        assertEquals(((Declaration.Bitfield)global).width(), size);
         return global;
     }
 


### PR DESCRIPTION
This patch fixes some test failures which are caused by https://git.openjdk.org/panama-foreign/pull/766.

As that patch removes support for sub-byte layouts, we can no longer represent bitfields using group layouts (because we can no longer model group elements whose size is not a multiple off 8).

In reality, jextract isn't doing much with bitfields: it just generates a bunch of padding layouts of the right size and storing them into a group layout, but this layout, of course, cannot be used for access (because sub-byte layout doesn't work with VarHandles).

To fix this, I have added a new subtype of `Declaration.Variable` - namely, `Declaration.Bitfield` - this is like a variable - it has a name (but no layout), and has a type. On top of this, a `Bitfield` also stores an `offset` (relative to the contained) and a `width` (the size in bits of the bitfield).

Most of the changes in this patch are caused by the fact that the underlying IR for bitfields has changed (as described above). Since bitfields are still variables (whose kind is `BITFIELD`) and since variable of that kind are ignored by the jextract backend, nothing is going to change, really. That said, should we want to add bitfield accessors one day, all the info to generate the accessor should be available in the jextract IR.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Reviewers
 * [Athijegannathan Sundararajan](https://openjdk.org/census#sundar) (@sundararajana - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract pull/101/head:pull/101` \
`$ git checkout pull/101`

Update a local copy of the PR: \
`$ git checkout pull/101` \
`$ git pull https://git.openjdk.org/jextract pull/101/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 101`

View PR using the GUI difftool: \
`$ git pr show -t 101`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/101.diff">https://git.openjdk.org/jextract/pull/101.diff</a>

</details>
