### PR TITLE
Tweak jextract to reflect changes to `MemorySegment::ofAddress`

### DIFF
--- a/samples/dlopen/Dlopen.java
+++ b/samples/dlopen/Dlopen.java
@@ -45,8 +45,7 @@ public class Dlopen {
             if (handleAddr.equals(MemorySegment.NULL)) {
                 throw new IllegalArgumentException("Cannot find library: " + libraryName);
             }
-            var handle = MemorySegment.ofAddress(handleAddr.address(), 0, arena,
-                () -> dlclose(handleAddr));
+            var handle = handleAddr.reinterpret(arena.scope(), org.unix.dlfcn_h::dlclose);
             return name -> {
                 try (var newArena = Arena.ofConfined()) {
                     var addr = dlsym(handle, newArena.allocateUtf8String(name));

--- a/samples/libffmpeg/LibffmpegMain.java
+++ b/samples/libffmpeg/LibffmpegMain.java
@@ -290,7 +290,8 @@ public class LibffmpegMain {
             // Write pixel data
             for (int y = 0; y < height; y++) {
                 // frameRGB.data[0] + y*frameRGB.linesize[0] is the pointer. And 3*width size of data
-                var pixelArray = MemorySegment.ofAddress(pdata.address() + y*linesize, 3*width, arena);
+                var pixelArray = pdata.slice(y * linesize)
+                                      .reinterpret(3*width, arena.scope(), null);
                 // dump the pixel byte buffer to file
                 os.write(pixelArray.toArray(C_CHAR));
             }

--- a/samples/libjimage/org/openjdk/JImageClose_t.java
+++ b/samples/libjimage/org/openjdk/JImageClose_t.java
@@ -18,8 +18,8 @@ public interface JImageClose_t {
     static MemorySegment allocate(JImageClose_t fi, Arena scope) {
         return RuntimeHelper.upcallStub(JImageClose_t.class, fi, constants$0.JImageClose_t$FUNC, scope);
     }
-    static JImageClose_t ofAddress(MemorySegment addr, Arena scope) {
-        MemorySegment symbol = MemorySegment.ofAddress(addr.address(), 0, scope);
+    static JImageClose_t ofAddress(MemorySegment addr, Arena arena) {
+        MemorySegment symbol = addr.reinterpret(arena.scope(), null);
         return (java.lang.foreign.MemorySegment _jimage) -> {
             try {
                 constants$0.JImageClose_t$MH.invokeExact(symbol, _jimage);

--- a/samples/libjimage/org/openjdk/JImageFindResource_t.java
+++ b/samples/libjimage/org/openjdk/JImageFindResource_t.java
@@ -18,8 +18,8 @@ public interface JImageFindResource_t {
     static MemorySegment allocate(JImageFindResource_t fi, Arena scope) {
         return RuntimeHelper.upcallStub(JImageFindResource_t.class, fi, constants$1.JImageFindResource_t$FUNC, scope);
     }
-    static JImageFindResource_t ofAddress(MemorySegment addr, Arena scope) {
-        MemorySegment symbol = MemorySegment.ofAddress(addr.address(), 0, scope);
+    static JImageFindResource_t ofAddress(MemorySegment addr, Arena arena) {
+        MemorySegment symbol = addr.reinterpret(arena.scope(), null);
         return (java.lang.foreign.MemorySegment _jimage, java.lang.foreign.MemorySegment _module_name, java.lang.foreign.MemorySegment _version, java.lang.foreign.MemorySegment _name, java.lang.foreign.MemorySegment _size) -> {
             try {
                 return (long)constants$1.JImageFindResource_t$MH.invokeExact(symbol, _jimage, _module_name, _version, _name, _size);

--- a/samples/libjimage/org/openjdk/JImageGetResource_t.java
+++ b/samples/libjimage/org/openjdk/JImageGetResource_t.java
@@ -18,8 +18,8 @@ public interface JImageGetResource_t {
     static MemorySegment allocate(JImageGetResource_t fi, Arena scope) {
         return RuntimeHelper.upcallStub(JImageGetResource_t.class, fi, constants$2.JImageGetResource_t$FUNC, scope);
     }
-    static JImageGetResource_t ofAddress(MemorySegment addr, Arena scope) {
-        MemorySegment symbol = MemorySegment.ofAddress(addr.address(), 0, scope);
+    static JImageGetResource_t ofAddress(MemorySegment addr, Arena arena) {
+        MemorySegment symbol = addr.reinterpret(arena.scope(), null);
         return (java.lang.foreign.MemorySegment _jimage, long _location, java.lang.foreign.MemorySegment _buffer, long _size) -> {
             try {
                 return (long)constants$2.JImageGetResource_t$MH.invokeExact(symbol, _jimage, _location, _buffer, _size);

--- a/samples/libjimage/org/openjdk/JImageOpen_t.java
+++ b/samples/libjimage/org/openjdk/JImageOpen_t.java
@@ -18,8 +18,8 @@ public interface JImageOpen_t {
     static MemorySegment allocate(JImageOpen_t fi, Arena scope) {
         return RuntimeHelper.upcallStub(JImageOpen_t.class, fi, constants$0.JImageOpen_t$FUNC, scope);
     }
-    static JImageOpen_t ofAddress(MemorySegment addr, Arena scope) {
-        MemorySegment symbol = MemorySegment.ofAddress(addr.address(), 0, scope);
+    static JImageOpen_t ofAddress(MemorySegment addr, Arena arena) {
+        MemorySegment symbol = addr.reinterpret(arena.scope(), null);
         return (java.lang.foreign.MemorySegment _jimage, java.lang.foreign.MemorySegment _package_name) -> {
             try {
                 return (java.lang.foreign.MemorySegment)constants$0.JImageOpen_t$MH.invokeExact(symbol, _jimage, _package_name);

--- a/samples/libjimage/org/openjdk/JImagePackageToModule_t.java
+++ b/samples/libjimage/org/openjdk/JImagePackageToModule_t.java
@@ -18,8 +18,8 @@ public interface JImagePackageToModule_t {
     static MemorySegment allocate(JImagePackageToModule_t fi, Arena scope) {
         return RuntimeHelper.upcallStub(JImagePackageToModule_t.class, fi, constants$1.JImagePackageToModule_t$FUNC, scope);
     }
-    static JImagePackageToModule_t ofAddress(MemorySegment addr, Arena scope) {
-        MemorySegment symbol = MemorySegment.ofAddress(addr.address(), 0, scope);
+    static JImagePackageToModule_t ofAddress(MemorySegment addr, Arena arena) {
+        MemorySegment symbol = addr.reinterpret(arena.scope(), null);
         return (java.lang.foreign.MemorySegment _jimage, java.lang.foreign.MemorySegment _package_name) -> {
             try {
                 return (java.lang.foreign.MemorySegment)constants$1.JImagePackageToModule_t$MH.invokeExact(symbol, _jimage, _package_name);

--- a/samples/libjimage/org/openjdk/JImageResourceIterator_t.java
+++ b/samples/libjimage/org/openjdk/JImageResourceIterator_t.java
@@ -18,8 +18,8 @@ public interface JImageResourceIterator_t {
     static MemorySegment allocate(JImageResourceIterator_t fi, Arena scope) {
         return RuntimeHelper.upcallStub(JImageResourceIterator_t.class, fi, constants$3.JImageResourceIterator_t$FUNC, scope);
     }
-    static JImageResourceIterator_t ofAddress(MemorySegment addr, Arena scope) {
-        MemorySegment symbol = MemorySegment.ofAddress(addr.address(), 0, scope);
+    static JImageResourceIterator_t ofAddress(MemorySegment addr, Arena arena) {
+        MemorySegment symbol = addr.reinterpret(arena.scope(), null);
         return (java.lang.foreign.MemorySegment _jimage, java.lang.foreign.MemorySegment _visitor, java.lang.foreign.MemorySegment _arg) -> {
             try {
                 constants$3.JImageResourceIterator_t$MH.invokeExact(symbol, _jimage, _visitor, _arg);

--- a/samples/libjimage/org/openjdk/JImageResourceVisitor_t.java
+++ b/samples/libjimage/org/openjdk/JImageResourceVisitor_t.java
@@ -18,8 +18,8 @@ public interface JImageResourceVisitor_t {
     static MemorySegment allocate(JImageResourceVisitor_t fi, Arena scope) {
         return RuntimeHelper.upcallStub(JImageResourceVisitor_t.class, fi, constants$2.JImageResourceVisitor_t$FUNC, scope);
     }
-    static JImageResourceVisitor_t ofAddress(MemorySegment addr, Arena scope) {
-        MemorySegment symbol = MemorySegment.ofAddress(addr.address(), 0, scope);
+    static JImageResourceVisitor_t ofAddress(MemorySegment addr, Arena arena) {
+        MemorySegment symbol = addr.reinterpret(arena.scope(), null);
         return (java.lang.foreign.MemorySegment _jimage, java.lang.foreign.MemorySegment _module_name, java.lang.foreign.MemorySegment _version, java.lang.foreign.MemorySegment _package_, java.lang.foreign.MemorySegment _name, java.lang.foreign.MemorySegment _extension, java.lang.foreign.MemorySegment _arg) -> {
             try {
                 return (int)constants$2.JImageResourceVisitor_t$MH.invokeExact(symbol, _jimage, _module_name, _version, _package_, _name, _extension, _arg);

--- a/samples/libjimage/org/openjdk/RuntimeHelper.java
+++ b/samples/libjimage/org/openjdk/RuntimeHelper.java
@@ -92,8 +92,8 @@ final class RuntimeHelper {
         }
     }
 
-    static MemorySegment asArray(MemorySegment addr, MemoryLayout layout, int numElements, Arena scope) {
-         return MemorySegment.ofAddress(addr.address(), numElements * layout.byteSize(), scope);
+    static MemorySegment asArray(MemorySegment addr, MemoryLayout layout, int numElements, Arena arena) {
+         return addr.reinterpret(numElements * layout.byteSize(), arena.scope(), null);
     }
 
     // Internals only below this point

--- a/samples/sqlite/SqliteMain.java
+++ b/samples/sqlite/SqliteMain.java
@@ -95,11 +95,11 @@ public class SqliteMain {
             var callback = sqlite3_exec$callback.allocate((a, argc, argv, columnNames) -> {
                 System.out.println("Row num: " + rowNum[0]++);
                 System.out.println("numColumns = " + argc);
-                var argv_seg = MemorySegment.ofAddress(argv.address(), C_POINTER.byteSize() * argc, arena);
-                var columnNames_seg = MemorySegment.ofAddress(columnNames.address(), C_POINTER.byteSize() * argc, arena);
+                argv = argv.reinterpret(C_POINTER.byteSize() * argc, arena, null);
+                columnNames = columnNames.reinterpret(C_POINTER.byteSize() * argc, arena, null);
                 for (int i = 0; i < argc; i++) {
-                     String name = columnNames_seg.getAtIndex(C_POINTER, i).getUtf8String(0);
-                     String value = argv_seg.getAtIndex(C_POINTER, i).getUtf8String(0);
+                     String name = columnNames.getAtIndex(C_POINTER, i).getUtf8String(0);
+                     String value = argv.getAtIndex(C_POINTER, i).getUtf8String(0);
 
                      System.out.printf("%s = %s\n", name, value);
                 }

--- a/src/main/java/org/openjdk/jextract/clang/ClangDisposable.java
+++ b/src/main/java/org/openjdk/jextract/clang/ClangDisposable.java
@@ -29,6 +29,7 @@ package org.openjdk.jextract.clang;
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.SegmentAllocator;
+import java.util.function.Consumer;
 
 /**
  * This class models a libclang entity that has an explicit lifecycle (e.g. TranslationUnit, Index).
@@ -40,12 +41,12 @@ public abstract class ClangDisposable implements SegmentAllocator, AutoCloseable
     protected final MemorySegment ptr;
     protected final Arena arena;
 
-    public ClangDisposable(MemorySegment ptr, long size, Runnable cleanup) {
+    public ClangDisposable(MemorySegment ptr, long size, Consumer<MemorySegment> cleanup) {
         this.arena = Arena.ofConfined();
-        this.ptr = MemorySegment.ofAddress(ptr.address(), size, arena, cleanup).asReadOnly();
+        this.ptr = ptr.reinterpret(size, arena.scope(), cleanup).asReadOnly();
     }
 
-    public ClangDisposable(MemorySegment ptr, Runnable cleanup) {
+    public ClangDisposable(MemorySegment ptr, Consumer<MemorySegment> cleanup) {
         this(ptr, 0, cleanup);
     }
 

--- a/src/main/java/org/openjdk/jextract/clang/Diagnostic.java
+++ b/src/main/java/org/openjdk/jextract/clang/Diagnostic.java
@@ -65,7 +65,7 @@ public class Diagnostic extends ClangDisposable {
     public static final int CXDiagnostic_Fatal   = Index_h.CXDiagnostic_Fatal();
 
     Diagnostic(MemorySegment ptr) {
-        super(ptr, () -> Index_h.clang_disposeDiagnostic(ptr));
+        super(ptr, Index_h::clang_disposeDiagnostic);
     }
 
     public int severity() {

--- a/src/main/java/org/openjdk/jextract/clang/Index.java
+++ b/src/main/java/org/openjdk/jextract/clang/Index.java
@@ -39,7 +39,7 @@ import static org.openjdk.jextract.clang.libclang.Index_h.C_POINTER;
 public class Index extends ClangDisposable {
 
     Index(MemorySegment addr) {
-        super(addr, () -> Index_h.clang_disposeIndex(addr));
+        super(addr, Index_h::clang_disposeIndex);
     }
 
     public static class UnsavedFile {

--- a/src/main/java/org/openjdk/jextract/clang/TranslationUnit.java
+++ b/src/main/java/org/openjdk/jextract/clang/TranslationUnit.java
@@ -47,7 +47,7 @@ public class TranslationUnit extends ClangDisposable {
     private static final int MAX_RETRIES = 10;
 
     TranslationUnit(MemorySegment addr) {
-        super(addr, () -> Index_h.clang_disposeTranslationUnit(addr));
+        super(addr, Index_h::clang_disposeTranslationUnit);
     }
 
     public Cursor getCursor() {
@@ -135,7 +135,7 @@ public class TranslationUnit extends ClangDisposable {
 
         Tokens(MemorySegment addr, int size) {
             super(addr, size * CXToken.$LAYOUT().byteSize(),
-                    () -> Index_h.clang_disposeTokens(TranslationUnit.this.ptr, addr, size));
+                    (addrCleanup) -> Index_h.clang_disposeTokens(TranslationUnit.this.ptr, addrCleanup, size));
             this.size = size;
         }
 

--- a/src/main/java/org/openjdk/jextract/clang/libclang/CXCursorVisitor.java
+++ b/src/main/java/org/openjdk/jextract/clang/libclang/CXCursorVisitor.java
@@ -43,8 +43,8 @@ public interface CXCursorVisitor {
     static MemorySegment allocate(CXCursorVisitor fi, Arena scope) {
         return RuntimeHelper.upcallStub(CXCursorVisitor.class, fi, constants$13.CXCursorVisitor$FUNC, scope);
     }
-    static CXCursorVisitor ofAddress(MemorySegment addr, Arena scope) {
-        MemorySegment symbol = MemorySegment.ofAddress(addr.address(), 0, scope);
+    static CXCursorVisitor ofAddress(MemorySegment addr, Arena arena) {
+        MemorySegment symbol = addr.reinterpret(arena.scope(), null);
         return (java.lang.foreign.MemorySegment _cursor, java.lang.foreign.MemorySegment _parent, java.lang.foreign.MemorySegment _client_data) -> {
             try {
                 return (int)constants$13.CXCursorVisitor$MH.invokeExact(symbol, _cursor, _parent, _client_data);

--- a/src/main/java/org/openjdk/jextract/clang/libclang/RuntimeHelper.java
+++ b/src/main/java/org/openjdk/jextract/clang/libclang/RuntimeHelper.java
@@ -80,7 +80,7 @@ final class RuntimeHelper {
 
     static MemorySegment lookupGlobalVariable(String name, MemoryLayout layout) {
         return SYMBOL_LOOKUP.find(name)
-                .map(s -> s.asUnbounded().asSlice(0, layout))
+                .map(s -> s.reinterpret(layout.byteSize()))
                 .orElse(null);
     }
 
@@ -110,8 +110,8 @@ final class RuntimeHelper {
         }
     }
 
-    static MemorySegment asArray(MemorySegment addr, MemoryLayout layout, int numElements, Arena scope) {
-         return MemorySegment.ofAddress(addr.address(), numElements * layout.byteSize(), scope);
+    static MemorySegment asArray(MemorySegment addr, MemoryLayout layout, int numElements, Arena arena) {
+         return addr.reinterpret(numElements * layout.byteSize(), arena.scope(), null);
     }
 
     // Internals only below this point

--- a/src/main/java/org/openjdk/jextract/impl/FunctionalInterfaceBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/FunctionalInterfaceBuilder.java
@@ -117,11 +117,11 @@ public class FunctionalInterfaceBuilder extends ClassSourceBuilder {
                  fiDesc, false, true);
             incrAlign();
             indent();
-            append(MEMBER_MODS + " " + className() + " ofAddress(MemorySegment addr, Arena scope) {\n");
+            append(MEMBER_MODS + " " + className() + " ofAddress(MemorySegment addr, Arena arena) {\n");
             incrAlign();
             indent();
-            append("MemorySegment symbol = MemorySegment.ofAddress(");
-            append("addr.address(), 0, scope);\n");
+            append("MemorySegment symbol = addr.reinterpret(");
+            append("arena.scope(), null);\n");
             indent();
             append("return (");
             String delim = "";

--- a/src/main/resources/org/openjdk/jextract/impl/resources/RuntimeHelper.java.template
+++ b/src/main/resources/org/openjdk/jextract/impl/resources/RuntimeHelper.java.template
@@ -51,7 +51,7 @@ final class RuntimeHelper {
 
     static MemorySegment lookupGlobalVariable(String name, MemoryLayout layout) {
         return SYMBOL_LOOKUP.find(name)
-                .map(s -> s.asUnbounded().asSlice(0, layout))
+                .map(s -> s.reinterpret(layout.byteSize()))
                 .orElse(null);
     }
 
@@ -81,8 +81,8 @@ final class RuntimeHelper {
         }
     }
 
-    static MemorySegment asArray(MemorySegment addr, MemoryLayout layout, int numElements, Arena scope) {
-         return MemorySegment.ofAddress(addr.address(), numElements * layout.byteSize(), scope);
+    static MemorySegment asArray(MemorySegment addr, MemoryLayout layout, int numElements, Arena arena) {
+         return addr.reinterpret(numElements * layout.byteSize(), arena.scope(), null);
     }
 
     // Internals only below this point

--- a/test/jtreg/generator/test8257892/LibUnsupportedTest.java
+++ b/test/jtreg/generator/test8257892/LibUnsupportedTest.java
@@ -65,7 +65,7 @@ public class LibUnsupportedTest {
     @Test
     public void testGetFoo() {
         try (Arena arena = Arena.ofConfined()) {
-            var seg = MemorySegment.ofAddress(getFoo().address(), Foo.sizeof(), arena);
+            var seg = Foo.ofAddress(getFoo(), arena);
             Foo.i$set(seg, 42);
             Foo.c$set(seg, (byte)'j');
             assertEquals(Foo.i$get(seg), 42);


### PR DESCRIPTION
This patch brings jextract in sync with the API changes in https://git.openjdk.org/panama-foreign/pull/797.

The changes are mostly trivial and, luckily, jextract bindings already shield developers from having to call `MemorySegment::ofAddress` manually, so not a lot of test changes were required.

I've also updated the samples (but I could not test them as my environment is not setup to do that). We will fix up samples issues later (if needed).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract pull/105/head:pull/105` \
`$ git checkout pull/105`

Update a local copy of the PR: \
`$ git checkout pull/105` \
`$ git pull https://git.openjdk.org/jextract pull/105/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 105`

View PR using the GUI difftool: \
`$ git pr show -t 105`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/105.diff">https://git.openjdk.org/jextract/pull/105.diff</a>

</details>
