### PR TITLE
7903435: TestDocComments fails on Windows

### DIFF
--- a/test/lib/testlib/JextractToolRunner.java
+++ b/test/lib/testlib/JextractToolRunner.java
@@ -110,7 +110,7 @@ public class JextractToolRunner {
         }
 
         public JextractResult checkSuccess() {
-            assertEquals(exitCode, SUCCESS, "Sucess expected, failed: " + exitCode);
+            assertEquals(exitCode, SUCCESS, "Sucess expected, failed: " + exitCode + ", Output: " + output);
             return this;
         }
 

--- a/test/testng/org/openjdk/jextract/test/toolprovider/Test7903257/TestDocComments.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/Test7903257/TestDocComments.java
@@ -67,7 +67,7 @@ public class TestDocComments extends JextractToolRunner {
     public void testTypedefs() throws IOException {
         var comments = getDocComments("typedefs.h", "typedefs_h.java");
         assertEquals(comments, List.of(
-            "typedef unsigned long size_t;",
+            "typedef unsigned long long size_t;",
             "typedef int INT_32;",
             "typedef int* INT_PTR;",
             "typedef struct Foo* OPAQUE_PTR;"));

--- a/test/testng/org/openjdk/jextract/test/toolprovider/Test7903257/typedefs.h
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/Test7903257/typedefs.h
@@ -21,7 +21,7 @@
  * questions.
  */
 
-typedef unsigned long size_t;
+typedef unsigned long long size_t;
 typedef int INT_32;
 typedef int* INT_PTR;
 typedef struct Foo* OPAQUE_PTR;


### PR DESCRIPTION
TestDocComments fails on Windows because it's trying to `typedef` `size_t` with the type `unsigned long`, which is different from the type Windows uses for `size_t`: `unsigned long long`.

Using the latter works accross supported platforms though.

(I've also amended the testing framework code to print out jextract output in case of a failure)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Issue
 * [CODETOOLS-7903435](https://bugs.openjdk.org/browse/CODETOOLS-7903435): TestDocComments fails on Windows


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract pull/106/head:pull/106` \
`$ git checkout pull/106`

Update a local copy of the PR: \
`$ git checkout pull/106` \
`$ git pull https://git.openjdk.org/jextract pull/106/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 106`

View PR using the GUI difftool: \
`$ git pr show -t 106`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/106.diff">https://git.openjdk.org/jextract/pull/106.diff</a>

</details>
