### PR TITLE
7903436: Changes needed for jdk20-based makefile build

### DIFF
--- a/make/Build.gmk
+++ b/make/Build.gmk
@@ -47,7 +47,7 @@ $(foreach file,$(NATIVE_TEST_SOURCES),$(eval $(call BuildNativeLibrary,$(file),$
 $(BUILD_CLASSES_DIR):
 	$(MKDIR) -p $(BUILD_CLASSES_DIR)/org/openjdk/jextract/impl
 	$(FIXPATH) $(PANAMA_JAVA_HOME)/bin/javac \
-	    --release=19 \
+	    --release=20 \
 	    --enable-preview \
 	    -d "$(BUILD_CLASSES_DIR)" \
 	    src/main/java/module-info.java \
@@ -71,7 +71,7 @@ $(BUILD_MODULES_DIR): $(BUILD_CLASSES_DIR)
 	# create jextract jmod file
 	$(FIXPATH) $(PANAMA_JAVA_HOME)/bin/jmod \
 	    create \
-	    --module-version=19 \
+	    --module-version=20 \
 	    --class-path=$(BUILD_CLASSES_DIR) \
 	    --libs=$(JEXTRACT_JMOD_LIBS_DIR) \
 	    --conf=$(JEXTRACT_JMOD_CONF_DIR) \


### PR DESCRIPTION
These are the changes for jdk20-based makefile builds. Just 2 simple version bumps

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Issue
 * [CODETOOLS-7903436](https://bugs.openjdk.org/browse/CODETOOLS-7903436): Changes needed for jdk20-based makefile build


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract pull/107/head:pull/107` \
`$ git checkout pull/107`

Update a local copy of the PR: \
`$ git checkout pull/107` \
`$ git pull https://git.openjdk.org/jextract pull/107/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 107`

View PR using the GUI difftool: \
`$ git pr show -t 107`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/107.diff">https://git.openjdk.org/jextract/pull/107.diff</a>

</details>
