### PR TITLE
fixed samples for API change MemorySegment.slice -> asSlice and to re-extract libjimage binding

### DIFF
--- a/samples/libffmpeg/LibffmpegMain.java
+++ b/samples/libffmpeg/LibffmpegMain.java
@@ -290,7 +290,7 @@ public class LibffmpegMain {
             // Write pixel data
             for (int y = 0; y < height; y++) {
                 // frameRGB.data[0] + y*frameRGB.linesize[0] is the pointer. And 3*width size of data
-                var pixelArray = pdata.slice(y * linesize)
+                var pixelArray = pdata.asSlice(y * linesize)
                                       .reinterpret(3*width, arena.scope(), null);
                 // dump the pixel byte buffer to file
                 os.write(pixelArray.toArray(C_CHAR));

--- a/samples/libjimage/org/openjdk/RuntimeHelper.java
+++ b/samples/libjimage/org/openjdk/RuntimeHelper.java
@@ -46,7 +46,6 @@ final class RuntimeHelper {
             libPath = "/lib/libjimage.so"; // some Unix
         }
         SymbolLookup loaderLookup = SymbolLookup.libraryLookup(libPath, Arena.global());
-
         SYMBOL_LOOKUP = name -> loaderLookup.find(name).or(() -> LINKER.defaultLookup().find(name));
     }
 
@@ -62,7 +61,7 @@ final class RuntimeHelper {
 
     static MemorySegment lookupGlobalVariable(String name, MemoryLayout layout) {
         return SYMBOL_LOOKUP.find(name)
-                .map(s -> s.asUnbounded().asSlice(0, layout))
+                .map(s -> s.reinterpret(layout.byteSize()))
                 .orElse(null);
     }
 


### PR DESCRIPTION
fixed samples for API change MemorySegment.slice -> asSlice and to re-extract libjimage binding

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract pull/108/head:pull/108` \
`$ git checkout pull/108`

Update a local copy of the PR: \
`$ git checkout pull/108` \
`$ git pull https://git.openjdk.org/jextract pull/108/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 108`

View PR using the GUI difftool: \
`$ git pr show -t 108`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/108.diff">https://git.openjdk.org/jextract/pull/108.diff</a>

</details>
