### PR TITLE
7903437: Improve translation strategy for function pointers

### DIFF
--- a/src/main/java/org/openjdk/jextract/impl/ConstantBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/ConstantBuilder.java
@@ -25,8 +25,6 @@
 
 package org.openjdk.jextract.impl;
 
-import org.openjdk.jextract.impl.ConstantBuilder.Constant.Kind;
-
 import java.lang.foreign.FunctionDescriptor;
 import java.lang.foreign.GroupLayout;
 import java.lang.foreign.MemorySegment;

--- a/src/main/java/org/openjdk/jextract/impl/ConstantBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/ConstantBuilder.java
@@ -25,11 +25,12 @@
 
 package org.openjdk.jextract.impl;
 
+import org.openjdk.jextract.impl.ConstantBuilder.Constant.Kind;
+
 import java.lang.foreign.FunctionDescriptor;
 import java.lang.foreign.GroupLayout;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.MemoryLayout;
-import java.lang.foreign.MemorySegment;
 import java.lang.foreign.SequenceLayout;
 import java.lang.foreign.StructLayout;
 import java.lang.foreign.ValueLayout;
@@ -81,9 +82,14 @@ public class ConstantBuilder extends ClassSourceBuilder {
                 () -> emitVarHandleField(javaName, nativeName, valueLayout, rootLayoutName, prefixElementNames));
     }
 
-    public Constant addMethodHandle(String javaName, String nativeName, FunctionDescriptor descriptor, boolean isVarargs, boolean virtual) {
+    public Constant addDowncallMethodHandle(String javaName, String nativeName, FunctionDescriptor descriptor, boolean isVarargs, boolean virtual) {
         return emitIfAbsent(javaName, Constant.Kind.METHOD_HANDLE,
-                () -> emitMethodHandleField(javaName, nativeName, descriptor, isVarargs, virtual));
+                () -> emitDowncallMethodHandleField(javaName, nativeName, descriptor, isVarargs, virtual));
+    }
+
+    public Constant addLookupMethodHandle(String javaName, String className, String name, FunctionDescriptor descriptor) {
+        return emitIfAbsent(javaName, Constant.Kind.METHOD_HANDLE,
+                () -> emitUpcallMethodHandleField(javaName, className, name, descriptor));
     }
 
     public Constant addSegment(String javaName, String nativeName, MemoryLayout layout) {
@@ -197,7 +203,7 @@ public class ConstantBuilder extends ClassSourceBuilder {
         return constant;
     }
 
-    private Constant emitMethodHandleField(String javaName, String nativeName, FunctionDescriptor descriptor, boolean isVarargs, boolean virtual) {
+    private Constant emitDowncallMethodHandleField(String javaName, String nativeName, FunctionDescriptor descriptor, boolean isVarargs, boolean virtual) {
         Constant functionDesc = addFunctionDesc(javaName, descriptor);
         incrAlign();
         String fieldName = Constant.Kind.METHOD_HANDLE.fieldName(javaName);
@@ -221,6 +227,21 @@ public class ConstantBuilder extends ClassSourceBuilder {
         append("\n");
         decrAlign();
         indent();
+        append(");\n");
+        decrAlign();
+        return new Constant(className(), javaName, Constant.Kind.METHOD_HANDLE);
+    }
+
+    private Constant emitUpcallMethodHandleField(String javaName, String className, String methodName, FunctionDescriptor descriptor) {
+        Constant functionDesc = addFunctionDesc(javaName, descriptor);
+        incrAlign();
+        String fieldName = Constant.Kind.METHOD_HANDLE.fieldName(javaName);
+        indent();
+        append(memberMods() + "MethodHandle ");
+        append(fieldName + " = RuntimeHelper.upcallHandle(");
+        append(className + ".class, ");
+        append("\"" + methodName + "\", ");
+        append(functionDesc.accessExpression());
         append(");\n");
         decrAlign();
         return new Constant(className(), javaName, Constant.Kind.METHOD_HANDLE);

--- a/src/main/java/org/openjdk/jextract/impl/FunctionalInterfaceBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/FunctionalInterfaceBuilder.java
@@ -97,13 +97,14 @@ public class FunctionalInterfaceBuilder extends ClassSourceBuilder {
     private void emitFunctionalFactories() {
         emitWithConstantClass(constantBuilder -> {
             Constant functionDesc = constantBuilder.addFunctionDesc(className(), fiDesc);
+            Constant upcallHandle = constantBuilder.addLookupMethodHandle(className() + "_UP", className(), "apply", fiDesc);
             incrAlign();
             indent();
             append(MEMBER_MODS + " MemorySegment allocate(" + className() + " fi, Arena scope) {\n");
             incrAlign();
             indent();
-            append("return RuntimeHelper.upcallStub(" + className() + ".class, fi, " +
-                functionDesc.accessExpression() + ", scope);\n");
+            append("return RuntimeHelper.upcallStub(" +
+                upcallHandle.accessExpression() + ", fi, " + functionDesc.accessExpression() + ", scope);\n");
             decrAlign();
             indent();
             append("}\n");
@@ -113,7 +114,7 @@ public class FunctionalInterfaceBuilder extends ClassSourceBuilder {
 
     private void emitFunctionalFactoryForPointer() {
         emitWithConstantClass(constantBuilder -> {
-            Constant mhConstant = constantBuilder.addMethodHandle(className(), className(),
+            Constant mhConstant = constantBuilder.addDowncallMethodHandle(className() + "_DOWN", className(),
                  fiDesc, false, true);
             incrAlign();
             indent();

--- a/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
@@ -24,7 +24,6 @@
  */
 package org.openjdk.jextract.impl;
 
-import java.lang.foreign.Linker;
 import java.lang.foreign.FunctionDescriptor;
 import java.lang.foreign.GroupLayout;
 import java.lang.foreign.MemorySegment;
@@ -109,7 +108,7 @@ abstract class HeaderFileBuilder extends ClassSourceBuilder {
         boolean isVarargs = funcTree.type().varargs();
 
         emitWithConstantClass(constantBuilder -> {
-            Constant mhConstant = constantBuilder.addMethodHandle(javaName, nativeName, descriptor, isVarargs, false)
+            Constant mhConstant = constantBuilder.addDowncallMethodHandle(javaName, nativeName, descriptor, isVarargs, false)
                     .emitGetter(this, MEMBER_MODS, Constant.QUALIFIED_NAME, nativeName);
             MethodType downcallType = descriptor.toMethodType();
             boolean needsAllocator = descriptor.returnLayout().isPresent() &&

--- a/src/main/resources/org/openjdk/jextract/impl/resources/RuntimeHelper.java.template
+++ b/src/main/resources/org/openjdk/jextract/impl/resources/RuntimeHelper.java.template
@@ -71,11 +71,18 @@ final class RuntimeHelper {
                 orElse(null);
     }
 
-    static <Z> MemorySegment upcallStub(Class<Z> fi, Z z, FunctionDescriptor fdesc, Arena scope) {
+    static MethodHandle upcallHandle(Class<?> fi, String name, FunctionDescriptor fdesc) {
         try {
-            MethodHandle handle = MH_LOOKUP.findVirtual(fi, "apply", fdesc.toMethodType());
-            handle = handle.bindTo(z);
-            return LINKER.upcallStub(handle, fdesc, scope);
+            return MH_LOOKUP.findVirtual(fi, name, fdesc.toMethodType());
+        } catch (Throwable ex) {
+            throw new AssertionError(ex);
+        }
+    }
+
+    static <Z> MemorySegment upcallStub(MethodHandle fiHandle, Z z, FunctionDescriptor fdesc, Arena scope) {
+        try {
+            fiHandle = fiHandle.bindTo(z);
+            return LINKER.upcallStub(fiHandle, fdesc, scope);
         } catch (Throwable ex) {
             throw new AssertionError(ex);
         }


### PR DESCRIPTION
The current translation stragegy for function pointers is not very efficient. Every time a lambda expression is turned into an upcall stub, a new method handle lookup is performed, which is quite a slow operation.

This patch improves the translation strategy so that the lookup is only performed once. For instance, considering the following `typedef`:

```
typedef void (*cb)(int, int);
```

jextract will generate the following functional interface:

```java
import static java.lang.foreign.ValueLayout.*;
/**
 * {@snippet :
 * void (*cb)(int,int);
 * }
 */
public interface cb {

    void apply(int _x0, int _x1);
    static MemorySegment allocate(cb fi, Arena scope) {
        return RuntimeHelper.upcallStub(constants$0.cb_UP$MH, fi, constants$0.cb$FUNC, scope);
    }
    static cb ofAddress(MemorySegment addr, Arena arena) {
        MemorySegment symbol = addr.reinterpret(arena.scope(), null);
        return (int __x0, int __x1) -> {
            try {
                constants$0.cb_DOWN$MH.invokeExact(symbol, __x0, __x1);
            } catch (Throwable ex$) {
                throw new AssertionError("should not reach here", ex$);
            }
        };
    }
}
```

Where the constants are defined as follows:

```java
    static final FunctionDescriptor cb$FUNC = FunctionDescriptor.ofVoid(
        Constants$root.C_INT$LAYOUT,
        Constants$root.C_INT$LAYOUT
    );
    
    static final FunctionDescriptor cb_UP$FUNC = FunctionDescriptor.ofVoid(
        Constants$root.C_INT$LAYOUT,
        Constants$root.C_INT$LAYOUT
    );
    
    static final MethodHandle cb_UP$MH = RuntimeHelper.upcallHandle(cb.class, "apply", constants$0.cb_UP$FUNC);
    
    static final FunctionDescriptor cb_DOWN$FUNC = FunctionDescriptor.ofVoid(
        Constants$root.C_INT$LAYOUT,
        Constants$root.C_INT$LAYOUT
    );
    
    static final MethodHandle cb_DOWN$MH = RuntimeHelper.downcallHandle(
        constants$0.cb_DOWN$FUNC
    );
```

And, where `RuntimeHelper::upcallHandler` is defined as follows:

```java
static MethodHandle upcallHandle(Class<?> fi, String name, FunctionDescriptor fdesc) {
        try {
            return MH_LOOKUP.findVirtual(fi, name, fdesc.toMethodType());
        } catch (Throwable ex) {
            throw new AssertionError(ex);
        }
    }
```

This allows to perform the method handle lookup only once. This means that when creating an upcall stub, we only have to `bind` the functional interface instance to the method handle, and then create an upcall stub with the resulting handle. Both operations should be fast after the first time, because of caching.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Issue
 * [CODETOOLS-7903437](https://bugs.openjdk.org/browse/CODETOOLS-7903437): Improve translation strategy for function pointers


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract pull/109/head:pull/109` \
`$ git checkout pull/109`

Update a local copy of the PR: \
`$ git checkout pull/109` \
`$ git pull https://git.openjdk.org/jextract pull/109/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 109`

View PR using the GUI difftool: \
`$ git pr show -t 109`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/109.diff">https://git.openjdk.org/jextract/pull/109.diff</a>

</details>
