### PR TITLE
Update jextract to reflect latest API tweaks

### DIFF
--- a/samples/dlopen/Dlopen.java
+++ b/samples/dlopen/Dlopen.java
@@ -45,7 +45,7 @@ public class Dlopen {
             if (handleAddr.equals(MemorySegment.NULL)) {
                 throw new IllegalArgumentException("Cannot find library: " + libraryName);
             }
-            var handle = handleAddr.reinterpret(arena.scope(), org.unix.dlfcn_h::dlclose);
+            var handle = handleAddr.reinterpret(arena, org.unix.dlfcn_h::dlclose);
             return name -> {
                 try (var newArena = Arena.ofConfined()) {
                     var addr = dlsym(handle, newArena.allocateUtf8String(name));

--- a/samples/libjimage/org/openjdk/JImageClose_t.java
+++ b/samples/libjimage/org/openjdk/JImageClose_t.java
@@ -19,7 +19,7 @@ public interface JImageClose_t {
         return RuntimeHelper.upcallStub(JImageClose_t.class, fi, constants$0.JImageClose_t$FUNC, scope);
     }
     static JImageClose_t ofAddress(MemorySegment addr, Arena arena) {
-        MemorySegment symbol = addr.reinterpret(arena.scope(), null);
+        MemorySegment symbol = addr.reinterpret(arena, null);
         return (java.lang.foreign.MemorySegment _jimage) -> {
             try {
                 constants$0.JImageClose_t$MH.invokeExact(symbol, _jimage);

--- a/samples/libjimage/org/openjdk/JImageFindResource_t.java
+++ b/samples/libjimage/org/openjdk/JImageFindResource_t.java
@@ -19,7 +19,7 @@ public interface JImageFindResource_t {
         return RuntimeHelper.upcallStub(JImageFindResource_t.class, fi, constants$1.JImageFindResource_t$FUNC, scope);
     }
     static JImageFindResource_t ofAddress(MemorySegment addr, Arena arena) {
-        MemorySegment symbol = addr.reinterpret(arena.scope(), null);
+        MemorySegment symbol = addr.reinterpret(arena, null);
         return (java.lang.foreign.MemorySegment _jimage, java.lang.foreign.MemorySegment _module_name, java.lang.foreign.MemorySegment _version, java.lang.foreign.MemorySegment _name, java.lang.foreign.MemorySegment _size) -> {
             try {
                 return (long)constants$1.JImageFindResource_t$MH.invokeExact(symbol, _jimage, _module_name, _version, _name, _size);

--- a/samples/libjimage/org/openjdk/JImageGetResource_t.java
+++ b/samples/libjimage/org/openjdk/JImageGetResource_t.java
@@ -19,7 +19,7 @@ public interface JImageGetResource_t {
         return RuntimeHelper.upcallStub(JImageGetResource_t.class, fi, constants$2.JImageGetResource_t$FUNC, scope);
     }
     static JImageGetResource_t ofAddress(MemorySegment addr, Arena arena) {
-        MemorySegment symbol = addr.reinterpret(arena.scope(), null);
+        MemorySegment symbol = addr.reinterpret(arena, null);
         return (java.lang.foreign.MemorySegment _jimage, long _location, java.lang.foreign.MemorySegment _buffer, long _size) -> {
             try {
                 return (long)constants$2.JImageGetResource_t$MH.invokeExact(symbol, _jimage, _location, _buffer, _size);

--- a/samples/libjimage/org/openjdk/JImageOpen_t.java
+++ b/samples/libjimage/org/openjdk/JImageOpen_t.java
@@ -19,7 +19,7 @@ public interface JImageOpen_t {
         return RuntimeHelper.upcallStub(JImageOpen_t.class, fi, constants$0.JImageOpen_t$FUNC, scope);
     }
     static JImageOpen_t ofAddress(MemorySegment addr, Arena arena) {
-        MemorySegment symbol = addr.reinterpret(arena.scope(), null);
+        MemorySegment symbol = addr.reinterpret(arena, null);
         return (java.lang.foreign.MemorySegment _jimage, java.lang.foreign.MemorySegment _package_name) -> {
             try {
                 return (java.lang.foreign.MemorySegment)constants$0.JImageOpen_t$MH.invokeExact(symbol, _jimage, _package_name);

--- a/samples/libjimage/org/openjdk/JImagePackageToModule_t.java
+++ b/samples/libjimage/org/openjdk/JImagePackageToModule_t.java
@@ -19,7 +19,7 @@ public interface JImagePackageToModule_t {
         return RuntimeHelper.upcallStub(JImagePackageToModule_t.class, fi, constants$1.JImagePackageToModule_t$FUNC, scope);
     }
     static JImagePackageToModule_t ofAddress(MemorySegment addr, Arena arena) {
-        MemorySegment symbol = addr.reinterpret(arena.scope(), null);
+        MemorySegment symbol = addr.reinterpret(arena, null);
         return (java.lang.foreign.MemorySegment _jimage, java.lang.foreign.MemorySegment _package_name) -> {
             try {
                 return (java.lang.foreign.MemorySegment)constants$1.JImagePackageToModule_t$MH.invokeExact(symbol, _jimage, _package_name);

--- a/samples/libjimage/org/openjdk/JImageResourceIterator_t.java
+++ b/samples/libjimage/org/openjdk/JImageResourceIterator_t.java
@@ -19,7 +19,7 @@ public interface JImageResourceIterator_t {
         return RuntimeHelper.upcallStub(JImageResourceIterator_t.class, fi, constants$3.JImageResourceIterator_t$FUNC, scope);
     }
     static JImageResourceIterator_t ofAddress(MemorySegment addr, Arena arena) {
-        MemorySegment symbol = addr.reinterpret(arena.scope(), null);
+        MemorySegment symbol = addr.reinterpret(arena, null);
         return (java.lang.foreign.MemorySegment _jimage, java.lang.foreign.MemorySegment _visitor, java.lang.foreign.MemorySegment _arg) -> {
             try {
                 constants$3.JImageResourceIterator_t$MH.invokeExact(symbol, _jimage, _visitor, _arg);

--- a/samples/libjimage/org/openjdk/JImageResourceVisitor_t.java
+++ b/samples/libjimage/org/openjdk/JImageResourceVisitor_t.java
@@ -19,7 +19,7 @@ public interface JImageResourceVisitor_t {
         return RuntimeHelper.upcallStub(JImageResourceVisitor_t.class, fi, constants$2.JImageResourceVisitor_t$FUNC, scope);
     }
     static JImageResourceVisitor_t ofAddress(MemorySegment addr, Arena arena) {
-        MemorySegment symbol = addr.reinterpret(arena.scope(), null);
+        MemorySegment symbol = addr.reinterpret(arena, null);
         return (java.lang.foreign.MemorySegment _jimage, java.lang.foreign.MemorySegment _module_name, java.lang.foreign.MemorySegment _version, java.lang.foreign.MemorySegment _package_, java.lang.foreign.MemorySegment _name, java.lang.foreign.MemorySegment _extension, java.lang.foreign.MemorySegment _arg) -> {
             try {
                 return (int)constants$2.JImageResourceVisitor_t$MH.invokeExact(symbol, _jimage, _module_name, _version, _package_, _name, _extension, _arg);

--- a/src/main/java/org/openjdk/jextract/clang/ClangDisposable.java
+++ b/src/main/java/org/openjdk/jextract/clang/ClangDisposable.java
@@ -43,7 +43,7 @@ public abstract class ClangDisposable implements SegmentAllocator, AutoCloseable
 
     public ClangDisposable(MemorySegment ptr, long size, Consumer<MemorySegment> cleanup) {
         this.arena = Arena.ofConfined();
-        this.ptr = ptr.reinterpret(size, arena.scope(), cleanup).asReadOnly();
+        this.ptr = ptr.reinterpret(size, arena, cleanup).asReadOnly();
     }
 
     public ClangDisposable(MemorySegment ptr, Consumer<MemorySegment> cleanup) {

--- a/src/main/java/org/openjdk/jextract/clang/libclang/CXCursorVisitor.java
+++ b/src/main/java/org/openjdk/jextract/clang/libclang/CXCursorVisitor.java
@@ -44,7 +44,7 @@ public interface CXCursorVisitor {
         return RuntimeHelper.upcallStub(CXCursorVisitor.class, fi, constants$13.CXCursorVisitor$FUNC, scope);
     }
     static CXCursorVisitor ofAddress(MemorySegment addr, Arena arena) {
-        MemorySegment symbol = addr.reinterpret(arena.scope(), null);
+        MemorySegment symbol = addr.reinterpret(arena, null);
         return (java.lang.foreign.MemorySegment _cursor, java.lang.foreign.MemorySegment _parent, java.lang.foreign.MemorySegment _client_data) -> {
             try {
                 return (int)constants$13.CXCursorVisitor$MH.invokeExact(symbol, _cursor, _parent, _client_data);

--- a/src/main/java/org/openjdk/jextract/clang/libclang/Constants$root.java
+++ b/src/main/java/org/openjdk/jextract/clang/libclang/Constants$root.java
@@ -44,7 +44,7 @@ final class Constants$root {
     static final OfLong C_LONG_LONG$LAYOUT = JAVA_LONG;
     static final OfFloat C_FLOAT$LAYOUT = JAVA_FLOAT;
     static final OfDouble C_DOUBLE$LAYOUT = JAVA_DOUBLE;
-    static final OfAddress C_POINTER$LAYOUT = ADDRESS.withBitAlignment(64)
+    static final AddressLayout C_POINTER$LAYOUT = ADDRESS.withBitAlignment(64)
             .withTargetLayout(MemoryLayout.sequenceLayout(C_CHAR$LAYOUT));
 }
 

--- a/src/main/java/org/openjdk/jextract/clang/libclang/Index_h.java
+++ b/src/main/java/org/openjdk/jextract/clang/libclang/Index_h.java
@@ -41,7 +41,7 @@ public class Index_h  {
     public static final OfLong C_LONG_LONG = Constants$root.C_LONG_LONG$LAYOUT;
     public static final OfFloat C_FLOAT = Constants$root.C_FLOAT$LAYOUT;
     public static final OfDouble C_DOUBLE = Constants$root.C_DOUBLE$LAYOUT;
-    public static final OfAddress C_POINTER = Constants$root.C_POINTER$LAYOUT;
+    public static final AddressLayout C_POINTER = Constants$root.C_POINTER$LAYOUT;
     /**
      * {@snippet :
      * enum CXErrorCode.CXError_Success = 0;
@@ -119,13 +119,13 @@ public class Index_h  {
      * typedef void* CXIndex;
      * }
      */
-    public static final OfAddress CXIndex = Constants$root.C_POINTER$LAYOUT;
+    public static final AddressLayout CXIndex = Constants$root.C_POINTER$LAYOUT;
     /**
      * {@snippet :
      * typedef struct CXTranslationUnitImpl* CXTranslationUnit;
      * }
      */
-    public static final OfAddress CXTranslationUnit = Constants$root.C_POINTER$LAYOUT;
+    public static final AddressLayout CXTranslationUnit = Constants$root.C_POINTER$LAYOUT;
     /**
      * {@snippet :
      * enum CXCursor_ExceptionSpecificationKind.CXCursor_ExceptionSpecificationKind_None = 0;

--- a/src/main/java/org/openjdk/jextract/clang/libclang/RuntimeHelper.java
+++ b/src/main/java/org/openjdk/jextract/clang/libclang/RuntimeHelper.java
@@ -111,7 +111,7 @@ final class RuntimeHelper {
     }
 
     static MemorySegment asArray(MemorySegment addr, MemoryLayout layout, int numElements, Arena arena) {
-         return addr.reinterpret(numElements * layout.byteSize(), arena.scope(), null);
+         return addr.reinterpret(numElements * layout.byteSize(), arena, null);
     }
 
     // Internals only below this point

--- a/src/main/java/org/openjdk/jextract/impl/FunctionalInterfaceBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/FunctionalInterfaceBuilder.java
@@ -122,7 +122,7 @@ public class FunctionalInterfaceBuilder extends ClassSourceBuilder {
             incrAlign();
             indent();
             append("MemorySegment symbol = addr.reinterpret(");
-            append("arena.scope(), null);\n");
+            append("arena, null);\n");
             indent();
             append("return (");
             String delim = "";

--- a/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
@@ -248,7 +248,7 @@ abstract class HeaderFileBuilder extends ClassSourceBuilder {
         indent();
         append(MEMBER_MODS);
         append(" final");
-        append(" OfAddress ");
+        append(" AddressLayout ");
         append(name);
         append(" = ");
         append(toplevel().rootConstants().resolvePrimitiveLayout(TypeImpl.PointerImpl.POINTER_LAYOUT).accessExpression());

--- a/src/main/java/org/openjdk/jextract/impl/ToplevelBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/ToplevelBuilder.java
@@ -290,9 +290,30 @@ class ToplevelBuilder extends JavaSourceBuilder {
         }
 
         private ValueLayout layoutNoName(ValueLayout layout) {
+            final ValueLayout newLayout;
+            if (layout.carrier() == boolean.class) {
+                newLayout = ValueLayout.JAVA_BOOLEAN;
+            } else if (layout.carrier() == byte.class) {
+                newLayout = ValueLayout.JAVA_BYTE;
+            } else if (layout.carrier() == char.class) {
+                newLayout = ValueLayout.JAVA_CHAR;
+            } else if (layout.carrier() == short.class) {
+                newLayout = ValueLayout.JAVA_SHORT;
+            } else if (layout.carrier() == int.class) {
+                newLayout = ValueLayout.JAVA_INT;
+            } else if (layout.carrier() == float.class) {
+                newLayout = ValueLayout.JAVA_FLOAT;
+            } else if (layout.carrier() == long.class) {
+                newLayout = ValueLayout.JAVA_LONG;
+            } else if (layout.carrier() == double.class) {
+                newLayout = ValueLayout.JAVA_DOUBLE;
+            } else if (layout.carrier() == MemorySegment.class) {
+                newLayout = ValueLayout.ADDRESS;
+            } else {
+                throw new AssertionError("Cannot get here");
+            }
             // drop name if present
-            return MemoryLayout.valueLayout(layout.carrier(), layout.order())
-                    .withBitAlignment(layout.bitAlignment());
+            return newLayout.withOrder(layout.order()).withBitAlignment(layout.bitAlignment());
         }
 
         public Constant resolvePrimitiveLayout(ValueLayout layout) {

--- a/src/main/java/org/openjdk/jextract/impl/TypeImpl.java
+++ b/src/main/java/org/openjdk/jextract/impl/TypeImpl.java
@@ -32,6 +32,7 @@ import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.function.Supplier;
 
+import java.lang.foreign.AddressLayout;
 import java.lang.foreign.FunctionDescriptor;
 import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.ValueLayout;
@@ -179,7 +180,7 @@ public abstract class TypeImpl implements Type {
     }
 
     public static final class PointerImpl extends DelegatedBase {
-        public static final ValueLayout.OfAddress POINTER_LAYOUT = ADDRESS.withBitAlignment(64)
+        public static final AddressLayout POINTER_LAYOUT = ADDRESS.withBitAlignment(64)
                 .withTargetLayout(MemoryLayout.sequenceLayout(ValueLayout.JAVA_BYTE));
 
         private final Supplier<Type> pointeeFactory;

--- a/src/main/resources/org/openjdk/jextract/impl/resources/RuntimeHelper.java.template
+++ b/src/main/resources/org/openjdk/jextract/impl/resources/RuntimeHelper.java.template
@@ -89,7 +89,7 @@ final class RuntimeHelper {
     }
 
     static MemorySegment asArray(MemorySegment addr, MemoryLayout layout, int numElements, Arena arena) {
-         return addr.reinterpret(numElements * layout.byteSize(), arena.scope(), null);
+         return addr.reinterpret(numElements * layout.byteSize(), arena, null);
     }
 
     // Internals only below this point

--- a/test/lib/testlib/JextractToolRunner.java
+++ b/test/lib/testlib/JextractToolRunner.java
@@ -37,6 +37,7 @@ import java.util.Arrays;
 import java.util.Objects;
 import java.util.spi.ToolProvider;
 
+import java.lang.foreign.AddressLayout;
 import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemoryLayout.PathElement;
 import java.lang.foreign.ValueLayout;
@@ -61,7 +62,7 @@ public class JextractToolRunner {
     public static final ValueLayout.OfLong C_LONG_LONG = ValueLayout.JAVA_LONG.withBitAlignment(64);
     public static final ValueLayout.OfFloat C_FLOAT = ValueLayout.JAVA_FLOAT.withBitAlignment(32);
     public static final ValueLayout.OfDouble C_DOUBLE = ValueLayout.JAVA_DOUBLE.withBitAlignment(64);
-    public static final ValueLayout.OfAddress C_POINTER = ValueLayout.ADDRESS
+    public static final AddressLayout C_POINTER = ValueLayout.ADDRESS
             .withTargetLayout(MemoryLayout.sequenceLayout(C_CHAR));
 
     // (private) exit codes from jextract tool. Copied from JextractTool.


### PR DESCRIPTION
We have done a number of smaller changes to the FFM API which require a refresh in the jextract code:

* Move `ValueLayout.OfAddress` to standalone class (`AddressLayout`)
* Tweak `MemorySegment::reinterpret` to accept `Arena` instead of `MemorySegment.Scope`
* Removal of `MemoryLayout::valueLayout` factory.

This patch fixes jextract to deal with these changes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract pull/111/head:pull/111` \
`$ git checkout pull/111`

Update a local copy of the PR: \
`$ git checkout pull/111` \
`$ git pull https://git.openjdk.org/jextract pull/111/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 111`

View PR using the GUI difftool: \
`$ git pr show -t 111`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/111.diff">https://git.openjdk.org/jextract/pull/111.diff</a>

</details>
