### PR TITLE
Simplify code to use `withoutName`

### DIFF
--- a/src/main/java/org/openjdk/jextract/impl/ToplevelBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/ToplevelBuilder.java
@@ -279,7 +279,7 @@ class ToplevelBuilder extends JavaSourceBuilder {
         }
 
         private Constant addPrimitiveLayout(String javaName, ValueLayout layout) {
-            ValueLayout layoutNoName = layoutNoName(layout);
+            ValueLayout layoutNoName = layout.withoutName();
             Constant layoutConstant = super.addLayout(javaName, layoutNoName);
             primitiveLayouts.put(layoutNoName, layoutConstant);
             return layoutConstant;
@@ -289,35 +289,8 @@ class ToplevelBuilder extends JavaSourceBuilder {
             return addPrimitiveLayout(javaName, (ValueLayout)kind.layout().orElseThrow());
         }
 
-        private ValueLayout layoutNoName(ValueLayout layout) {
-            final ValueLayout newLayout;
-            if (layout.carrier() == boolean.class) {
-                newLayout = ValueLayout.JAVA_BOOLEAN;
-            } else if (layout.carrier() == byte.class) {
-                newLayout = ValueLayout.JAVA_BYTE;
-            } else if (layout.carrier() == char.class) {
-                newLayout = ValueLayout.JAVA_CHAR;
-            } else if (layout.carrier() == short.class) {
-                newLayout = ValueLayout.JAVA_SHORT;
-            } else if (layout.carrier() == int.class) {
-                newLayout = ValueLayout.JAVA_INT;
-            } else if (layout.carrier() == float.class) {
-                newLayout = ValueLayout.JAVA_FLOAT;
-            } else if (layout.carrier() == long.class) {
-                newLayout = ValueLayout.JAVA_LONG;
-            } else if (layout.carrier() == double.class) {
-                newLayout = ValueLayout.JAVA_DOUBLE;
-            } else if (layout.carrier() == MemorySegment.class) {
-                newLayout = ValueLayout.ADDRESS;
-            } else {
-                throw new AssertionError("Cannot get here");
-            }
-            // drop name if present
-            return newLayout.withOrder(layout.order()).withBitAlignment(layout.bitAlignment());
-        }
-
         public Constant resolvePrimitiveLayout(ValueLayout layout) {
-            return primitiveLayouts.get(layoutNoName(layout));
+            return primitiveLayouts.get(layout.withoutName());
         }
     }
 


### PR DESCRIPTION
This patch simplifies some recently added code to just use the newly added layout API method to drop a name from a value layout.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract pull/112/head:pull/112` \
`$ git checkout pull/112`

Update a local copy of the PR: \
`$ git checkout pull/112` \
`$ git pull https://git.openjdk.org/jextract pull/112/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 112`

View PR using the GUI difftool: \
`$ git pr show -t 112`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/112.diff">https://git.openjdk.org/jextract/pull/112.diff</a>

</details>
