### PR TITLE
7903314: Jextract doesn't honor pack pragmas

### DIFF
--- a/src/main/java/org/openjdk/jextract/Declaration.java
+++ b/src/main/java/org/openjdk/jextract/Declaration.java
@@ -235,12 +235,6 @@ public interface Declaration {
         Type type();
 
         /**
-         * The optional layout associated with this variable declaration.
-         * @return The optional layout associated with this variable declaration.
-         */
-        Optional<MemoryLayout> layout();
-
-        /**
          * The kind associated with this variable declaration.
          * @return The kind associated with this variable declaration.
          */

--- a/src/main/java/org/openjdk/jextract/impl/ConstantBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/ConstantBuilder.java
@@ -289,6 +289,11 @@ public class ConstantBuilder extends ClassSourceBuilder {
     private void emitLayoutString(MemoryLayout l) {
         if (l instanceof ValueLayout val) {
             append(primitiveLayoutString(val));
+            if (l.bitAlignment() != l.bitSize()) {
+                append(".withBitAlignment(");
+                append(l.bitAlignment());
+                append(")");
+            }
         } else if (l instanceof SequenceLayout seq) {
             append("MemoryLayout.sequenceLayout(");
             append(seq.elementCount() + ", ");

--- a/src/main/java/org/openjdk/jextract/impl/DeclarationImpl.java
+++ b/src/main/java/org/openjdk/jextract/impl/DeclarationImpl.java
@@ -178,11 +178,6 @@ public abstract class DeclarationImpl implements Declaration {
         }
 
         @Override
-        public Optional<MemoryLayout> layout() {
-            return layout;
-        }
-
-        @Override
         public Variable withAttributes(Map<String, List<Constable>> attrs) {
             return new VariableImpl(type, layout, kind, name(), pos(), attrs);
         }

--- a/src/main/java/org/openjdk/jextract/impl/OutputFactory.java
+++ b/src/main/java/org/openjdk/jextract/impl/OutputFactory.java
@@ -354,7 +354,7 @@ public class OutputFactory implements Declaration.Visitor<Void, Declaration> {
             declared.tree().accept(this, tree);
         }
 
-        MemoryLayout layout = tree.layout().orElse(Type.layoutFor(type).orElse(null));
+        MemoryLayout layout = Type.layoutFor(type).orElse(null);
         if (layout == null) {
             //no layout - abort
             return null;

--- a/src/main/java/org/openjdk/jextract/impl/PrettyPrinter.java
+++ b/src/main/java/org/openjdk/jextract/impl/PrettyPrinter.java
@@ -110,7 +110,7 @@ public class PrettyPrinter implements Declaration.Visitor<Void, Void> {
             builder.append("Bitfield: " + " type = " + d.type().accept(typeVisitor, null) + ", name = " + bitfield.name()
                     + ", offset = " + bitfield.offset() + ", width = " + bitfield.width());
         } else {
-            builder.append("Variable: " + d.kind() + " " + d.name() + " type = " + d.type().accept(typeVisitor, null) + ", layout = " + d.layout());
+            builder.append("Variable: " + d.kind() + " " + d.name() + " type = " + d.type().accept(typeVisitor, null));
         }
         builder.append("\n");
         getAttributes(d);

--- a/src/main/java/org/openjdk/jextract/impl/RecordLayoutComputer.java
+++ b/src/main/java/org/openjdk/jextract/impl/RecordLayoutComputer.java
@@ -26,6 +26,7 @@
 
 package org.openjdk.jextract.impl;
 
+import java.lang.foreign.GroupLayout;
 import java.lang.foreign.MemoryLayout;
 import org.openjdk.jextract.Declaration;
 import org.openjdk.jextract.clang.Cursor;
@@ -33,6 +34,9 @@ import org.openjdk.jextract.clang.CursorKind;
 import org.openjdk.jextract.clang.Type;
 import org.openjdk.jextract.clang.TypeKind;
 
+import java.lang.foreign.SequenceLayout;
+import java.lang.foreign.StructLayout;
+import java.lang.foreign.ValueLayout;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -117,16 +121,19 @@ abstract class RecordLayoutComputer {
     abstract void processField(Cursor c);
     abstract Declaration.Scoped finishRecord(String anonName);
 
-    void addField(Declaration declaration) {
+    void addField(long offset, Declaration declaration) {
         fieldDecls.add(declaration);
         MemoryLayout layout = null;
         if (declaration instanceof Declaration.Scoped scoped) {
             layout = scoped.layout().orElse(null);
         } else if (declaration instanceof Declaration.Variable var) {
-            layout = var.layout().orElse(null);
+            layout = org.openjdk.jextract.Type.layoutFor(var.type()).orElse(null);
         }
         if (layout != null) {
-            //fieldLayouts.add(layout.name().isEmpty() ? layout.withName(declaration.name()) : layout);
+            if ((offset % layout.bitAlignment()) != 0) {
+                long maxAlign = Long.lowestOneBit(offset);
+                layout = forceAlign(layout, maxAlign);
+            }
             fieldLayouts.add(declaration.name().isEmpty() ? layout : layout.withName(declaration.name()));
         }
     }
@@ -137,9 +144,9 @@ abstract class RecordLayoutComputer {
 
     void addField(long offset, Type parent, Cursor c) {
         if (c.isAnonymousStruct()) {
-            addField(((org.openjdk.jextract.Type.Declared)computeAnonymous(typeMaker, offset, parent, c.type(), nextAnonymousName())).tree());
+            addField(offset, ((org.openjdk.jextract.Type.Declared)computeAnonymous(typeMaker, offset, parent, c.type(), nextAnonymousName())).tree());
         } else {
-            addField(field(offset, c));
+            addField(offset, field(offset, c));
         }
     }
 
@@ -183,6 +190,22 @@ abstract class RecordLayoutComputer {
             return offsets.stream().findFirst()
                     .orElseThrow(() -> new IllegalStateException(
                             "Can not find offset of: " + c + ", in: " + parent));
+        }
+    }
+
+    MemoryLayout forceAlign(MemoryLayout layout, long maxAlign) {
+        if (layout instanceof GroupLayout groupLayout) {
+            MemoryLayout[] newMembers = groupLayout.memberLayouts()
+                    .stream().map(l -> forceAlign(l, maxAlign)).toArray(MemoryLayout[]::new);
+            return groupLayout instanceof StructLayout ?
+                    MemoryLayout.structLayout(newMembers) :
+                    MemoryLayout.unionLayout(newMembers);
+        } else if (layout instanceof SequenceLayout sequenceLayout) {
+            return MemoryLayout.sequenceLayout(sequenceLayout.elementCount(),
+                    forceAlign(sequenceLayout.elementLayout(), maxAlign));
+        } else {
+            return layout.bitAlignment() > maxAlign ?
+                    layout.withBitAlignment(maxAlign) : layout;
         }
     }
 }

--- a/src/main/java/org/openjdk/jextract/impl/StructLayoutComputer.java
+++ b/src/main/java/org/openjdk/jextract/impl/StructLayoutComputer.java
@@ -51,12 +51,12 @@ final class StructLayoutComputer extends RecordLayoutComputer {
     }
 
     @Override
-    void addField(Declaration declaration) {
+    void addField(long offset, Declaration declaration) {
         if (bitfieldDecls != null) {
             bitfieldDecls.add(declaration);
             bitfieldSize += ((Declaration.Bitfield)declaration).width();
         } else {
-            super.addField(declaration);
+            super.addField(offset, declaration);
         }
     }
 
@@ -140,7 +140,8 @@ final class StructLayoutComputer extends RecordLayoutComputer {
         } else if (anonName != null) {
             g = g.withName(anonName);
         }
-        Declaration.Scoped declaration = Declaration.struct(TreeMaker.CursorPosition.of(cursor), cursor.spelling(), g, fieldDecls.stream().toArray(Declaration[]::new));
+        Declaration.Scoped declaration = Declaration.struct(TreeMaker.CursorPosition.of(cursor), cursor.spelling(),
+                g, fieldDecls.stream().toArray(Declaration[]::new));
         return declaration;
     }
 
@@ -152,7 +153,7 @@ final class StructLayoutComputer extends RecordLayoutComputer {
             bitfieldDecls = null;
             bitfieldSize = 0;
             if (!prevBitfieldDecls.isEmpty()) {
-                addField(bitfield(prevBitfieldDecls.toArray(new Declaration.Variable[0])));
+                addField(offset, bitfield(prevBitfieldDecls.toArray(new Declaration.Variable[0])));
             }
             fieldLayouts.add(MemoryLayout.paddingLayout(prevBitfieldSize));
         }

--- a/src/main/java/org/openjdk/jextract/impl/ToplevelBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/ToplevelBuilder.java
@@ -279,7 +279,7 @@ class ToplevelBuilder extends JavaSourceBuilder {
         }
 
         private Constant addPrimitiveLayout(String javaName, ValueLayout layout) {
-            ValueLayout layoutNoName = layout.withoutName();
+            ValueLayout layoutNoName = normalize(layout);
             Constant layoutConstant = super.addLayout(javaName, layoutNoName);
             primitiveLayouts.put(layoutNoName, layoutConstant);
             return layoutConstant;
@@ -290,7 +290,13 @@ class ToplevelBuilder extends JavaSourceBuilder {
         }
 
         public Constant resolvePrimitiveLayout(ValueLayout layout) {
-            return primitiveLayouts.get(layout.withoutName());
+            return primitiveLayouts.get(normalize(layout));
+        }
+
+        public ValueLayout normalize(ValueLayout valueLayout) {
+            return valueLayout
+                    .withBitAlignment(valueLayout.bitSize()) // use natural alignment
+                    .withoutName(); // drop name
         }
     }
 

--- a/test/testng/org/openjdk/jextract/test/api/TestPackedStructs.java
+++ b/test/testng/org/openjdk/jextract/test/api/TestPackedStructs.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package org.openjdk.jextract.test.api;
+
+import org.openjdk.jextract.Declaration;
+import org.testng.annotations.Test;
+import testlib.JextractApiTestBase;
+
+import static org.testng.Assert.assertEquals;
+
+import java.lang.foreign.GroupLayout;
+
+public class TestPackedStructs extends JextractApiTestBase {
+
+    static final String[] NAMES = {
+            "S1", "S2", "S3", "S4", "S5", "S6"
+    };
+
+    @Test
+    public void testPackedStructs() {
+        Declaration.Scoped d = parse("packedstructs.h");
+        System.out.println(d);
+        for (String name : NAMES) {
+            Declaration.Scoped scoped = checkStruct(d, name, "first", "second");
+            GroupLayout groupLayout = (GroupLayout)scoped.layout().get();
+            assertEquals(groupLayout.memberLayouts().get(1).bitAlignment(), 8);
+        }
+    }
+}

--- a/test/testng/org/openjdk/jextract/test/api/packedstructs.h
+++ b/test/testng/org/openjdk/jextract/test/api/packedstructs.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#pragma pack(1)
+struct S1 {
+   char first;
+   int second;
+};
+
+#pragma pack(1)
+struct S2 {
+   char first;
+   struct { int i } second;
+};
+
+#pragma pack(1)
+struct S3 {
+   char first;
+   int second[2];
+};
+
+#pragma pack(1)
+struct S4 {
+   char first;
+   union { int x; int y; } second;
+};
+
+#pragma pack(1)
+struct S5 {
+   char first;
+   union { struct { int i } x; struct { int i } y; } second;
+};
+
+#pragma pack(1)
+struct S6 {
+   char first;
+   union { int x[2]; int y[2]; } second;
+};


### PR DESCRIPTION
This patch fixes a long standing issue where jextract ignores alignment directives (e.g. `pragma pack`). Because of this issue, jextract can sometiems generate layouts whose alignment is incorrect (e.g. jextract might attempt to add a `i32` to a struct at an offset that is not 32-bit aligned).

The fix is in `RecordLayoutComputer` - when we need to emit the layout of a given struct field, we need to additionally pass in the offset at which the field is added. Then we check that the offset conforms to the field alignment. If not, we force-align the layout to the available alignment. This should only affect instances of `ValueLayout`.

During code generation, when we lookup a value layout, we first drop both name and custom alignment (so that the lookup will find what it's looking for). Additional name and/or alignment is added back when the layout is turned back into a string.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Issue
 * [CODETOOLS-7903314](https://bugs.openjdk.org/browse/CODETOOLS-7903314): Jextract doesn't honor pack pragmas


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract pull/113/head:pull/113` \
`$ git checkout pull/113`

Update a local copy of the PR: \
`$ git checkout pull/113` \
`$ git pull https://git.openjdk.org/jextract pull/113/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 113`

View PR using the GUI difftool: \
`$ git pr show -t 113`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/113.diff">https://git.openjdk.org/jextract/pull/113.diff</a>

</details>
