### PR TITLE
Bring jdk20 branch in sync with panama branch

### DIFF
--- a/src/main/java/org/openjdk/jextract/Declaration.java
+++ b/src/main/java/org/openjdk/jextract/Declaration.java
@@ -248,6 +248,22 @@ public interface Declaration {
     }
 
     /**
+     * A bitfield declaration. Same as a variable declaration, but doesn't have a layout. Instead, it has
+     * an offset (relative to the enclosing container) and a width.
+     */
+    interface Bitfield extends Variable {
+        /**
+         * {@return The bitfield offset (relative to the enclosing container)}
+         */
+        long offset();
+
+        /**
+         * {@return The bitfield width (in bits)}
+         */
+        long width();
+    }
+
+    /**
      * A constant value declaration.
      */
     interface Constant extends Declaration {
@@ -354,15 +370,16 @@ public interface Declaration {
     }
 
     /**
-     * Creates a new bitfield declaration with given name, type and layout.
+     * Creates a new bitfield declaration with given name, type, offset and width.
      * @param pos the bitfield declaration position.
      * @param name the bitfield declaration name.
      * @param type the bitfield declaration type.
-     * @param layout the bitfield declaration layout.
+     * @param offset the offset of the bitfield (relative to the enclosing container).
+     * @param width the bitfield width.
      * @return a new bitfield declaration with given name, type and layout.
      */
-    static Declaration.Variable bitfield(Position pos, String name, Type type, MemoryLayout layout) {
-        return new DeclarationImpl.VariableImpl(type, layout, Declaration.Variable.Kind.BITFIELD, name, pos);
+    static Declaration.Variable bitfield(Position pos, String name, Type type, long offset, long width) {
+        return new DeclarationImpl.BitfieldImpl(type, offset, width, name, pos);
     }
 
     /**
@@ -414,13 +431,12 @@ public interface Declaration {
     /**
      * Creates a new bitfields group declaration with given name and layout.
      * @param pos the bitfields group declaration position.
-     * @param layout the bitfields group declaration layout.
      * @param bitfields the bitfields group member declarations.
      * @return a new bitfields group declaration with given name and layout.
      */
-    static Declaration.Scoped bitfields(Position pos, MemoryLayout layout, Declaration.Variable... bitfields) {
+    static Declaration.Scoped bitfields(Position pos, Declaration.Variable... bitfields) {
         List<Declaration> declList = List.of(bitfields);
-        return new DeclarationImpl.ScopedImpl(Declaration.Scoped.Kind.BITFIELDS, layout, declList, "", pos);
+        return new DeclarationImpl.ScopedImpl(Declaration.Scoped.Kind.BITFIELDS, declList, "", pos);
     }
 
     /**

--- a/src/main/java/org/openjdk/jextract/Declaration.java
+++ b/src/main/java/org/openjdk/jextract/Declaration.java
@@ -235,12 +235,6 @@ public interface Declaration {
         Type type();
 
         /**
-         * The optional layout associated with this variable declaration.
-         * @return The optional layout associated with this variable declaration.
-         */
-        Optional<MemoryLayout> layout();
-
-        /**
          * The kind associated with this variable declaration.
          * @return The kind associated with this variable declaration.
          */

--- a/src/main/java/org/openjdk/jextract/impl/ConstantBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/ConstantBuilder.java
@@ -289,6 +289,11 @@ public class ConstantBuilder extends ClassSourceBuilder {
     private void emitLayoutString(MemoryLayout l) {
         if (l instanceof ValueLayout val) {
             append(primitiveLayoutString(val));
+            if (l.bitAlignment() != l.bitSize()) {
+                append(".withBitAlignment(");
+                append(l.bitAlignment());
+                append(")");
+            }
         } else if (l instanceof SequenceLayout seq) {
             append("MemoryLayout.sequenceLayout(");
             append(seq.elementCount() + ", ");

--- a/src/main/java/org/openjdk/jextract/impl/DeclarationImpl.java
+++ b/src/main/java/org/openjdk/jextract/impl/DeclarationImpl.java
@@ -141,7 +141,7 @@ public abstract class DeclarationImpl implements Declaration {
         }
     }
 
-    public static final class VariableImpl extends DeclarationImpl implements Declaration.Variable {
+    public static class VariableImpl extends DeclarationImpl implements Declaration.Variable {
 
         final Variable.Kind kind;
         final Type type;
@@ -204,6 +204,56 @@ public abstract class DeclarationImpl implements Declaration {
         @Override
         public int hashCode() {
             return Objects.hash(super.hashCode(), kind, type);
+        }
+    }
+
+    public static final class BitfieldImpl extends VariableImpl implements Declaration.Bitfield {
+
+        final long offset;
+        final long width;
+
+        private BitfieldImpl(Type type, long offset, long width, String name, Position pos, Map<String, List<Constable>> attrs) {
+            super(type, Optional.<MemoryLayout>empty(), Kind.BITFIELD, name, pos, attrs);
+            this.offset = offset;
+            this.width = width;
+        }
+
+        public BitfieldImpl(Type type, long offset, long width, String name, Position pos) {
+            this(type, offset, width, name, pos, null);
+        }
+
+        @Override
+        public long offset() {
+            return offset;
+        }
+
+        @Override
+        public long width() {
+            return width;
+        }
+
+        @Override
+        public Variable withAttributes(Map<String, List<Constable>> attrs) {
+            return new BitfieldImpl(type, offset, width, name(), pos(), attrs);
+        }
+
+        @Override
+        public Variable stripAttributes() {
+            return new BitfieldImpl(type, offset, width, name(), pos(), null);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof BitfieldImpl bitfield)) return false;
+            if (!super.equals(o)) return false;
+            return offset == bitfield.offset &&
+                    width == bitfield.width;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(super.hashCode(), offset, width);
         }
     }
 

--- a/src/main/java/org/openjdk/jextract/impl/DeclarationImpl.java
+++ b/src/main/java/org/openjdk/jextract/impl/DeclarationImpl.java
@@ -178,11 +178,6 @@ public abstract class DeclarationImpl implements Declaration {
         }
 
         @Override
-        public Optional<MemoryLayout> layout() {
-            return layout;
-        }
-
-        @Override
         public Variable withAttributes(Map<String, List<Constable>> attrs) {
             return new VariableImpl(type, layout, kind, name(), pos(), attrs);
         }

--- a/src/main/java/org/openjdk/jextract/impl/FunctionalInterfaceBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/FunctionalInterfaceBuilder.java
@@ -97,13 +97,14 @@ public class FunctionalInterfaceBuilder extends ClassSourceBuilder {
     private void emitFunctionalFactories() {
         emitWithConstantClass(constantBuilder -> {
             Constant functionDesc = constantBuilder.addFunctionDesc(className(), fiDesc);
+            Constant upcallHandle = constantBuilder.addLookupMethodHandle(className() + "_UP", className(), "apply", fiDesc);
             incrAlign();
             indent();
             append(MEMBER_MODS + " MemorySegment allocate(" + className() + " fi, SegmentScope scope) {\n");
             incrAlign();
             indent();
-            append("return RuntimeHelper.upcallStub(" + className() + ".class, fi, " +
-                functionDesc.accessExpression() + ", scope);\n");
+            append("return RuntimeHelper.upcallStub(" +
+                upcallHandle.accessExpression() + ", fi, " + functionDesc.accessExpression() + ", scope);\n");
             decrAlign();
             indent();
             append("}\n");
@@ -113,7 +114,7 @@ public class FunctionalInterfaceBuilder extends ClassSourceBuilder {
 
     private void emitFunctionalFactoryForPointer() {
         emitWithConstantClass(constantBuilder -> {
-            Constant mhConstant = constantBuilder.addMethodHandle(className(), className(),
+            Constant mhConstant = constantBuilder.addDowncallMethodHandle(className() + "_DOWN", className(),
                  fiDesc, false, true);
             incrAlign();
             indent();

--- a/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
@@ -24,7 +24,6 @@
  */
 package org.openjdk.jextract.impl;
 
-import java.lang.foreign.Linker;
 import java.lang.foreign.FunctionDescriptor;
 import java.lang.foreign.GroupLayout;
 import java.lang.foreign.MemorySegment;
@@ -109,7 +108,7 @@ abstract class HeaderFileBuilder extends ClassSourceBuilder {
         boolean isVarargs = funcTree.type().varargs();
 
         emitWithConstantClass(constantBuilder -> {
-            Constant mhConstant = constantBuilder.addMethodHandle(javaName, nativeName, descriptor, isVarargs, false)
+            Constant mhConstant = constantBuilder.addDowncallMethodHandle(javaName, nativeName, descriptor, isVarargs, false)
                     .emitGetter(this, MEMBER_MODS, Constant.QUALIFIED_NAME, nativeName);
             MethodType downcallType = descriptor.toMethodType();
             boolean needsAllocator = descriptor.returnLayout().isPresent() &&

--- a/src/main/java/org/openjdk/jextract/impl/OutputFactory.java
+++ b/src/main/java/org/openjdk/jextract/impl/OutputFactory.java
@@ -354,7 +354,7 @@ public class OutputFactory implements Declaration.Visitor<Void, Declaration> {
             declared.tree().accept(this, tree);
         }
 
-        MemoryLayout layout = tree.layout().orElse(Type.layoutFor(type).orElse(null));
+        MemoryLayout layout = Type.layoutFor(type).orElse(null);
         if (layout == null) {
             //no layout - abort
             return null;

--- a/src/main/java/org/openjdk/jextract/impl/PrettyPrinter.java
+++ b/src/main/java/org/openjdk/jextract/impl/PrettyPrinter.java
@@ -110,7 +110,7 @@ public class PrettyPrinter implements Declaration.Visitor<Void, Void> {
             builder.append("Bitfield: " + " type = " + d.type().accept(typeVisitor, null) + ", name = " + bitfield.name()
                     + ", offset = " + bitfield.offset() + ", width = " + bitfield.width());
         } else {
-            builder.append("Variable: " + d.kind() + " " + d.name() + " type = " + d.type().accept(typeVisitor, null) + ", layout = " + d.layout());
+            builder.append("Variable: " + d.kind() + " " + d.name() + " type = " + d.type().accept(typeVisitor, null));
         }
         builder.append("\n");
         getAttributes(d);

--- a/src/main/java/org/openjdk/jextract/impl/PrettyPrinter.java
+++ b/src/main/java/org/openjdk/jextract/impl/PrettyPrinter.java
@@ -31,6 +31,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.lang.foreign.MemoryLayout;
 import org.openjdk.jextract.Declaration;
+import org.openjdk.jextract.Declaration.Bitfield;
+import org.openjdk.jextract.Declaration.Variable.Kind;
 import org.openjdk.jextract.Position;
 import org.openjdk.jextract.Type;
 
@@ -104,7 +106,12 @@ public class PrettyPrinter implements Declaration.Visitor<Void, Void> {
     @Override
     public Void visitVariable(Declaration.Variable d, Void aVoid) {
         indent();
-        builder.append("Variable: " + d.kind() + " " + d.name() + " type = " + d.type().accept(typeVisitor, null) + ", layout = " + d.layout());
+        if (d instanceof Bitfield bitfield) {
+            builder.append("Bitfield: " + " type = " + d.type().accept(typeVisitor, null) + ", name = " + bitfield.name()
+                    + ", offset = " + bitfield.offset() + ", width = " + bitfield.width());
+        } else {
+            builder.append("Variable: " + d.kind() + " " + d.name() + " type = " + d.type().accept(typeVisitor, null) + ", layout = " + d.layout());
+        }
         builder.append("\n");
         getAttributes(d);
         return null;

--- a/src/main/java/org/openjdk/jextract/impl/RecordLayoutComputer.java
+++ b/src/main/java/org/openjdk/jextract/impl/RecordLayoutComputer.java
@@ -26,6 +26,7 @@
 
 package org.openjdk.jextract.impl;
 
+import java.lang.foreign.GroupLayout;
 import java.lang.foreign.MemoryLayout;
 import org.openjdk.jextract.Declaration;
 import org.openjdk.jextract.clang.Cursor;
@@ -33,6 +34,9 @@ import org.openjdk.jextract.clang.CursorKind;
 import org.openjdk.jextract.clang.Type;
 import org.openjdk.jextract.clang.TypeKind;
 
+import java.lang.foreign.SequenceLayout;
+import java.lang.foreign.StructLayout;
+import java.lang.foreign.ValueLayout;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -117,16 +121,19 @@ abstract class RecordLayoutComputer {
     abstract void processField(Cursor c);
     abstract Declaration.Scoped finishRecord(String anonName);
 
-    void addField(Declaration declaration) {
+    void addField(long offset, Declaration declaration) {
         fieldDecls.add(declaration);
         MemoryLayout layout = null;
         if (declaration instanceof Declaration.Scoped scoped) {
             layout = scoped.layout().orElse(null);
         } else if (declaration instanceof Declaration.Variable var) {
-            layout = var.layout().orElse(null);
+            layout = org.openjdk.jextract.Type.layoutFor(var.type()).orElse(null);
         }
         if (layout != null) {
-            //fieldLayouts.add(layout.name().isEmpty() ? layout.withName(declaration.name()) : layout);
+            if ((offset % layout.bitAlignment()) != 0) {
+                long maxAlign = Long.lowestOneBit(offset);
+                layout = forceAlign(layout, maxAlign);
+            }
             fieldLayouts.add(declaration.name().isEmpty() ? layout : layout.withName(declaration.name()));
         }
     }
@@ -137,9 +144,9 @@ abstract class RecordLayoutComputer {
 
     void addField(long offset, Type parent, Cursor c) {
         if (c.isAnonymousStruct()) {
-            addField(((org.openjdk.jextract.Type.Declared)computeAnonymous(typeMaker, offset, parent, c.type(), nextAnonymousName())).tree());
+            addField(offset, ((org.openjdk.jextract.Type.Declared)computeAnonymous(typeMaker, offset, parent, c.type(), nextAnonymousName())).tree());
         } else {
-            addField(field(offset, c));
+            addField(offset, field(offset, c));
         }
     }
 
@@ -183,6 +190,22 @@ abstract class RecordLayoutComputer {
             return offsets.stream().findFirst()
                     .orElseThrow(() -> new IllegalStateException(
                             "Can not find offset of: " + c + ", in: " + parent));
+        }
+    }
+
+    MemoryLayout forceAlign(MemoryLayout layout, long maxAlign) {
+        if (layout instanceof GroupLayout groupLayout) {
+            MemoryLayout[] newMembers = groupLayout.memberLayouts()
+                    .stream().map(l -> forceAlign(l, maxAlign)).toArray(MemoryLayout[]::new);
+            return groupLayout instanceof StructLayout ?
+                    MemoryLayout.structLayout(newMembers) :
+                    MemoryLayout.unionLayout(newMembers);
+        } else if (layout instanceof SequenceLayout sequenceLayout) {
+            return MemoryLayout.sequenceLayout(sequenceLayout.elementCount(),
+                    forceAlign(sequenceLayout.elementLayout(), maxAlign));
+        } else {
+            return layout.bitAlignment() > maxAlign ?
+                    layout.withBitAlignment(maxAlign) : layout;
         }
     }
 }

--- a/src/main/java/org/openjdk/jextract/impl/RecordLayoutComputer.java
+++ b/src/main/java/org/openjdk/jextract/impl/RecordLayoutComputer.java
@@ -139,7 +139,7 @@ abstract class RecordLayoutComputer {
         if (c.isAnonymousStruct()) {
             addField(((org.openjdk.jextract.Type.Declared)computeAnonymous(typeMaker, offset, parent, c.type(), nextAnonymousName())).tree());
         } else {
-            addField(field(c));
+            addField(field(offset, c));
         }
     }
 
@@ -147,12 +147,11 @@ abstract class RecordLayoutComputer {
         return "$anon$" + anonCount++;
     }
 
-    Declaration field(Cursor c) {
+    Declaration field(long offset, Cursor c) {
         org.openjdk.jextract.Type type = typeMaker.makeType(c.type());
         String name = c.spelling();
         if (c.isBitField()) {
-            MemoryLayout sublayout = MemoryLayout.paddingLayout(c.getBitFieldWidth());
-            return Declaration.bitfield(TreeMaker.CursorPosition.of(c), name, type, sublayout.withName(name));
+            return Declaration.bitfield(TreeMaker.CursorPosition.of(c), name, type, offset, c.getBitFieldWidth());
         } else if (c.isAnonymousStruct() && type instanceof org.openjdk.jextract.Type.Declared decl) {
             return decl.tree();
         } else {
@@ -167,8 +166,8 @@ abstract class RecordLayoutComputer {
         return c.isBitField() ? c.getBitFieldWidth() : c.type().size() * 8;
     }
 
-    Declaration.Scoped bitfield(List<MemoryLayout> sublayouts, Declaration.Variable... declarations) {
-        return Declaration.bitfields(declarations[0].pos(), MemoryLayout.structLayout(sublayouts.toArray(new MemoryLayout[0])), declarations);
+    Declaration.Scoped bitfield(Declaration.Variable... declarations) {
+        return Declaration.bitfields(declarations[0].pos(), declarations);
     }
 
     long offsetOf(Type parent, Cursor c) {

--- a/src/main/java/org/openjdk/jextract/impl/StructLayoutComputer.java
+++ b/src/main/java/org/openjdk/jextract/impl/StructLayoutComputer.java
@@ -154,6 +154,10 @@ final class StructLayoutComputer extends RecordLayoutComputer {
             if (!prevBitfieldDecls.isEmpty()) {
                 addField(bitfield(prevBitfieldDecls.toArray(new Declaration.Variable[0])));
             }
+            if (prevBitfieldSize == 0) {
+                // nothing to do
+                return;
+            }
             fieldLayouts.add(MemoryLayout.paddingLayout(prevBitfieldSize));
         }
     }

--- a/src/main/java/org/openjdk/jextract/impl/StructLayoutComputer.java
+++ b/src/main/java/org/openjdk/jextract/impl/StructLayoutComputer.java
@@ -51,12 +51,12 @@ final class StructLayoutComputer extends RecordLayoutComputer {
     }
 
     @Override
-    void addField(Declaration declaration) {
+    void addField(long offset, Declaration declaration) {
         if (bitfieldDecls != null) {
             bitfieldDecls.add(declaration);
             bitfieldSize += ((Declaration.Bitfield)declaration).width();
         } else {
-            super.addField(declaration);
+            super.addField(offset, declaration);
         }
     }
 
@@ -140,7 +140,8 @@ final class StructLayoutComputer extends RecordLayoutComputer {
         } else if (anonName != null) {
             g = g.withName(anonName);
         }
-        Declaration.Scoped declaration = Declaration.struct(TreeMaker.CursorPosition.of(cursor), cursor.spelling(), g, fieldDecls.stream().toArray(Declaration[]::new));
+        Declaration.Scoped declaration = Declaration.struct(TreeMaker.CursorPosition.of(cursor), cursor.spelling(),
+                g, fieldDecls.stream().toArray(Declaration[]::new));
         return declaration;
     }
 
@@ -152,7 +153,7 @@ final class StructLayoutComputer extends RecordLayoutComputer {
             bitfieldDecls = null;
             bitfieldSize = 0;
             if (!prevBitfieldDecls.isEmpty()) {
-                addField(bitfield(prevBitfieldDecls.toArray(new Declaration.Variable[0])));
+                addField(offset, bitfield(prevBitfieldDecls.toArray(new Declaration.Variable[0])));
             }
             if (prevBitfieldSize == 0) {
                 // nothing to do

--- a/src/main/java/org/openjdk/jextract/impl/ToplevelBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/ToplevelBuilder.java
@@ -31,6 +31,8 @@ import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.ValueLayout;
 import org.openjdk.jextract.Declaration;
 import org.openjdk.jextract.Type;
+import org.openjdk.jextract.Type.Primitive;
+import org.openjdk.jextract.Type.Primitive.Kind;
 
 import javax.tools.JavaFileObject;
 import java.lang.constant.ClassDesc;
@@ -275,7 +277,7 @@ class ToplevelBuilder extends JavaSourceBuilder {
         }
 
         private Constant addPrimitiveLayout(String javaName, ValueLayout layout) {
-            ValueLayout layoutNoName = layoutNoName(layout);
+            ValueLayout layoutNoName = normalize(layout);
             Constant layoutConstant = super.addLayout(javaName, layoutNoName);
             primitiveLayouts.put(layoutNoName, layoutConstant);
             return layoutConstant;
@@ -285,14 +287,13 @@ class ToplevelBuilder extends JavaSourceBuilder {
             return addPrimitiveLayout(javaName, (ValueLayout)kind.layout().orElseThrow());
         }
 
-        private ValueLayout layoutNoName(ValueLayout layout) {
-            // drop name if present
-            return MemoryLayout.valueLayout(layout.carrier(), layout.order())
-                    .withBitAlignment(layout.bitAlignment());
+        public Constant resolvePrimitiveLayout(ValueLayout layout) {
+            return primitiveLayouts.get(normalize(layout));
         }
 
-        public Constant resolvePrimitiveLayout(ValueLayout layout) {
-            return primitiveLayouts.get(layoutNoName(layout));
+        public ValueLayout normalize(ValueLayout valueLayout) {
+            return MemoryLayout.valueLayout(valueLayout.carrier(), valueLayout.order()) // drop name
+                    .withBitAlignment(valueLayout.bitSize()); // use natural alignment
         }
     }
 

--- a/src/main/java/org/openjdk/jextract/impl/TreeMaker.java
+++ b/src/main/java/org/openjdk/jextract/impl/TreeMaker.java
@@ -98,9 +98,7 @@ class TreeMaker {
         return switch (c.kind()) {
             case EnumDecl -> createEnum(c);
             case EnumConstantDecl -> createEnumConstant(c);
-            case FieldDecl -> c.isBitField() ?
-                        createBitfield(c) :
-                        createVar(c, Declaration.Variable.Kind.FIELD);
+            case FieldDecl -> createVar(c, Declaration.Variable.Kind.FIELD);
             case ParmDecl -> createVar(c, Declaration.Variable.Kind.PARAMETER);
             case FunctionDecl -> createFunction(c);
             case StructDecl -> createRecord(c, Declaration.Scoped.Kind.STRUCT);
@@ -314,13 +312,8 @@ class TreeMaker {
         }
     }
 
-    private Declaration.Variable createBitfield(Cursor c) {
-        checkCursorAny(c, CursorKind.FieldDecl);
-        return Declaration.bitfield(CursorPosition.of(c), c.spelling(), toType(c),
-                MemoryLayout.paddingLayout(c.getBitFieldWidth()));
-    }
-
     private Declaration.Variable createVar(Cursor c, Declaration.Variable.Kind kind) {
+        if (c.isBitField()) throw new AssertionError("Cannot get here!");
         checkCursorAny(c, CursorKind.VarDecl, CursorKind.FieldDecl, CursorKind.ParmDecl);
         Type type;
         try {

--- a/src/main/java/org/openjdk/jextract/impl/UnionLayoutComputer.java
+++ b/src/main/java/org/openjdk/jextract/impl/UnionLayoutComputer.java
@@ -64,12 +64,12 @@ final class UnionLayoutComputer extends RecordLayoutComputer {
     }
 
     @Override
-    Declaration field(Cursor c) {
+    Declaration field(long offset, Cursor c) {
         if (c.isBitField()) {
-            Declaration.Variable var = (Declaration.Variable)super.field(c);
-            return bitfield(List.of(var.layout().get()), var);
+            Declaration.Variable var = (Declaration.Variable)super.field(offset, c);
+            return bitfield(var);
         } else {
-            return super.field(c);
+            return super.field(offset, c);
         }
     }
 

--- a/src/main/resources/org/openjdk/jextract/impl/resources/RuntimeHelper.java.template
+++ b/src/main/resources/org/openjdk/jextract/impl/resources/RuntimeHelper.java.template
@@ -69,11 +69,18 @@ final class RuntimeHelper {
                 orElse(null);
     }
 
-    static <Z> MemorySegment upcallStub(Class<Z> fi, Z z, FunctionDescriptor fdesc, SegmentScope scope) {
+    static MethodHandle upcallHandle(Class<?> fi, String name, FunctionDescriptor fdesc) {
         try {
-            MethodHandle handle = MH_LOOKUP.findVirtual(fi, "apply", fdesc.toMethodType());
-            handle = handle.bindTo(z);
-            return LINKER.upcallStub(handle, fdesc, scope);
+            return MH_LOOKUP.findVirtual(fi, name, fdesc.toMethodType());
+        } catch (Throwable ex) {
+            throw new AssertionError(ex);
+        }
+    }
+
+    static <Z> MemorySegment upcallStub(MethodHandle fiHandle, Z z, FunctionDescriptor fdesc, SegmentScope scope) {
+        try {
+            fiHandle = fiHandle.bindTo(z);
+            return LINKER.upcallStub(fiHandle, fdesc, scope);
         } catch (Throwable ex) {
             throw new AssertionError(ex);
         }

--- a/test/lib/testlib/JextractApiTestBase.java
+++ b/test/lib/testlib/JextractApiTestBase.java
@@ -120,7 +120,7 @@ public class JextractApiTestBase {
     public static Declaration.Variable checkBitField(Declaration.Scoped record, String name, Type type, int size) {
         Declaration.Variable global = checkVariable(record, name, type);
         assertEquals(global.kind(), Declaration.Variable.Kind.BITFIELD);
-        assertEquals(global.layout().get().bitSize(), size);
+        assertEquals(((Declaration.Bitfield)global).width(), size);
         return global;
     }
 

--- a/test/testng/org/openjdk/jextract/test/api/TestPackedStructs.java
+++ b/test/testng/org/openjdk/jextract/test/api/TestPackedStructs.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package org.openjdk.jextract.test.api;
+
+import org.openjdk.jextract.Declaration;
+import org.testng.annotations.Test;
+import testlib.JextractApiTestBase;
+
+import static org.testng.Assert.assertEquals;
+
+import java.lang.foreign.GroupLayout;
+
+public class TestPackedStructs extends JextractApiTestBase {
+
+    static final String[] NAMES = {
+            "S1", "S2", "S3", "S4", "S5", "S6"
+    };
+
+    @Test
+    public void testPackedStructs() {
+        Declaration.Scoped d = parse("packedstructs.h");
+        System.out.println(d);
+        for (String name : NAMES) {
+            Declaration.Scoped scoped = checkStruct(d, name, "first", "second");
+            GroupLayout groupLayout = (GroupLayout)scoped.layout().get();
+            assertEquals(groupLayout.memberLayouts().get(1).bitAlignment(), 8);
+        }
+    }
+}

--- a/test/testng/org/openjdk/jextract/test/api/packedstructs.h
+++ b/test/testng/org/openjdk/jextract/test/api/packedstructs.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#pragma pack(1)
+struct S1 {
+   char first;
+   int second;
+};
+
+#pragma pack(1)
+struct S2 {
+   char first;
+   struct { int i } second;
+};
+
+#pragma pack(1)
+struct S3 {
+   char first;
+   int second[2];
+};
+
+#pragma pack(1)
+struct S4 {
+   char first;
+   union { int x; int y; } second;
+};
+
+#pragma pack(1)
+struct S5 {
+   char first;
+   union { struct { int i } x; struct { int i } y; } second;
+};
+
+#pragma pack(1)
+struct S6 {
+   char first;
+   union { int x[2]; int y[2]; } second;
+};


### PR DESCRIPTION
This PR brings fixes from `panama` branch back to the `jdk20` branch.
We are doing this as part of getting ready to start shipping binary snapshot of the jdk20 version of jextract.