### PR TITLE
TCL sample fails because generated code is too large. 

### DIFF
--- a/samples/tcl/compile.sh
+++ b/samples/tcl/compile.sh
@@ -1,3 +1,6 @@
 jextract -l tcl -t org.tcl \
+  --include-function Tcl_CreateInterp \
+  --include-function Tcl_Eval \
+  --include-function Tcl_DeleteInterp \
   -I /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include \
    /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/tcl.h


### PR DESCRIPTION
But we only use 3 functions. Using filtering fixes the same jextraction step.