### PR TITLE
7903463: jextract generates empty padding layouts

### DIFF
--- a/src/main/java/org/openjdk/jextract/impl/StructLayoutComputer.java
+++ b/src/main/java/org/openjdk/jextract/impl/StructLayoutComputer.java
@@ -155,7 +155,9 @@ final class StructLayoutComputer extends RecordLayoutComputer {
             if (!prevBitfieldDecls.isEmpty()) {
                 addField(offset, bitfield(prevBitfieldDecls.toArray(new Declaration.Variable[0])));
             }
-            fieldLayouts.add(MemoryLayout.paddingLayout(prevBitfieldSize));
+            if (prevBitfieldSize > 0) {
+                fieldLayouts.add(MemoryLayout.paddingLayout(prevBitfieldSize));
+            }
         }
     }
 }


### PR DESCRIPTION
This simple patch fixes a bug where jextract would generate a zero-sized padding layout when handling bitfields. This behavior causes a test failure when running against JDK 21.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Issue
 * [CODETOOLS-7903463](https://bugs.openjdk.org/browse/CODETOOLS-7903463): jextract generates empty padding layouts


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/119/head:pull/119` \
`$ git checkout pull/119`

Update a local copy of the PR: \
`$ git checkout pull/119` \
`$ git pull https://git.openjdk.org/jextract.git pull/119/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 119`

View PR using the GUI difftool: \
`$ git pr show -t 119`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/119.diff">https://git.openjdk.org/jextract/pull/119.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/119#issuecomment-1527745322)