### PR TITLE
7903475: Jextract should use new byte-based layout methods

### DIFF
--- a/src/main/java/org/openjdk/jextract/Type.java
+++ b/src/main/java/org/openjdk/jextract/Type.java
@@ -129,11 +129,11 @@ public interface Type {
             /**
              * {@code float} type.
              */
-            Float("float", ValueLayout.JAVA_FLOAT.withBitAlignment(32)),
+            Float("float", ValueLayout.JAVA_FLOAT),
             /**
              * {@code double} type.
              */
-            Double("double", ValueLayout.JAVA_DOUBLE.withBitAlignment(64)),
+            Double("double", ValueLayout.JAVA_DOUBLE),
             /**
               * {@code long double} type.
               */

--- a/src/main/java/org/openjdk/jextract/clang/libclang/CXString.java
+++ b/src/main/java/org/openjdk/jextract/clang/libclang/CXString.java
@@ -45,7 +45,7 @@ public class CXString {
     static final StructLayout $struct$LAYOUT = MemoryLayout.structLayout(
         Constants$root.C_POINTER$LAYOUT.withName("data"),
         Constants$root.C_INT$LAYOUT.withName("private_flags"),
-        MemoryLayout.paddingLayout(32)
+        MemoryLayout.paddingLayout(4)
     );
     public static MemoryLayout $LAYOUT() {
         return CXString.$struct$LAYOUT;

--- a/src/main/java/org/openjdk/jextract/clang/libclang/CXType.java
+++ b/src/main/java/org/openjdk/jextract/clang/libclang/CXType.java
@@ -44,7 +44,7 @@ public class CXType {
 
     static final StructLayout $struct$LAYOUT = MemoryLayout.structLayout(
         Constants$root.C_INT$LAYOUT.withName("kind"),
-        MemoryLayout.paddingLayout(32),
+        MemoryLayout.paddingLayout(4),
         MemoryLayout.sequenceLayout(2, Constants$root.C_POINTER$LAYOUT).withName("data")
     );
     public static MemoryLayout $LAYOUT() {

--- a/src/main/java/org/openjdk/jextract/clang/libclang/Constants$root.java
+++ b/src/main/java/org/openjdk/jextract/clang/libclang/Constants$root.java
@@ -44,7 +44,7 @@ final class Constants$root {
     static final OfLong C_LONG_LONG$LAYOUT = JAVA_LONG;
     static final OfFloat C_FLOAT$LAYOUT = JAVA_FLOAT;
     static final OfDouble C_DOUBLE$LAYOUT = JAVA_DOUBLE;
-    static final AddressLayout C_POINTER$LAYOUT = ADDRESS.withBitAlignment(64)
+    static final AddressLayout C_POINTER$LAYOUT = ADDRESS
             .withTargetLayout(MemoryLayout.sequenceLayout(C_CHAR$LAYOUT));
 }
 

--- a/src/main/java/org/openjdk/jextract/clang/libclang/constants$0.java
+++ b/src/main/java/org/openjdk/jextract/clang/libclang/constants$0.java
@@ -40,7 +40,7 @@ final class constants$0 {
         MemoryLayout.structLayout(
             Constants$root.C_POINTER$LAYOUT.withName("data"),
             Constants$root.C_INT$LAYOUT.withName("private_flags"),
-            MemoryLayout.paddingLayout(32)
+            MemoryLayout.paddingLayout(4)
         )
     );
     static final MethodHandle clang_getCString$MH = RuntimeHelper.downcallHandle(
@@ -51,7 +51,7 @@ final class constants$0 {
         MemoryLayout.structLayout(
             Constants$root.C_POINTER$LAYOUT.withName("data"),
             Constants$root.C_INT$LAYOUT.withName("private_flags"),
-            MemoryLayout.paddingLayout(32)
+            MemoryLayout.paddingLayout(4)
         )
     );
     static final MethodHandle clang_disposeString$MH = RuntimeHelper.downcallHandle(
@@ -76,7 +76,7 @@ final class constants$0 {
     static final FunctionDescriptor clang_getFileName$FUNC = FunctionDescriptor.of(MemoryLayout.structLayout(
         Constants$root.C_POINTER$LAYOUT.withName("data"),
         Constants$root.C_INT$LAYOUT.withName("private_flags"),
-        MemoryLayout.paddingLayout(32)
+        MemoryLayout.paddingLayout(4)
     ),
         Constants$root.C_POINTER$LAYOUT
     );
@@ -87,7 +87,7 @@ final class constants$0 {
     static final FunctionDescriptor clang_getNullLocation$FUNC = FunctionDescriptor.of(MemoryLayout.structLayout(
         MemoryLayout.sequenceLayout(2, Constants$root.C_POINTER$LAYOUT).withName("ptr_data"),
         Constants$root.C_INT$LAYOUT.withName("int_data"),
-        MemoryLayout.paddingLayout(32)
+        MemoryLayout.paddingLayout(4)
     ));
     static final MethodHandle clang_getNullLocation$MH = RuntimeHelper.downcallHandle(
         "clang_getNullLocation",

--- a/src/main/java/org/openjdk/jextract/clang/libclang/constants$1.java
+++ b/src/main/java/org/openjdk/jextract/clang/libclang/constants$1.java
@@ -40,12 +40,12 @@ final class constants$1 {
         MemoryLayout.structLayout(
             MemoryLayout.sequenceLayout(2, Constants$root.C_POINTER$LAYOUT).withName("ptr_data"),
             Constants$root.C_INT$LAYOUT.withName("int_data"),
-            MemoryLayout.paddingLayout(32)
+            MemoryLayout.paddingLayout(4)
         ),
         MemoryLayout.structLayout(
             MemoryLayout.sequenceLayout(2, Constants$root.C_POINTER$LAYOUT).withName("ptr_data"),
             Constants$root.C_INT$LAYOUT.withName("int_data"),
-            MemoryLayout.paddingLayout(32)
+            MemoryLayout.paddingLayout(4)
         )
     );
     static final MethodHandle clang_equalLocations$MH = RuntimeHelper.downcallHandle(
@@ -55,7 +55,7 @@ final class constants$1 {
     static final FunctionDescriptor clang_getLocation$FUNC = FunctionDescriptor.of(MemoryLayout.structLayout(
         MemoryLayout.sequenceLayout(2, Constants$root.C_POINTER$LAYOUT).withName("ptr_data"),
         Constants$root.C_INT$LAYOUT.withName("int_data"),
-        MemoryLayout.paddingLayout(32)
+        MemoryLayout.paddingLayout(4)
     ),
         Constants$root.C_POINTER$LAYOUT,
         Constants$root.C_POINTER$LAYOUT,
@@ -69,7 +69,7 @@ final class constants$1 {
     static final FunctionDescriptor clang_getLocationForOffset$FUNC = FunctionDescriptor.of(MemoryLayout.structLayout(
         MemoryLayout.sequenceLayout(2, Constants$root.C_POINTER$LAYOUT).withName("ptr_data"),
         Constants$root.C_INT$LAYOUT.withName("int_data"),
-        MemoryLayout.paddingLayout(32)
+        MemoryLayout.paddingLayout(4)
     ),
         Constants$root.C_POINTER$LAYOUT,
         Constants$root.C_POINTER$LAYOUT,
@@ -83,7 +83,7 @@ final class constants$1 {
         MemoryLayout.structLayout(
             MemoryLayout.sequenceLayout(2, Constants$root.C_POINTER$LAYOUT).withName("ptr_data"),
             Constants$root.C_INT$LAYOUT.withName("int_data"),
-            MemoryLayout.paddingLayout(32)
+            MemoryLayout.paddingLayout(4)
         )
     );
     static final MethodHandle clang_Location_isInSystemHeader$MH = RuntimeHelper.downcallHandle(
@@ -94,7 +94,7 @@ final class constants$1 {
         MemoryLayout.structLayout(
             MemoryLayout.sequenceLayout(2, Constants$root.C_POINTER$LAYOUT).withName("ptr_data"),
             Constants$root.C_INT$LAYOUT.withName("int_data"),
-            MemoryLayout.paddingLayout(32)
+            MemoryLayout.paddingLayout(4)
         )
     );
     static final MethodHandle clang_Location_isFromMainFile$MH = RuntimeHelper.downcallHandle(

--- a/src/main/java/org/openjdk/jextract/clang/libclang/constants$10.java
+++ b/src/main/java/org/openjdk/jextract/clang/libclang/constants$10.java
@@ -39,7 +39,7 @@ final class constants$10 {
     static final FunctionDescriptor clang_isVolatileQualifiedType$FUNC = FunctionDescriptor.of(Constants$root.C_INT$LAYOUT,
         MemoryLayout.structLayout(
             Constants$root.C_INT$LAYOUT.withName("kind"),
-            MemoryLayout.paddingLayout(32),
+            MemoryLayout.paddingLayout(4),
             MemoryLayout.sequenceLayout(2, Constants$root.C_POINTER$LAYOUT).withName("data")
         )
     );
@@ -50,11 +50,11 @@ final class constants$10 {
     static final FunctionDescriptor clang_getTypedefName$FUNC = FunctionDescriptor.of(MemoryLayout.structLayout(
         Constants$root.C_POINTER$LAYOUT.withName("data"),
         Constants$root.C_INT$LAYOUT.withName("private_flags"),
-        MemoryLayout.paddingLayout(32)
+        MemoryLayout.paddingLayout(4)
     ),
         MemoryLayout.structLayout(
             Constants$root.C_INT$LAYOUT.withName("kind"),
-            MemoryLayout.paddingLayout(32),
+            MemoryLayout.paddingLayout(4),
             MemoryLayout.sequenceLayout(2, Constants$root.C_POINTER$LAYOUT).withName("data")
         )
     );
@@ -64,12 +64,12 @@ final class constants$10 {
     );
     static final FunctionDescriptor clang_getPointeeType$FUNC = FunctionDescriptor.of(MemoryLayout.structLayout(
         Constants$root.C_INT$LAYOUT.withName("kind"),
-        MemoryLayout.paddingLayout(32),
+        MemoryLayout.paddingLayout(4),
         MemoryLayout.sequenceLayout(2, Constants$root.C_POINTER$LAYOUT).withName("data")
     ),
         MemoryLayout.structLayout(
             Constants$root.C_INT$LAYOUT.withName("kind"),
-            MemoryLayout.paddingLayout(32),
+            MemoryLayout.paddingLayout(4),
             MemoryLayout.sequenceLayout(2, Constants$root.C_POINTER$LAYOUT).withName("data")
         )
     );
@@ -84,7 +84,7 @@ final class constants$10 {
     ),
         MemoryLayout.structLayout(
             Constants$root.C_INT$LAYOUT.withName("kind"),
-            MemoryLayout.paddingLayout(32),
+            MemoryLayout.paddingLayout(4),
             MemoryLayout.sequenceLayout(2, Constants$root.C_POINTER$LAYOUT).withName("data")
         )
     );
@@ -95,7 +95,7 @@ final class constants$10 {
     static final FunctionDescriptor clang_getTypeKindSpelling$FUNC = FunctionDescriptor.of(MemoryLayout.structLayout(
         Constants$root.C_POINTER$LAYOUT.withName("data"),
         Constants$root.C_INT$LAYOUT.withName("private_flags"),
-        MemoryLayout.paddingLayout(32)
+        MemoryLayout.paddingLayout(4)
     ),
         Constants$root.C_INT$LAYOUT
     );
@@ -106,7 +106,7 @@ final class constants$10 {
     static final FunctionDescriptor clang_getFunctionTypeCallingConv$FUNC = FunctionDescriptor.of(Constants$root.C_INT$LAYOUT,
         MemoryLayout.structLayout(
             Constants$root.C_INT$LAYOUT.withName("kind"),
-            MemoryLayout.paddingLayout(32),
+            MemoryLayout.paddingLayout(4),
             MemoryLayout.sequenceLayout(2, Constants$root.C_POINTER$LAYOUT).withName("data")
         )
     );

--- a/src/main/java/org/openjdk/jextract/clang/libclang/constants$11.java
+++ b/src/main/java/org/openjdk/jextract/clang/libclang/constants$11.java
@@ -38,12 +38,12 @@ final class constants$11 {
     private constants$11() {}
     static final FunctionDescriptor clang_getResultType$FUNC = FunctionDescriptor.of(MemoryLayout.structLayout(
         Constants$root.C_INT$LAYOUT.withName("kind"),
-        MemoryLayout.paddingLayout(32),
+        MemoryLayout.paddingLayout(4),
         MemoryLayout.sequenceLayout(2, Constants$root.C_POINTER$LAYOUT).withName("data")
     ),
         MemoryLayout.structLayout(
             Constants$root.C_INT$LAYOUT.withName("kind"),
-            MemoryLayout.paddingLayout(32),
+            MemoryLayout.paddingLayout(4),
             MemoryLayout.sequenceLayout(2, Constants$root.C_POINTER$LAYOUT).withName("data")
         )
     );
@@ -54,7 +54,7 @@ final class constants$11 {
     static final FunctionDescriptor clang_getNumArgTypes$FUNC = FunctionDescriptor.of(Constants$root.C_INT$LAYOUT,
         MemoryLayout.structLayout(
             Constants$root.C_INT$LAYOUT.withName("kind"),
-            MemoryLayout.paddingLayout(32),
+            MemoryLayout.paddingLayout(4),
             MemoryLayout.sequenceLayout(2, Constants$root.C_POINTER$LAYOUT).withName("data")
         )
     );
@@ -64,12 +64,12 @@ final class constants$11 {
     );
     static final FunctionDescriptor clang_getArgType$FUNC = FunctionDescriptor.of(MemoryLayout.structLayout(
         Constants$root.C_INT$LAYOUT.withName("kind"),
-        MemoryLayout.paddingLayout(32),
+        MemoryLayout.paddingLayout(4),
         MemoryLayout.sequenceLayout(2, Constants$root.C_POINTER$LAYOUT).withName("data")
     ),
         MemoryLayout.structLayout(
             Constants$root.C_INT$LAYOUT.withName("kind"),
-            MemoryLayout.paddingLayout(32),
+            MemoryLayout.paddingLayout(4),
             MemoryLayout.sequenceLayout(2, Constants$root.C_POINTER$LAYOUT).withName("data")
         ),
         Constants$root.C_INT$LAYOUT
@@ -81,7 +81,7 @@ final class constants$11 {
     static final FunctionDescriptor clang_isFunctionTypeVariadic$FUNC = FunctionDescriptor.of(Constants$root.C_INT$LAYOUT,
         MemoryLayout.structLayout(
             Constants$root.C_INT$LAYOUT.withName("kind"),
-            MemoryLayout.paddingLayout(32),
+            MemoryLayout.paddingLayout(4),
             MemoryLayout.sequenceLayout(2, Constants$root.C_POINTER$LAYOUT).withName("data")
         )
     );
@@ -91,7 +91,7 @@ final class constants$11 {
     );
     static final FunctionDescriptor clang_getCursorResultType$FUNC = FunctionDescriptor.of(MemoryLayout.structLayout(
         Constants$root.C_INT$LAYOUT.withName("kind"),
-        MemoryLayout.paddingLayout(32),
+        MemoryLayout.paddingLayout(4),
         MemoryLayout.sequenceLayout(2, Constants$root.C_POINTER$LAYOUT).withName("data")
     ),
         MemoryLayout.structLayout(
@@ -106,12 +106,12 @@ final class constants$11 {
     );
     static final FunctionDescriptor clang_getElementType$FUNC = FunctionDescriptor.of(MemoryLayout.structLayout(
         Constants$root.C_INT$LAYOUT.withName("kind"),
-        MemoryLayout.paddingLayout(32),
+        MemoryLayout.paddingLayout(4),
         MemoryLayout.sequenceLayout(2, Constants$root.C_POINTER$LAYOUT).withName("data")
     ),
         MemoryLayout.structLayout(
             Constants$root.C_INT$LAYOUT.withName("kind"),
-            MemoryLayout.paddingLayout(32),
+            MemoryLayout.paddingLayout(4),
             MemoryLayout.sequenceLayout(2, Constants$root.C_POINTER$LAYOUT).withName("data")
         )
     );

--- a/src/main/java/org/openjdk/jextract/clang/libclang/constants$12.java
+++ b/src/main/java/org/openjdk/jextract/clang/libclang/constants$12.java
@@ -39,7 +39,7 @@ final class constants$12 {
     static final FunctionDescriptor clang_getNumElements$FUNC = FunctionDescriptor.of(Constants$root.C_LONG_LONG$LAYOUT,
         MemoryLayout.structLayout(
             Constants$root.C_INT$LAYOUT.withName("kind"),
-            MemoryLayout.paddingLayout(32),
+            MemoryLayout.paddingLayout(4),
             MemoryLayout.sequenceLayout(2, Constants$root.C_POINTER$LAYOUT).withName("data")
         )
     );
@@ -49,12 +49,12 @@ final class constants$12 {
     );
     static final FunctionDescriptor clang_getArrayElementType$FUNC = FunctionDescriptor.of(MemoryLayout.structLayout(
         Constants$root.C_INT$LAYOUT.withName("kind"),
-        MemoryLayout.paddingLayout(32),
+        MemoryLayout.paddingLayout(4),
         MemoryLayout.sequenceLayout(2, Constants$root.C_POINTER$LAYOUT).withName("data")
     ),
         MemoryLayout.structLayout(
             Constants$root.C_INT$LAYOUT.withName("kind"),
-            MemoryLayout.paddingLayout(32),
+            MemoryLayout.paddingLayout(4),
             MemoryLayout.sequenceLayout(2, Constants$root.C_POINTER$LAYOUT).withName("data")
         )
     );
@@ -65,7 +65,7 @@ final class constants$12 {
     static final FunctionDescriptor clang_getArraySize$FUNC = FunctionDescriptor.of(Constants$root.C_LONG_LONG$LAYOUT,
         MemoryLayout.structLayout(
             Constants$root.C_INT$LAYOUT.withName("kind"),
-            MemoryLayout.paddingLayout(32),
+            MemoryLayout.paddingLayout(4),
             MemoryLayout.sequenceLayout(2, Constants$root.C_POINTER$LAYOUT).withName("data")
         )
     );
@@ -76,7 +76,7 @@ final class constants$12 {
     static final FunctionDescriptor clang_Type_getSizeOf$FUNC = FunctionDescriptor.of(Constants$root.C_LONG_LONG$LAYOUT,
         MemoryLayout.structLayout(
             Constants$root.C_INT$LAYOUT.withName("kind"),
-            MemoryLayout.paddingLayout(32),
+            MemoryLayout.paddingLayout(4),
             MemoryLayout.sequenceLayout(2, Constants$root.C_POINTER$LAYOUT).withName("data")
         )
     );
@@ -87,7 +87,7 @@ final class constants$12 {
     static final FunctionDescriptor clang_Type_getOffsetOf$FUNC = FunctionDescriptor.of(Constants$root.C_LONG_LONG$LAYOUT,
         MemoryLayout.structLayout(
             Constants$root.C_INT$LAYOUT.withName("kind"),
-            MemoryLayout.paddingLayout(32),
+            MemoryLayout.paddingLayout(4),
             MemoryLayout.sequenceLayout(2, Constants$root.C_POINTER$LAYOUT).withName("data")
         ),
         Constants$root.C_POINTER$LAYOUT

--- a/src/main/java/org/openjdk/jextract/clang/libclang/constants$13.java
+++ b/src/main/java/org/openjdk/jextract/clang/libclang/constants$13.java
@@ -90,7 +90,7 @@ final class constants$13 {
     static final FunctionDescriptor clang_getCursorUSR$FUNC = FunctionDescriptor.of(MemoryLayout.structLayout(
         Constants$root.C_POINTER$LAYOUT.withName("data"),
         Constants$root.C_INT$LAYOUT.withName("private_flags"),
-        MemoryLayout.paddingLayout(32)
+        MemoryLayout.paddingLayout(4)
     ),
         MemoryLayout.structLayout(
             Constants$root.C_INT$LAYOUT.withName("kind"),

--- a/src/main/java/org/openjdk/jextract/clang/libclang/constants$14.java
+++ b/src/main/java/org/openjdk/jextract/clang/libclang/constants$14.java
@@ -39,7 +39,7 @@ final class constants$14 {
     static final FunctionDescriptor clang_getCursorSpelling$FUNC = FunctionDescriptor.of(MemoryLayout.structLayout(
         Constants$root.C_POINTER$LAYOUT.withName("data"),
         Constants$root.C_INT$LAYOUT.withName("private_flags"),
-        MemoryLayout.paddingLayout(32)
+        MemoryLayout.paddingLayout(4)
     ),
         MemoryLayout.structLayout(
             Constants$root.C_INT$LAYOUT.withName("kind"),
@@ -89,7 +89,7 @@ final class constants$14 {
     static final FunctionDescriptor clang_getCursorPrettyPrinted$FUNC = FunctionDescriptor.of(MemoryLayout.structLayout(
         Constants$root.C_POINTER$LAYOUT.withName("data"),
         Constants$root.C_INT$LAYOUT.withName("private_flags"),
-        MemoryLayout.paddingLayout(32)
+        MemoryLayout.paddingLayout(4)
     ),
         MemoryLayout.structLayout(
             Constants$root.C_INT$LAYOUT.withName("kind"),

--- a/src/main/java/org/openjdk/jextract/clang/libclang/constants$15.java
+++ b/src/main/java/org/openjdk/jextract/clang/libclang/constants$15.java
@@ -39,7 +39,7 @@ final class constants$15 {
     static final FunctionDescriptor clang_getCursorDisplayName$FUNC = FunctionDescriptor.of(MemoryLayout.structLayout(
         Constants$root.C_POINTER$LAYOUT.withName("data"),
         Constants$root.C_INT$LAYOUT.withName("private_flags"),
-        MemoryLayout.paddingLayout(32)
+        MemoryLayout.paddingLayout(4)
     ),
         MemoryLayout.structLayout(
             Constants$root.C_INT$LAYOUT.withName("kind"),
@@ -106,7 +106,7 @@ final class constants$15 {
     static final FunctionDescriptor clang_Cursor_getMangling$FUNC = FunctionDescriptor.of(MemoryLayout.structLayout(
         Constants$root.C_POINTER$LAYOUT.withName("data"),
         Constants$root.C_INT$LAYOUT.withName("private_flags"),
-        MemoryLayout.paddingLayout(32)
+        MemoryLayout.paddingLayout(4)
     ),
         MemoryLayout.structLayout(
             Constants$root.C_INT$LAYOUT.withName("kind"),

--- a/src/main/java/org/openjdk/jextract/clang/libclang/constants$16.java
+++ b/src/main/java/org/openjdk/jextract/clang/libclang/constants$16.java
@@ -49,7 +49,7 @@ final class constants$16 {
     static final FunctionDescriptor clang_getTokenSpelling$FUNC = FunctionDescriptor.of(MemoryLayout.structLayout(
         Constants$root.C_POINTER$LAYOUT.withName("data"),
         Constants$root.C_INT$LAYOUT.withName("private_flags"),
-        MemoryLayout.paddingLayout(32)
+        MemoryLayout.paddingLayout(4)
     ),
         Constants$root.C_POINTER$LAYOUT,
         MemoryLayout.structLayout(
@@ -64,7 +64,7 @@ final class constants$16 {
     static final FunctionDescriptor clang_getTokenLocation$FUNC = FunctionDescriptor.of(MemoryLayout.structLayout(
         MemoryLayout.sequenceLayout(2, Constants$root.C_POINTER$LAYOUT).withName("ptr_data"),
         Constants$root.C_INT$LAYOUT.withName("int_data"),
-        MemoryLayout.paddingLayout(32)
+        MemoryLayout.paddingLayout(4)
     ),
         Constants$root.C_POINTER$LAYOUT,
         MemoryLayout.structLayout(

--- a/src/main/java/org/openjdk/jextract/clang/libclang/constants$17.java
+++ b/src/main/java/org/openjdk/jextract/clang/libclang/constants$17.java
@@ -39,7 +39,7 @@ final class constants$17 {
     static final FunctionDescriptor clang_getCursorKindSpelling$FUNC = FunctionDescriptor.of(MemoryLayout.structLayout(
         Constants$root.C_POINTER$LAYOUT.withName("data"),
         Constants$root.C_INT$LAYOUT.withName("private_flags"),
-        MemoryLayout.paddingLayout(32)
+        MemoryLayout.paddingLayout(4)
     ),
         Constants$root.C_INT$LAYOUT
     );
@@ -50,7 +50,7 @@ final class constants$17 {
     static final FunctionDescriptor clang_getClangVersion$FUNC = FunctionDescriptor.of(MemoryLayout.structLayout(
         Constants$root.C_POINTER$LAYOUT.withName("data"),
         Constants$root.C_INT$LAYOUT.withName("private_flags"),
-        MemoryLayout.paddingLayout(32)
+        MemoryLayout.paddingLayout(4)
     ));
     static final MethodHandle clang_getClangVersion$MH = RuntimeHelper.downcallHandle(
         "clang_getClangVersion",

--- a/src/main/java/org/openjdk/jextract/clang/libclang/constants$2.java
+++ b/src/main/java/org/openjdk/jextract/clang/libclang/constants$2.java
@@ -40,7 +40,7 @@ final class constants$2 {
         MemoryLayout.structLayout(
             MemoryLayout.sequenceLayout(2, Constants$root.C_POINTER$LAYOUT).withName("ptr_data"),
             Constants$root.C_INT$LAYOUT.withName("int_data"),
-            MemoryLayout.paddingLayout(32)
+            MemoryLayout.paddingLayout(4)
         ),
         Constants$root.C_POINTER$LAYOUT,
         Constants$root.C_POINTER$LAYOUT,
@@ -55,7 +55,7 @@ final class constants$2 {
         MemoryLayout.structLayout(
             MemoryLayout.sequenceLayout(2, Constants$root.C_POINTER$LAYOUT).withName("ptr_data"),
             Constants$root.C_INT$LAYOUT.withName("int_data"),
-            MemoryLayout.paddingLayout(32)
+            MemoryLayout.paddingLayout(4)
         ),
         Constants$root.C_POINTER$LAYOUT,
         Constants$root.C_POINTER$LAYOUT,
@@ -70,7 +70,7 @@ final class constants$2 {
         MemoryLayout.structLayout(
             MemoryLayout.sequenceLayout(2, Constants$root.C_POINTER$LAYOUT).withName("ptr_data"),
             Constants$root.C_INT$LAYOUT.withName("int_data"),
-            MemoryLayout.paddingLayout(32)
+            MemoryLayout.paddingLayout(4)
         ),
         Constants$root.C_POINTER$LAYOUT,
         Constants$root.C_POINTER$LAYOUT,
@@ -84,7 +84,7 @@ final class constants$2 {
     static final FunctionDescriptor clang_getRangeStart$FUNC = FunctionDescriptor.of(MemoryLayout.structLayout(
         MemoryLayout.sequenceLayout(2, Constants$root.C_POINTER$LAYOUT).withName("ptr_data"),
         Constants$root.C_INT$LAYOUT.withName("int_data"),
-        MemoryLayout.paddingLayout(32)
+        MemoryLayout.paddingLayout(4)
     ),
         MemoryLayout.structLayout(
             MemoryLayout.sequenceLayout(2, Constants$root.C_POINTER$LAYOUT).withName("ptr_data"),
@@ -99,7 +99,7 @@ final class constants$2 {
     static final FunctionDescriptor clang_getRangeEnd$FUNC = FunctionDescriptor.of(MemoryLayout.structLayout(
         MemoryLayout.sequenceLayout(2, Constants$root.C_POINTER$LAYOUT).withName("ptr_data"),
         Constants$root.C_INT$LAYOUT.withName("int_data"),
-        MemoryLayout.paddingLayout(32)
+        MemoryLayout.paddingLayout(4)
     ),
         MemoryLayout.structLayout(
             MemoryLayout.sequenceLayout(2, Constants$root.C_POINTER$LAYOUT).withName("ptr_data"),

--- a/src/main/java/org/openjdk/jextract/clang/libclang/constants$3.java
+++ b/src/main/java/org/openjdk/jextract/clang/libclang/constants$3.java
@@ -61,7 +61,7 @@ final class constants$3 {
     static final FunctionDescriptor clang_formatDiagnostic$FUNC = FunctionDescriptor.of(MemoryLayout.structLayout(
         Constants$root.C_POINTER$LAYOUT.withName("data"),
         Constants$root.C_INT$LAYOUT.withName("private_flags"),
-        MemoryLayout.paddingLayout(32)
+        MemoryLayout.paddingLayout(4)
     ),
         Constants$root.C_POINTER$LAYOUT,
         Constants$root.C_INT$LAYOUT

--- a/src/main/java/org/openjdk/jextract/clang/libclang/constants$4.java
+++ b/src/main/java/org/openjdk/jextract/clang/libclang/constants$4.java
@@ -39,7 +39,7 @@ final class constants$4 {
     static final FunctionDescriptor clang_getDiagnosticLocation$FUNC = FunctionDescriptor.of(MemoryLayout.structLayout(
         MemoryLayout.sequenceLayout(2, Constants$root.C_POINTER$LAYOUT).withName("ptr_data"),
         Constants$root.C_INT$LAYOUT.withName("int_data"),
-        MemoryLayout.paddingLayout(32)
+        MemoryLayout.paddingLayout(4)
     ),
         Constants$root.C_POINTER$LAYOUT
     );
@@ -50,7 +50,7 @@ final class constants$4 {
     static final FunctionDescriptor clang_getDiagnosticSpelling$FUNC = FunctionDescriptor.of(MemoryLayout.structLayout(
         Constants$root.C_POINTER$LAYOUT.withName("data"),
         Constants$root.C_INT$LAYOUT.withName("private_flags"),
-        MemoryLayout.paddingLayout(32)
+        MemoryLayout.paddingLayout(4)
     ),
         Constants$root.C_POINTER$LAYOUT
     );

--- a/src/main/java/org/openjdk/jextract/clang/libclang/constants$7.java
+++ b/src/main/java/org/openjdk/jextract/clang/libclang/constants$7.java
@@ -61,7 +61,7 @@ final class constants$7 {
     static final FunctionDescriptor clang_getCursorLocation$FUNC = FunctionDescriptor.of(MemoryLayout.structLayout(
         MemoryLayout.sequenceLayout(2, Constants$root.C_POINTER$LAYOUT).withName("ptr_data"),
         Constants$root.C_INT$LAYOUT.withName("int_data"),
-        MemoryLayout.paddingLayout(32)
+        MemoryLayout.paddingLayout(4)
     ),
         MemoryLayout.structLayout(
             Constants$root.C_INT$LAYOUT.withName("kind"),
@@ -90,7 +90,7 @@ final class constants$7 {
     );
     static final FunctionDescriptor clang_getCursorType$FUNC = FunctionDescriptor.of(MemoryLayout.structLayout(
         Constants$root.C_INT$LAYOUT.withName("kind"),
-        MemoryLayout.paddingLayout(32),
+        MemoryLayout.paddingLayout(4),
         MemoryLayout.sequenceLayout(2, Constants$root.C_POINTER$LAYOUT).withName("data")
     ),
         MemoryLayout.structLayout(
@@ -106,11 +106,11 @@ final class constants$7 {
     static final FunctionDescriptor clang_getTypeSpelling$FUNC = FunctionDescriptor.of(MemoryLayout.structLayout(
         Constants$root.C_POINTER$LAYOUT.withName("data"),
         Constants$root.C_INT$LAYOUT.withName("private_flags"),
-        MemoryLayout.paddingLayout(32)
+        MemoryLayout.paddingLayout(4)
     ),
         MemoryLayout.structLayout(
             Constants$root.C_INT$LAYOUT.withName("kind"),
-            MemoryLayout.paddingLayout(32),
+            MemoryLayout.paddingLayout(4),
             MemoryLayout.sequenceLayout(2, Constants$root.C_POINTER$LAYOUT).withName("data")
         )
     );

--- a/src/main/java/org/openjdk/jextract/clang/libclang/constants$8.java
+++ b/src/main/java/org/openjdk/jextract/clang/libclang/constants$8.java
@@ -38,7 +38,7 @@ final class constants$8 {
     private constants$8() {}
     static final FunctionDescriptor clang_getTypedefDeclUnderlyingType$FUNC = FunctionDescriptor.of(MemoryLayout.structLayout(
         Constants$root.C_INT$LAYOUT.withName("kind"),
-        MemoryLayout.paddingLayout(32),
+        MemoryLayout.paddingLayout(4),
         MemoryLayout.sequenceLayout(2, Constants$root.C_POINTER$LAYOUT).withName("data")
     ),
         MemoryLayout.structLayout(
@@ -53,7 +53,7 @@ final class constants$8 {
     );
     static final FunctionDescriptor clang_getEnumDeclIntegerType$FUNC = FunctionDescriptor.of(MemoryLayout.structLayout(
         Constants$root.C_INT$LAYOUT.withName("kind"),
-        MemoryLayout.paddingLayout(32),
+        MemoryLayout.paddingLayout(4),
         MemoryLayout.sequenceLayout(2, Constants$root.C_POINTER$LAYOUT).withName("data")
     ),
         MemoryLayout.structLayout(

--- a/src/main/java/org/openjdk/jextract/clang/libclang/constants$9.java
+++ b/src/main/java/org/openjdk/jextract/clang/libclang/constants$9.java
@@ -55,12 +55,12 @@ final class constants$9 {
     static final FunctionDescriptor clang_equalTypes$FUNC = FunctionDescriptor.of(Constants$root.C_INT$LAYOUT,
         MemoryLayout.structLayout(
             Constants$root.C_INT$LAYOUT.withName("kind"),
-            MemoryLayout.paddingLayout(32),
+            MemoryLayout.paddingLayout(4),
             MemoryLayout.sequenceLayout(2, Constants$root.C_POINTER$LAYOUT).withName("data")
         ),
         MemoryLayout.structLayout(
             Constants$root.C_INT$LAYOUT.withName("kind"),
-            MemoryLayout.paddingLayout(32),
+            MemoryLayout.paddingLayout(4),
             MemoryLayout.sequenceLayout(2, Constants$root.C_POINTER$LAYOUT).withName("data")
         )
     );
@@ -70,12 +70,12 @@ final class constants$9 {
     );
     static final FunctionDescriptor clang_getCanonicalType$FUNC = FunctionDescriptor.of(MemoryLayout.structLayout(
         Constants$root.C_INT$LAYOUT.withName("kind"),
-        MemoryLayout.paddingLayout(32),
+        MemoryLayout.paddingLayout(4),
         MemoryLayout.sequenceLayout(2, Constants$root.C_POINTER$LAYOUT).withName("data")
     ),
         MemoryLayout.structLayout(
             Constants$root.C_INT$LAYOUT.withName("kind"),
-            MemoryLayout.paddingLayout(32),
+            MemoryLayout.paddingLayout(4),
             MemoryLayout.sequenceLayout(2, Constants$root.C_POINTER$LAYOUT).withName("data")
         )
     );
@@ -86,7 +86,7 @@ final class constants$9 {
     static final FunctionDescriptor clang_isConstQualifiedType$FUNC = FunctionDescriptor.of(Constants$root.C_INT$LAYOUT,
         MemoryLayout.structLayout(
             Constants$root.C_INT$LAYOUT.withName("kind"),
-            MemoryLayout.paddingLayout(32),
+            MemoryLayout.paddingLayout(4),
             MemoryLayout.sequenceLayout(2, Constants$root.C_POINTER$LAYOUT).withName("data")
         )
     );

--- a/src/main/java/org/openjdk/jextract/impl/Constants.java
+++ b/src/main/java/org/openjdk/jextract/impl/Constants.java
@@ -346,9 +346,9 @@ public class Constants {
         private void emitLayoutString(MemoryLayout l) {
             if (l instanceof ValueLayout val) {
                 append(ImmediateConstant.ofPrimitiveLayout(val).accessExpression());
-                if (l.bitAlignment() != l.bitSize()) {
-                    append(".withBitAlignment(");
-                    append(l.bitAlignment());
+                if (l.byteAlignment() != l.byteSize()) {
+                    append(".withByteAlignment(");
+                    append(l.byteAlignment());
                     append(")");
                 }
             } else if (l instanceof SequenceLayout seq) {
@@ -376,7 +376,7 @@ public class Constants {
                 append(")");
             } else {
                 // padding (or unsupported)
-                append("MemoryLayout.paddingLayout(" + l.bitSize() + ")");
+                append("MemoryLayout.paddingLayout(" + l.byteSize() + ")");
             }
             if (l.name().isPresent()) {
                 append(".withName(\"" +  l.name().get() + "\")");

--- a/src/main/java/org/openjdk/jextract/impl/StructLayoutComputer.java
+++ b/src/main/java/org/openjdk/jextract/impl/StructLayoutComputer.java
@@ -156,7 +156,10 @@ final class StructLayoutComputer extends RecordLayoutComputer {
                 addField(offset, bitfield(prevBitfieldDecls.toArray(new Declaration.Variable[0])));
             }
             if (prevBitfieldSize > 0) {
-                fieldLayouts.add(MemoryLayout.paddingLayout(prevBitfieldSize));
+                if (prevBitfieldSize % 8 != 0) {
+                    throw new IllegalStateException("Cannot get here: " + prevBitfieldSize);
+                }
+                fieldLayouts.add(MemoryLayout.paddingLayout(prevBitfieldSize / 8));
             }
         }
     }

--- a/src/main/java/org/openjdk/jextract/impl/TypeImpl.java
+++ b/src/main/java/org/openjdk/jextract/impl/TypeImpl.java
@@ -180,7 +180,7 @@ public abstract class TypeImpl implements Type {
     }
 
     public static final class PointerImpl extends DelegatedBase {
-        public static final AddressLayout POINTER_LAYOUT = ADDRESS.withBitAlignment(64)
+        public static final AddressLayout POINTER_LAYOUT = ADDRESS
                 .withTargetLayout(MemoryLayout.sequenceLayout(ValueLayout.JAVA_BYTE));
 
         private final Supplier<Type> pointeeFactory;

--- a/src/main/java/org/openjdk/jextract/impl/UnsupportedLayouts.java
+++ b/src/main/java/org/openjdk/jextract/impl/UnsupportedLayouts.java
@@ -37,30 +37,30 @@ import java.nio.ByteOrder;
 public final class UnsupportedLayouts {
     private UnsupportedLayouts() {}
 
-    public static final MemoryLayout __INT128 = makeUnsupportedLayout(128, "__int128");
+    public static final MemoryLayout __INT128 = makeUnsupportedLayout(16, "__int128");
 
-    public static final MemoryLayout LONG_DOUBLE = makeUnsupportedLayout(128, "long double");
+    public static final MemoryLayout LONG_DOUBLE = makeUnsupportedLayout(16, "long double");
 
-    public static final MemoryLayout _FLOAT128 = makeUnsupportedLayout(128, "_float128");
+    public static final MemoryLayout _FLOAT128 = makeUnsupportedLayout(16, "_float128");
 
-    public static final MemoryLayout __FP16 = makeUnsupportedLayout(16, "__fp16");
+    public static final MemoryLayout __FP16 = makeUnsupportedLayout(2, "__fp16");
 
-    public static final MemoryLayout CHAR16 = makeUnsupportedLayout(16, "char16");
+    public static final MemoryLayout CHAR16 = makeUnsupportedLayout(2, "char16");
 
-    public static final MemoryLayout WCHAR_T = makeUnsupportedLayout(16, "wchar_t");
+    public static final MemoryLayout WCHAR_T = makeUnsupportedLayout(2, "wchar_t");
 
     static String firstUnsupportedType(Type type) {
         return type.accept(unsupportedVisitor, null);
     }
 
     private static MemoryLayout makeUnsupportedLayout(long size, String name) {
-        return MemoryLayout.paddingLayout(size).withBitAlignment(size).withName(name);
+        return MemoryLayout.paddingLayout(size).withByteAlignment(size).withName(name);
     }
 
     static Type.Visitor<String, Void> unsupportedVisitor = new Type.Visitor<>() {
         @Override
         public String visitPrimitive(Type.Primitive t, Void unused) {
-            MemoryLayout layout = t.kind().layout().orElse(MemoryLayout.paddingLayout(64));
+            MemoryLayout layout = t.kind().layout().orElse(MemoryLayout.paddingLayout(8));
             if (layout.equals(__INT128) || layout.equals(LONG_DOUBLE) || layout.equals(_FLOAT128) || layout.equals(__FP16)) {
                 return layout.name().get();
             } else {

--- a/test/lib/testlib/JextractToolRunner.java
+++ b/test/lib/testlib/JextractToolRunner.java
@@ -56,12 +56,12 @@ public class JextractToolRunner {
 
     public static final ValueLayout.OfBoolean C_BOOL = ValueLayout.JAVA_BOOLEAN;
     public static final ValueLayout.OfByte C_CHAR = ValueLayout.JAVA_BYTE;
-    public static final ValueLayout.OfShort C_SHORT = ValueLayout.JAVA_SHORT.withBitAlignment(16);
-    public static final ValueLayout.OfInt C_INT = ValueLayout.JAVA_INT.withBitAlignment(32);
-    public static final ValueLayout C_LONG = IS_WINDOWS ? ValueLayout.JAVA_INT.withBitAlignment(32) : ValueLayout.JAVA_LONG.withBitAlignment(64);
-    public static final ValueLayout.OfLong C_LONG_LONG = ValueLayout.JAVA_LONG.withBitAlignment(64);
-    public static final ValueLayout.OfFloat C_FLOAT = ValueLayout.JAVA_FLOAT.withBitAlignment(32);
-    public static final ValueLayout.OfDouble C_DOUBLE = ValueLayout.JAVA_DOUBLE.withBitAlignment(64);
+    public static final ValueLayout.OfShort C_SHORT = ValueLayout.JAVA_SHORT;
+    public static final ValueLayout.OfInt C_INT = ValueLayout.JAVA_INT;
+    public static final ValueLayout C_LONG = IS_WINDOWS ? ValueLayout.JAVA_INT : ValueLayout.JAVA_LONG;
+    public static final ValueLayout.OfLong C_LONG_LONG = ValueLayout.JAVA_LONG;
+    public static final ValueLayout.OfFloat C_FLOAT = ValueLayout.JAVA_FLOAT;
+    public static final ValueLayout.OfDouble C_DOUBLE = ValueLayout.JAVA_DOUBLE;
     public static final AddressLayout C_POINTER = ValueLayout.ADDRESS
             .withTargetLayout(MemoryLayout.sequenceLayout(C_CHAR));
 

--- a/test/testng/org/openjdk/jextract/test/api/TestPackedStructs.java
+++ b/test/testng/org/openjdk/jextract/test/api/TestPackedStructs.java
@@ -44,7 +44,7 @@ public class TestPackedStructs extends JextractApiTestBase {
         for (String name : NAMES) {
             Declaration.Scoped scoped = checkStruct(d, name, "first", "second");
             GroupLayout groupLayout = (GroupLayout)scoped.layout().get();
-            assertEquals(groupLayout.memberLayouts().get(1).bitAlignment(), 8);
+            assertEquals(groupLayout.memberLayouts().get(1).byteAlignment(), 1);
         }
     }
 }

--- a/test/testng/org/openjdk/jextract/test/toolprovider/IncompleteArrayTest.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/IncompleteArrayTest.java
@@ -48,7 +48,7 @@ public class IncompleteArrayTest extends JextractToolRunner {
             MemoryLayout actualLayout = findLayout(cls);
             MemoryLayout expectedLayout = MemoryLayout.structLayout(
                 C_INT.withName("size"),
-                MemoryLayout.paddingLayout(32),
+                MemoryLayout.paddingLayout(4),
                 MemoryLayout.sequenceLayout(0, C_POINTER).withName("data")
             ).withName("Foo");
             assertEquals(actualLayout, expectedLayout);


### PR DESCRIPTION
This PR tweaks jextract to work with the API changes in the layout API introduced in https://github.com/openjdk/jdk/pull/14013.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Issue
 * [CODETOOLS-7903475](https://bugs.openjdk.org/browse/CODETOOLS-7903475): Jextract should use new byte-based layout methods


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/120/head:pull/120` \
`$ git checkout pull/120`

Update a local copy of the PR: \
`$ git checkout pull/120` \
`$ git pull https://git.openjdk.org/jextract.git pull/120/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 120`

View PR using the GUI difftool: \
`$ git pr show -t 120`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/120.diff">https://git.openjdk.org/jextract/pull/120.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/120#issuecomment-1561443628)