### PR TITLE
7903481: Jextract doesn't enforce group layout alignment correctly in some cases

### DIFF
--- a/src/main/java/org/openjdk/jextract/clang/Type.java
+++ b/src/main/java/org/openjdk/jextract/clang/Type.java
@@ -164,8 +164,20 @@ public final class Type extends ClangDisposable.Owned {
         return Index_h.clang_Type_getSizeOf(segment);
     }
 
+    private long align0() {
+        return Index_h.clang_Type_getAlignOf(segment);
+    }
+
     public long size() {
         long res = size0();
+        if(TypeLayoutError.isError(res)) {
+            throw new TypeLayoutError(res, String.format("segment: %s", this));
+        }
+        return res;
+    }
+
+    public long align() {
+        long res = align0();
         if(TypeLayoutError.isError(res)) {
             throw new TypeLayoutError(res, String.format("segment: %s", this));
         }

--- a/src/main/java/org/openjdk/jextract/clang/libclang/Index_h.java
+++ b/src/main/java/org/openjdk/jextract/clang/libclang/Index_h.java
@@ -4990,6 +4990,22 @@ public class Index_h  {
             throw new AssertionError("should not reach here", ex$);
         }
     }
+    public static MethodHandle clang_Type_getAlignOf$MH() {
+        return RuntimeHelper.requireNonNull(constants$12.clang_Type_getAlignOf$MH,"clang_Type_getAlignOf");
+    }
+    /**
+     * {@snippet :
+     * long long clang_Type_getAlignOf(CXType T);
+     * }
+     */
+    public static long clang_Type_getAlignOf(MemorySegment T) {
+        var mh$ = clang_Type_getAlignOf$MH();
+        try {
+            return (long)mh$.invokeExact(T);
+        } catch (Throwable ex$) {
+            throw new AssertionError("should not reach here", ex$);
+        }
+    }
     public static MethodHandle clang_Type_getOffsetOf$MH() {
         return RuntimeHelper.requireNonNull(constants$12.clang_Type_getOffsetOf$MH,"clang_Type_getOffsetOf");
     }

--- a/src/main/java/org/openjdk/jextract/clang/libclang/constants$12.java
+++ b/src/main/java/org/openjdk/jextract/clang/libclang/constants$12.java
@@ -84,6 +84,17 @@ final class constants$12 {
         "clang_Type_getSizeOf",
         constants$12.clang_Type_getSizeOf$FUNC
     );
+    static final FunctionDescriptor clang_Type_getAlignOf$FUNC = FunctionDescriptor.of(Constants$root.C_LONG_LONG$LAYOUT,
+            MemoryLayout.structLayout(
+                    Constants$root.C_INT$LAYOUT.withName("kind"),
+                    MemoryLayout.paddingLayout(4),
+                    MemoryLayout.sequenceLayout(2, Constants$root.C_POINTER$LAYOUT).withName("data")
+            )
+    );
+    static final MethodHandle clang_Type_getAlignOf$MH = RuntimeHelper.downcallHandle(
+            "clang_Type_getAlignOf",
+            constants$12.clang_Type_getAlignOf$FUNC
+    );
     static final FunctionDescriptor clang_Type_getOffsetOf$FUNC = FunctionDescriptor.of(Constants$root.C_LONG_LONG$LAYOUT,
         MemoryLayout.structLayout(
             Constants$root.C_INT$LAYOUT.withName("kind"),

--- a/src/main/java/org/openjdk/jextract/impl/StructLayoutComputer.java
+++ b/src/main/java/org/openjdk/jextract/impl/StructLayoutComputer.java
@@ -133,8 +133,8 @@ final class StructLayoutComputer extends RecordLayoutComputer {
          */
         handleBitfields();
 
-        MemoryLayout[] fields = fieldLayouts.toArray(new MemoryLayout[0]);
-        GroupLayout g = MemoryLayout.structLayout(fields);
+        GroupLayout g = MemoryLayout.structLayout(alignFields());
+        checkSize(g);
         if (!cursor.spelling().isEmpty()) {
             g = g.withName(cursor.spelling());
         } else if (anonName != null) {

--- a/src/main/java/org/openjdk/jextract/impl/TypeImpl.java
+++ b/src/main/java/org/openjdk/jextract/impl/TypeImpl.java
@@ -373,7 +373,7 @@ public abstract class TypeImpl implements Type {
     public static Optional<MemoryLayout> getLayout(org.openjdk.jextract.Type t) {
         try {
             return Optional.of(getLayoutInternal(t));
-        } catch (Throwable ex) {
+        } catch (UnsupportedOperationException ex) {
             return Optional.empty();
         }
     }
@@ -389,7 +389,7 @@ public abstract class TypeImpl implements Type {
             } else {
                 return Optional.of(FunctionDescriptor.of(getLayoutInternal(retType), args));
             }
-        } catch (Throwable ex) {
+        } catch (UnsupportedOperationException ex) {
             return Optional.empty();
         }
     }

--- a/src/main/java/org/openjdk/jextract/impl/UnionLayoutComputer.java
+++ b/src/main/java/org/openjdk/jextract/impl/UnionLayoutComputer.java
@@ -91,12 +91,10 @@ final class UnionLayoutComputer extends RecordLayoutComputer {
         if (actualSize < expectedSize) {
             // emit an extra padding of expected size to make sure union layout size is computed correctly
             addPadding(expectedSize);
-        } else if (actualSize > expectedSize) {
-            throw new AssertionError("Invalid union size - expected: " + expectedSize + "; found: " + actualSize);
         }
 
-        MemoryLayout[] fields = fieldLayouts.toArray(new MemoryLayout[0]);
-        GroupLayout g = MemoryLayout.unionLayout(fields);
+        GroupLayout g = MemoryLayout.unionLayout(alignFields());
+        checkSize(g);
         if (!cursor.spelling().isEmpty()) {
             g = g.withName(cursor.spelling());
         } else if (anonName != null) {

--- a/test/testng/org/openjdk/jextract/test/api/TestPackedStructs.java
+++ b/test/testng/org/openjdk/jextract/test/api/TestPackedStructs.java
@@ -34,7 +34,7 @@ import java.lang.foreign.GroupLayout;
 public class TestPackedStructs extends JextractApiTestBase {
 
     static final String[] NAMES = {
-            "S1", "S2", "S3", "S4", "S5", "S6"
+            "S1", "S2", "S3", "S4", "S5", "S6", "S7", "S8"
     };
 
     @Test

--- a/test/testng/org/openjdk/jextract/test/api/packedstructs.h
+++ b/test/testng/org/openjdk/jextract/test/api/packedstructs.h
@@ -56,3 +56,15 @@ struct S6 {
    char first;
    union { int x[2]; int y[2]; } second;
 };
+
+#pragma pack(1)
+struct S7 {
+   long long first;
+   int second;
+};
+
+#pragma pack(1)
+struct S8 {
+   struct S7 first[1];
+   struct S7 second[1];
+};


### PR DESCRIPTION
This patch overhauls the treatment of pragma packs directives.

The current logic tries to detect fields occurring at misaligned offsets, and relaxes alignment constraints for these fields.
However, in cases like this:

```
#pragma pack(push, 1)
struct A {
   long long a;
   int b;
}
```

Each field is correctly aligned. But the struct size (12) is not a multiple of its natural alignment (8). As a result, we run into issues when building a sequence layout out of this struct, because of the eager checks added to the layout API.

This patch fixes support for packed structs "the right way", that is, by asking clang the struct/union alignment, and then making sure that any field is aligned accordingly before the group layout is created.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Issue
 * [CODETOOLS-7903481](https://bugs.openjdk.org/browse/CODETOOLS-7903481): Jextract doesn't enforce group layout alignment correctly in some cases


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/121/head:pull/121` \
`$ git checkout pull/121`

Update a local copy of the PR: \
`$ git checkout pull/121` \
`$ git pull https://git.openjdk.org/jextract.git pull/121/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 121`

View PR using the GUI difftool: \
`$ git pr show -t 121`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/121.diff">https://git.openjdk.org/jextract/pull/121.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/121#issuecomment-1568306011)