### PR TITLE
7903485  Windows.h fails to extract on jextract/panama

### DIFF
--- a/src/main/java/org/openjdk/jextract/Type.java
+++ b/src/main/java/org/openjdk/jextract/Type.java
@@ -137,7 +137,9 @@ public interface Type {
             /**
               * {@code long double} type.
               */
-            LongDouble("long double", UnsupportedLayouts.LONG_DOUBLE),
+            LongDouble("long double", TypeImpl.IS_WINDOWS ?
+                    ValueLayout.JAVA_DOUBLE :
+                    UnsupportedLayouts.LONG_DOUBLE),
             /**
              * {@code float128} type.
              */

--- a/src/main/java/org/openjdk/jextract/clang/Cursor.java
+++ b/src/main/java/org/openjdk/jextract/clang/Cursor.java
@@ -64,6 +64,10 @@ public final class Cursor extends ClangDisposable.Owned {
         return Index_h.clang_Cursor_isAnonymousRecordDecl(segment) != 0;
     }
 
+    public boolean isAnonymous() {
+        return Index_h.clang_Cursor_isAnonymous(segment) != 0;
+    }
+
     public boolean isMacroFunctionLike() {
         return Index_h.clang_Cursor_isMacroFunctionLike(segment) != 0;
     }

--- a/src/main/java/org/openjdk/jextract/impl/OutputFactory.java
+++ b/src/main/java/org/openjdk/jextract/impl/OutputFactory.java
@@ -222,7 +222,7 @@ public class OutputFactory implements Declaration.Visitor<Void, Declaration> {
 
         //generate functional interface
         if (func.varargs() && !func.argumentTypes().isEmpty()) {
-            warn("varargs in callbacks is not supported: " + func);
+            warn("varargs in callbacks is not supported: " + CDeclarationPrinter.declaration(func, javaName));
             return false;
         }
 

--- a/src/main/java/org/openjdk/jextract/impl/OutputFactory.java
+++ b/src/main/java/org/openjdk/jextract/impl/OutputFactory.java
@@ -208,15 +208,15 @@ public class OutputFactory implements Declaration.Visitor<Void, Declaration> {
     }
 
     private boolean generateFunctionalInterface(Type.Function func, String javaName) {
-        FunctionDescriptor descriptor = Type.descriptorFor(func).orElse(null);
-        if (descriptor == null) {
-            return false;
-        }
-
         String unsupportedType = UnsupportedLayouts.firstUnsupportedType(func);
         if (unsupportedType != null) {
             warn("skipping " + javaName + " because of unsupported type usage: " +
                     unsupportedType);
+            return false;
+        }
+
+        FunctionDescriptor descriptor = Type.descriptorFor(func).orElse(null);
+        if (descriptor == null) {
             return false;
         }
 
@@ -233,16 +233,16 @@ public class OutputFactory implements Declaration.Visitor<Void, Declaration> {
 
     @Override
     public Void visitFunction(Declaration.Function funcTree, Declaration parent) {
-        FunctionDescriptor descriptor = Type.descriptorFor(funcTree.type()).orElse(null);
-        if (descriptor == null) {
-            return null;
-        }
-
         //generate static wrapper for function
         String unsupportedType = UnsupportedLayouts.firstUnsupportedType(funcTree.type());
         if (unsupportedType != null) {
             warn("skipping " + funcTree.name() + " because of unsupported type usage: " +
                     unsupportedType);
+            return null;
+        }
+
+        FunctionDescriptor descriptor = Type.descriptorFor(funcTree.type()).orElse(null);
+        if (descriptor == null) {
             return null;
         }
 

--- a/src/main/java/org/openjdk/jextract/impl/RecordLayoutComputer.java
+++ b/src/main/java/org/openjdk/jextract/impl/RecordLayoutComputer.java
@@ -110,7 +110,8 @@ abstract class RecordLayoutComputer {
             }
         });
 
-        Declaration.Scoped declaration = finishRecord(anonName);
+        String declName = recordName();
+        Declaration.Scoped declaration = finishRecord(anonName != null ? anonName : declName, declName);
         if (cursor.isAnonymousStruct()) {
             // record this with a declaration attribute, so we don't have to rely on the cursor again later
             declaration = (Declaration.Scoped)declaration.withAttribute("ANONYMOUS", true);
@@ -120,7 +121,7 @@ abstract class RecordLayoutComputer {
 
     abstract void startBitfield();
     abstract void processField(Cursor c);
-    abstract Declaration.Scoped finishRecord(String anonName);
+    abstract Declaration.Scoped finishRecord(String layoutName, String declName);
 
     void addField(long offset, Declaration declaration) {
         fieldDecls.add(declaration);
@@ -196,6 +197,14 @@ abstract class RecordLayoutComputer {
             throw new AssertionError(
                     String.format("Unexpected size for layout %s. Found %d ; expected %d",
                             layout, layout.byteSize(), cursor.type().size()));
+        }
+    }
+
+    private String recordName() {
+        if (cursor.isAnonymous()) {
+            return "";
+        } else {
+            return cursor.spelling();
         }
     }
 

--- a/src/main/java/org/openjdk/jextract/impl/StructLayoutComputer.java
+++ b/src/main/java/org/openjdk/jextract/impl/StructLayoutComputer.java
@@ -88,6 +88,7 @@ final class StructLayoutComputer extends RecordLayoutComputer {
         long expectedOffset = offsetOf(parent, c);
         if (offset > expectedOffset) {
             // out-of-order field, skip
+            System.err.println("WARNING: ignoring field: " + c.spelling() + " in struct " + type.spelling());
             return;
         }
         if (expectedOffset > offset) {

--- a/src/main/java/org/openjdk/jextract/impl/StructLayoutComputer.java
+++ b/src/main/java/org/openjdk/jextract/impl/StructLayoutComputer.java
@@ -86,6 +86,10 @@ final class StructLayoutComputer extends RecordLayoutComputer {
     void processField(Cursor c) {
         boolean isBitfield = c.isBitField();
         long expectedOffset = offsetOf(parent, c);
+        if (offset > expectedOffset) {
+            // out-of-order field, skip
+            return;
+        }
         if (expectedOffset > offset) {
             addPadding(expectedOffset - offset);
             actualSize += (expectedOffset - offset);
@@ -115,7 +119,7 @@ final class StructLayoutComputer extends RecordLayoutComputer {
     }
 
     @Override
-    Declaration.Scoped finishRecord(String anonName) {
+    Declaration.Scoped finishRecord(String layoutName, String declName) {
         // pad at the end, if any
         long expectedSize = type.size() * 8;
         if (actualSize < expectedSize) {
@@ -135,12 +139,8 @@ final class StructLayoutComputer extends RecordLayoutComputer {
 
         GroupLayout g = MemoryLayout.structLayout(alignFields());
         checkSize(g);
-        if (!cursor.spelling().isEmpty()) {
-            g = g.withName(cursor.spelling());
-        } else if (anonName != null) {
-            g = g.withName(anonName);
-        }
-        Declaration.Scoped declaration = Declaration.struct(TreeMaker.CursorPosition.of(cursor), cursor.spelling(),
+        g = g.withName(layoutName);
+        Declaration.Scoped declaration = Declaration.struct(TreeMaker.CursorPosition.of(cursor), declName,
                 g, fieldDecls.stream().toArray(Declaration[]::new));
         return declaration;
     }

--- a/src/main/java/org/openjdk/jextract/impl/TreeMaker.java
+++ b/src/main/java/org/openjdk/jextract/impl/TreeMaker.java
@@ -231,12 +231,7 @@ class TreeMaker {
             MemoryLayout layout = TypeMaker.valueLayoutForSize(c.type().size() * 8).layout().orElseThrow();
             return Declaration.enum_(CursorPosition.of(c), c.spelling(), layout, decls.toArray(new Declaration[0]));
         } else {
-            //just a declaration
-            //if there's a real definition somewhere else, skip this redundant declaration
-            if (!c.getDefinition().isInvalid()) {
-                return null;
-            }
-            return Declaration.enum_(CursorPosition.of(c), c.spelling(), decls.toArray(new Declaration[0]));
+            return null;
         }
     }
 

--- a/src/main/java/org/openjdk/jextract/impl/TreeMaker.java
+++ b/src/main/java/org/openjdk/jextract/impl/TreeMaker.java
@@ -203,17 +203,18 @@ class TreeMaker {
 
     public Declaration.Scoped createRecord(Cursor c, Declaration.Scoped.Kind scopeKind) {
         Type.Declared t = (Type.Declared)RecordLayoutComputer.compute(typeMaker, 0, c.type(), c.type());
-        List<Declaration> decls = filterNestedDeclarations(t.tree().members());
         if (c.isDefinition()) {
+            Declaration.Scoped scoped = t.tree();
+            List<Declaration> decls = filterNestedDeclarations(scoped.members());
             //just a declaration AND definition, we have a layout
-            return Declaration.scoped(scopeKind, CursorPosition.of(c), c.spelling(),
-                                      t.tree().layout().get(), decls.toArray(new Declaration[0]));
+            return Declaration.scoped(scoped.kind(), scoped.pos(), scoped.name(),
+                                      scoped.layout().get(), decls.toArray(new Declaration[0]));
         } else {
             //if there's a real definition somewhere else, skip this redundant declaration
             if (!c.getDefinition().isInvalid()) {
                 return null;
             }
-            return Declaration.scoped(scopeKind, CursorPosition.of(c), c.spelling(), decls.toArray(new Declaration[0]));
+            return Declaration.scoped(scopeKind, CursorPosition.of(c), c.spelling());
         }
     }
 

--- a/src/main/java/org/openjdk/jextract/impl/TypeImpl.java
+++ b/src/main/java/org/openjdk/jextract/impl/TypeImpl.java
@@ -373,7 +373,7 @@ public abstract class TypeImpl implements Type {
     public static Optional<MemoryLayout> getLayout(org.openjdk.jextract.Type t) {
         try {
             return Optional.of(getLayoutInternal(t));
-        } catch (Throwable ex) {
+        } catch (UnsupportedOperationException ex) {
             return Optional.empty();
         }
     }
@@ -389,7 +389,7 @@ public abstract class TypeImpl implements Type {
             } else {
                 return Optional.of(FunctionDescriptor.of(getLayoutInternal(retType), args));
             }
-        } catch (Throwable ex) {
+        } catch (UnsupportedOperationException ex) {
             return Optional.empty();
         }
     }

--- a/src/main/java/org/openjdk/jextract/impl/TypeImpl.java
+++ b/src/main/java/org/openjdk/jextract/impl/TypeImpl.java
@@ -373,7 +373,7 @@ public abstract class TypeImpl implements Type {
     public static Optional<MemoryLayout> getLayout(org.openjdk.jextract.Type t) {
         try {
             return Optional.of(getLayoutInternal(t));
-        } catch (UnsupportedOperationException ex) {
+        } catch (Throwable ex) {
             return Optional.empty();
         }
     }
@@ -389,7 +389,7 @@ public abstract class TypeImpl implements Type {
             } else {
                 return Optional.of(FunctionDescriptor.of(getLayoutInternal(retType), args));
             }
-        } catch (UnsupportedOperationException ex) {
+        } catch (Throwable ex) {
             return Optional.empty();
         }
     }

--- a/src/main/java/org/openjdk/jextract/impl/UnionLayoutComputer.java
+++ b/src/main/java/org/openjdk/jextract/impl/UnionLayoutComputer.java
@@ -85,7 +85,7 @@ final class UnionLayoutComputer extends RecordLayoutComputer {
     }
 
     @Override
-    Declaration.Scoped finishRecord(String anonName) {
+    Declaration.Scoped finishRecord(String layoutName, String declName) {
         // size mismatch indicates use of bitfields in union
         long expectedSize = type.size() * 8;
         if (actualSize < expectedSize) {
@@ -95,11 +95,7 @@ final class UnionLayoutComputer extends RecordLayoutComputer {
 
         GroupLayout g = MemoryLayout.unionLayout(alignFields());
         checkSize(g);
-        if (!cursor.spelling().isEmpty()) {
-            g = g.withName(cursor.spelling());
-        } else if (anonName != null) {
-            g = g.withName(anonName);
-        }
-        return Declaration.union(TreeMaker.CursorPosition.of(cursor), cursor.spelling(), g, fieldDecls.stream().toArray(Declaration[]::new));
+        g = g.withName(layoutName);
+        return Declaration.union(TreeMaker.CursorPosition.of(cursor), declName, g, fieldDecls.stream().toArray(Declaration[]::new));
     }
 }

--- a/src/main/java/org/openjdk/jextract/impl/UnsupportedLayouts.java
+++ b/src/main/java/org/openjdk/jextract/impl/UnsupportedLayouts.java
@@ -37,9 +37,11 @@ import java.nio.ByteOrder;
 public final class UnsupportedLayouts {
     private UnsupportedLayouts() {}
 
+    private static final boolean IS_WINDOWS = System.getProperty("os.name").startsWith("Windows");
+
     public static final MemoryLayout __INT128 = makeUnsupportedLayout(16, "__int128");
 
-    public static final MemoryLayout LONG_DOUBLE = makeUnsupportedLayout(16, "long double");
+    public static final MemoryLayout LONG_DOUBLE = makeUnsupportedLayout(IS_WINDOWS ? 8 : 16, "long double");
 
     public static final MemoryLayout _FLOAT128 = makeUnsupportedLayout(16, "_float128");
 

--- a/src/main/java/org/openjdk/jextract/impl/UnsupportedLayouts.java
+++ b/src/main/java/org/openjdk/jextract/impl/UnsupportedLayouts.java
@@ -25,7 +25,6 @@
 package org.openjdk.jextract.impl;
 
 import java.lang.foreign.MemoryLayout;
-import java.lang.foreign.ValueLayout;
 import org.openjdk.jextract.Declaration;
 import org.openjdk.jextract.Type;
 
@@ -37,11 +36,9 @@ import java.nio.ByteOrder;
 public final class UnsupportedLayouts {
     private UnsupportedLayouts() {}
 
-    private static final boolean IS_WINDOWS = System.getProperty("os.name").startsWith("Windows");
-
     public static final MemoryLayout __INT128 = makeUnsupportedLayout(16, "__int128");
 
-    public static final MemoryLayout LONG_DOUBLE = makeUnsupportedLayout(IS_WINDOWS ? 8 : 16, "long double");
+    public static final MemoryLayout LONG_DOUBLE = makeUnsupportedLayout(16, "long double");
 
     public static final MemoryLayout _FLOAT128 = makeUnsupportedLayout(16, "_float128");
 

--- a/test/jtreg/generator/test8257892/LibUnsupportedTest.java
+++ b/test/jtreg/generator/test8257892/LibUnsupportedTest.java
@@ -28,6 +28,7 @@ import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemoryLayout.PathElement;
 import java.lang.foreign.MemorySegment;
 import org.testng.annotations.Test;
+import org.testng.SkipException;
 
 import test.jextract.unsupported.unsupported_h;
 import static org.testng.Assert.assertEquals;
@@ -51,6 +52,9 @@ import test.jextract.unsupported.*;
  */
 
 public class LibUnsupportedTest {
+
+    private static final boolean IS_WINDOWS = System.getProperty("os.name").startsWith("Windows");
+
     @Test
     public void testAllocateFoo() {
         try (Arena arena = Arena.ofConfined()) {
@@ -86,6 +90,9 @@ public class LibUnsupportedTest {
 
     @Test
     public void testIgnoredMethods() {
+        if (IS_WINDOWS) {
+            throw new SkipException("long double works on Windows");
+        }
         assertNull(findMethod(unsupported_h.class, "func"));
         assertNull(findMethod(unsupported_h.class, "func2"));
         assertNull(findMethod(unsupported_h.class, "func3"));


### PR DESCRIPTION
This patch fixes a number of issues I discovered while trying to extract Windows.h on a recent jextract:

* the size of `long double` layout is wrong. This means that if a struct with a field of that type is declared, StructLayoutComputer will fail (as it will see a size != expected size reported by clang)
* There are cases where, also for unsupported layouts, we end up creating function descriptors with things containing padding. This is caused by the fact that the check for unsupported layouts in functions is performed *after* the creation of the function descriptor.
* Sometimes libclang reports field cursors in an out-of-order fashion. I have not been able to pinpoint the exact cause, as all my attempts to create a reduced test case failed. When this behavior occurs, jextract ends up generating extra fields and padding. I believe this behavior has always been there, but now brought to the fore by the new eager checks.
* A change in behavior of recent libclang causes `cursor.spelling()` to return non-empty strings (see https://github.com/llvm/llvm-project/issues/58429)
* A quality of life fix, to generate "sensible" warnings when variadic callbacks are found

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Issue
 * [CODETOOLS-7903485](https://bugs.openjdk.org/browse/CODETOOLS-7903485): Windows.h fails to extract on jextract/panama (**Bug** - P2)


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/122/head:pull/122` \
`$ git checkout pull/122`

Update a local copy of the PR: \
`$ git checkout pull/122` \
`$ git pull https://git.openjdk.org/jextract.git pull/122/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 122`

View PR using the GUI difftool: \
`$ git pr show -t 122`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/122.diff">https://git.openjdk.org/jextract/pull/122.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/122#issuecomment-1572321283)