### PR TITLE
Update jextract/panama branch to track JDK 22

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ supports JDK 18. Please checkout the [Gradle compatibility matrix](https://docs.
 
 
 ```sh
-$ sh ./gradlew -Pjdk21_home=<jdk21_home_dir> -Pllvm_home=<libclang_dir> clean verify
+$ sh ./gradlew -Pjdk22_home=<jdk22_home_dir> -Pllvm_home=<libclang_dir> clean verify
 ```
 
 
@@ -52,7 +52,7 @@ Expected a header file
 The repository also contains a comprehensive set of tests, written using the [jtreg](https://openjdk.java.net/jtreg/) test framework, which can be run as follows (again, on Windows, `gradlew.bat` should be used instead):
 
 ```sh
-$ sh ./gradlew -Pjdk21_home=<jdk21_home_dir> -Pllvm_home=<libclang_dir> -Pjtreg_home=<jtreg_home> jtreg
+$ sh ./gradlew -Pjdk22_home=<jdk22_home_dir> -Pllvm_home=<libclang_dir> -Pjtreg_home=<jtreg_home> jtreg
 ```
 
 Note however that running `jtreg` task requires `cmake` to be available on the `PATH`.
@@ -86,8 +86,8 @@ import org.jextract.Point2d;
 
 class TestPoint {
     public static void main(String[] args) {
-        try (var session = MemorySession.openConfined()) {
-           MemorySegment point = MemorySegment.allocateNative(Point2d.$LAYOUT(), session);
+        try (Arena arena = Arena.ofConfined()) {
+           MemorySegment point = arena.allocate(Point2d.$LAYOUT());
            Point2d.x$set(point, 3d);
            Point2d.y$set(point, 4d);
            distance(point);

--- a/build.gradle
+++ b/build.gradle
@@ -40,10 +40,10 @@ repositories {
 }
 
 compileJava {
-    options.release = 21
+    options.release = 22
     options.compilerArgs << "--enable-preview"
     options.fork = true
-    options.forkOptions.executable = "${jdk21_home}/bin/javac"
+    options.forkOptions.executable = "${jdk22_home}/bin/javac"
 }
 
 jar {
@@ -83,7 +83,7 @@ task createJextractJmod(type: Exec) {
         delete(jextract_jmod_file)
     }
 
-    executable = "${jdk21_home}/bin/jmod"
+    executable = "${jdk22_home}/bin/jmod"
     args = [
           "create",
           "--module-version=$jextract_version",
@@ -109,7 +109,7 @@ task createJextractImage(type: Exec) {
         delete(jextract_app_dir)
     }
 
-    executable = "${jdk21_home}/bin/jlink"
+    executable = "${jdk22_home}/bin/jlink"
     args = [
          "--module-path=$jmods_dir",
          "--add-modules=org.openjdk.jextract,jdk.compiler,jdk.zipfs",
@@ -145,9 +145,9 @@ task createRuntimeImageForTest(type: Exec) {
         delete(out_dir)
     }
 
-    executable = "${jdk21_home}/bin/jlink"
+    executable = "${jdk22_home}/bin/jlink"
     args = [
-         "--module-path=$jmods_dir" + File.pathSeparator + "$jdk21_home/jmods",
+         "--module-path=$jmods_dir" + File.pathSeparator + "$jdk22_home/jmods",
          "--add-modules=ALL-MODULE-PATH",
          "--output=$out_dir",
     ]

--- a/src/main/java/org/openjdk/jextract/clang/EvalResult.java
+++ b/src/main/java/org/openjdk/jextract/clang/EvalResult.java
@@ -91,7 +91,7 @@ public class EvalResult implements AutoCloseable {
 
     private String getAsString0() {
         MemorySegment value = Index_h.clang_EvalResult_getAsStr(ptr);
-        return value.getUtf8String(0);
+        return value.getString(0);
     }
 
     public String getAsString() {

--- a/src/main/java/org/openjdk/jextract/clang/Index.java
+++ b/src/main/java/org/openjdk/jextract/clang/Index.java
@@ -71,10 +71,10 @@ public class Index extends ClangDisposable {
     public TranslationUnit parseTU(String file, Consumer<Diagnostic> dh, int options, String... args)
             throws ParsingFailedException {
         try (Arena arena = Arena.ofConfined()) {
-            MemorySegment src = arena.allocateUtf8String(file);
+            MemorySegment src = arena.allocateString(file);
             MemorySegment cargs = args.length == 0 ? null : arena.allocateArray(C_POINTER, args.length);
             for (int i = 0 ; i < args.length ; i++) {
-                cargs.set(C_POINTER, i * C_POINTER.byteSize(), arena.allocateUtf8String(args[i]));
+                cargs.set(C_POINTER, i * C_POINTER.byteSize(), arena.allocateString(args[i]));
             }
             MemorySegment outAddress = arena.allocate(C_POINTER);
             ErrorCode code = ErrorCode.valueOf(Index_h.clang_parseTranslationUnit2(

--- a/src/main/java/org/openjdk/jextract/clang/LibClang.java
+++ b/src/main/java/org/openjdk/jextract/clang/LibClang.java
@@ -47,7 +47,7 @@ public class LibClang {
     private static final SegmentAllocator IMPLICIT_ALLOCATOR = (size, align) -> Arena.ofAuto().allocate(size, align);
 
     private final static MemorySegment disableCrashRecovery =
-            IMPLICIT_ALLOCATOR.allocateUtf8String("LIBCLANG_DISABLE_CRASH_RECOVERY=" + CRASH_RECOVERY);
+            IMPLICIT_ALLOCATOR.allocateString("LIBCLANG_DISABLE_CRASH_RECOVERY=" + CRASH_RECOVERY);
 
     static {
         if (!CRASH_RECOVERY) {
@@ -75,7 +75,7 @@ public class LibClang {
 
     public static String CXStrToString(MemorySegment cxstr) {
         MemorySegment buf = Index_h.clang_getCString(cxstr);
-        String str = buf.getUtf8String(0);
+        String str = buf.getString(0);
         Index_h.clang_disposeString(cxstr);
         return str;
     }

--- a/src/main/java/org/openjdk/jextract/clang/TranslationUnit.java
+++ b/src/main/java/org/openjdk/jextract/clang/TranslationUnit.java
@@ -57,7 +57,7 @@ public class TranslationUnit extends ClangDisposable {
 
     public final void save(Path path) throws TranslationUnitSaveException {
         try (Arena arena = Arena.ofConfined()) {
-            MemorySegment pathStr = arena.allocateUtf8String(path.toAbsolutePath().toString());
+            MemorySegment pathStr = arena.allocateString(path.toAbsolutePath().toString());
             SaveError res = SaveError.valueOf(Index_h.clang_saveTranslationUnit(ptr, pathStr, 0));
             if (res != SaveError.None) {
                 throw new TranslationUnitSaveException(path, res);
@@ -85,8 +85,8 @@ public class TranslationUnit extends ClangDisposable {
                     arena.allocateArray(CXUnsavedFile.$LAYOUT(), inMemoryFiles.length);
             for (int i = 0; i < inMemoryFiles.length; i++) {
                 MemorySegment start = files.asSlice(i * CXUnsavedFile.$LAYOUT().byteSize());
-                start.set(C_POINTER, FILENAME_OFFSET, arena.allocateUtf8String(inMemoryFiles[i].file));
-                start.set(C_POINTER, CONTENTS_OFFSET, arena.allocateUtf8String(inMemoryFiles[i].contents));
+                start.set(C_POINTER, FILENAME_OFFSET, arena.allocateString(inMemoryFiles[i].file));
+                start.set(C_POINTER, CONTENTS_OFFSET, arena.allocateString(inMemoryFiles[i].contents));
                 start.set(C_INT, LENGTH_OFFSET, inMemoryFiles[i].contents.length());
             }
             ErrorCode code;

--- a/src/main/java/org/openjdk/jextract/clang/Type.java
+++ b/src/main/java/org/openjdk/jextract/clang/Type.java
@@ -106,7 +106,7 @@ public final class Type extends ClangDisposable.Owned {
     // Struct/RecordType
     private long getOffsetOf0(String fieldName) {
         try (Arena arena = Arena.ofConfined()) {
-            MemorySegment cfname = arena.allocateUtf8String(fieldName);
+            MemorySegment cfname = arena.allocateString(fieldName);
             return Index_h.clang_Type_getOffsetOf(segment, cfname);
         }
     }

--- a/src/main/java/org/openjdk/jextract/clang/libclang/Constants$root.java
+++ b/src/main/java/org/openjdk/jextract/clang/libclang/Constants$root.java
@@ -45,7 +45,7 @@ final class Constants$root {
     static final OfFloat C_FLOAT$LAYOUT = JAVA_FLOAT;
     static final OfDouble C_DOUBLE$LAYOUT = JAVA_DOUBLE;
     static final AddressLayout C_POINTER$LAYOUT = ADDRESS
-            .withTargetLayout(MemoryLayout.sequenceLayout(C_CHAR$LAYOUT));
+            .withTargetLayout(MemoryLayout.sequenceLayout(Long.MAX_VALUE, C_CHAR$LAYOUT));
 }
 
 

--- a/src/main/java/org/openjdk/jextract/impl/Constants.java
+++ b/src/main/java/org/openjdk/jextract/impl/Constants.java
@@ -65,7 +65,7 @@ public class Constants {
             });
         }
         AddressLayout pointerLayout = ValueLayout.ADDRESS.withTargetLayout(
-                MemoryLayout.sequenceLayout(ValueLayout.JAVA_BYTE));
+                MemoryLayout.sequenceLayout(Long.MAX_VALUE, ValueLayout.JAVA_BYTE));
         cache.put(pointerLayout, ImmediateConstant.ofPrimitiveLayout(pointerLayout));
     }
 
@@ -427,7 +427,7 @@ public class Constants {
             append("MemorySegment ");
             NamedConstant segConstant = new NamedConstant(MemorySegment.class);
             append(segConstant.constantName);
-            append(" = RuntimeHelper.CONSTANT_ALLOCATOR.allocateUtf8String(\"");
+            append(" = RuntimeHelper.CONSTANT_ALLOCATOR.allocateString(\"");
             append(Utils.quote(Objects.toString(value)));
             append("\");\n");
             decrAlign();

--- a/src/main/java/org/openjdk/jextract/impl/TypeImpl.java
+++ b/src/main/java/org/openjdk/jextract/impl/TypeImpl.java
@@ -181,7 +181,7 @@ public abstract class TypeImpl implements Type {
 
     public static final class PointerImpl extends DelegatedBase {
         public static final AddressLayout POINTER_LAYOUT = ADDRESS
-                .withTargetLayout(MemoryLayout.sequenceLayout(ValueLayout.JAVA_BYTE));
+                .withTargetLayout(MemoryLayout.sequenceLayout(Long.MAX_VALUE, ValueLayout.JAVA_BYTE));
 
         private final Supplier<Type> pointeeFactory;
 

--- a/src/main/java/org/openjdk/jextract/impl/Writer.java
+++ b/src/main/java/org/openjdk/jextract/impl/Writer.java
@@ -51,7 +51,7 @@ public final class Writer {
         } else {
             return InMemoryJavaCompiler.compile(sources,
                 "--enable-preview",
-                "--source", "21",
+                "--source", "22",
                 "-d", dest.toAbsolutePath().toString(),
                 "-cp", dest.toAbsolutePath().toString());
         }

--- a/src/main/resources/org/openjdk/jextract/impl/resources/RuntimeHelper.java.template
+++ b/src/main/resources/org/openjdk/jextract/impl/resources/RuntimeHelper.java.template
@@ -24,6 +24,7 @@ import java.lang.foreign.MemoryLayout;
 
 import static java.lang.foreign.Linker.*;
 import static java.lang.foreign.ValueLayout.*;
+import static java.lang.Long.MAX_VALUE;
 
 final class RuntimeHelper {
 
@@ -32,7 +33,7 @@ final class RuntimeHelper {
     private static final MethodHandles.Lookup MH_LOOKUP = MethodHandles.lookup();
     private static final SymbolLookup SYMBOL_LOOKUP;
     private static final SegmentAllocator THROWING_ALLOCATOR = (x, y) -> { throw new AssertionError("should not reach here"); };
-    static final AddressLayout POINTER = ValueLayout.ADDRESS.withTargetLayout(MemoryLayout.sequenceLayout(JAVA_BYTE));
+    static final AddressLayout POINTER = ValueLayout.ADDRESS.withTargetLayout(MemoryLayout.sequenceLayout(MAX_VALUE, JAVA_BYTE));
 
     final static SegmentAllocator CONSTANT_ALLOCATOR =
             (size, align) -> Arena.ofAuto().allocate(size, align);

--- a/test/jtreg/generator/test8244959/Test8244959.java
+++ b/test/jtreg/generator/test8244959/Test8244959.java
@@ -52,9 +52,9 @@ public class Test8244959 {
         try (Arena arena = Arena.ofConfined()) {
             MemorySegment s = arena.allocate(1024);
             my_sprintf(s,
-                    arena.allocateUtf8String("%hhd %c %.2f %.2f %lld %lld %d %hd %d %d %lld %c"), 12,
+                    arena.allocateString("%hhd %c %.2f %.2f %lld %lld %d %hd %d %d %lld %c"), 12,
                     (byte) 1, 'b', -1.25f, 5.5d, -200L, Long.MAX_VALUE, (byte) -2, (short) 2, 3, (short) -4, 5L, 'a');
-            String str = s.getUtf8String(0);
+            String str = s.getString(0);
             assertEquals(str, "1 b -1.25 5.50 -200 " + Long.MAX_VALUE + " -2 2 3 -4 5 a");
         }
     }

--- a/test/jtreg/generator/test8246341/LibTest8246341Test.java
+++ b/test/jtreg/generator/test8246341/LibTest8246341Test.java
@@ -53,10 +53,10 @@ public class LibTest8246341Test {
             var callback = func$callback.allocate((argc, argv) -> {
                 callbackCalled[0] = true;
                 assertEquals(argc, 4);
-                assertEquals(argv.getAtIndex(C_POINTER, 0).getUtf8String(0), "java");
-                assertEquals(argv.getAtIndex(C_POINTER, 1).getUtf8String(0), "python");
-                assertEquals(argv.getAtIndex(C_POINTER, 2).getUtf8String(0), "javascript");
-                assertEquals(argv.getAtIndex(C_POINTER, 3).getUtf8String(0), "c++");
+                assertEquals(argv.getAtIndex(C_POINTER, 0).getString(0), "java");
+                assertEquals(argv.getAtIndex(C_POINTER, 1).getString(0), "python");
+                assertEquals(argv.getAtIndex(C_POINTER, 2).getString(0), "javascript");
+                assertEquals(argv.getAtIndex(C_POINTER, 3).getString(0), "c++");
             }, arena);
             func(callback);
         }
@@ -69,7 +69,7 @@ public class LibTest8246341Test {
             var addr = arena.allocate(C_POINTER);
             addr.set(C_POINTER, 0, MemorySegment.NULL);
             fillin(addr);
-            assertEquals(addr.get(C_POINTER, 0).getUtf8String(0), "hello world");
+            assertEquals(addr.get(C_POINTER, 0).getString(0), "hello world");
         }
     }
 }

--- a/test/jtreg/generator/test8253390/LibTest8253390Test.java
+++ b/test/jtreg/generator/test8253390/LibTest8253390Test.java
@@ -44,7 +44,7 @@ import static test.jextract.test8253390.test8253390_h.*;
 public class LibTest8253390Test {
     @Test
     public void testSquare() {
-        assertEquals(GREETING().getUtf8String(0), "hello\nworld");
-        assertEquals(GREETING2().getUtf8String(0), "hello\tworld");
+        assertEquals(GREETING().getString(0), "hello\nworld");
+        assertEquals(GREETING2().getString(0), "hello\tworld");
     }
 }

--- a/test/lib/JtregJextractSources.java
+++ b/test/lib/JtregJextractSources.java
@@ -72,7 +72,7 @@ public class JtregJextractSources {
             System.err.println("compiling jextracted sources @ " + sourcePath.toAbsolutePath());
             List<String> commands = new ArrayList<>();
             commands.add("-parameters");
-            commands.add("--source=21");
+            commands.add("--source=22");
             commands.add("--enable-preview");
             commands.add("-d");
             commands.add(outputDir.toAbsolutePath().toString());

--- a/test/lib/testlib/JextractToolRunner.java
+++ b/test/lib/testlib/JextractToolRunner.java
@@ -63,7 +63,7 @@ public class JextractToolRunner {
     public static final ValueLayout.OfFloat C_FLOAT = ValueLayout.JAVA_FLOAT;
     public static final ValueLayout.OfDouble C_DOUBLE = ValueLayout.JAVA_DOUBLE;
     public static final AddressLayout C_POINTER = ValueLayout.ADDRESS
-            .withTargetLayout(MemoryLayout.sequenceLayout(C_CHAR));
+            .withTargetLayout(MemoryLayout.sequenceLayout(Long.MAX_VALUE, C_CHAR));
 
     // (private) exit codes from jextract tool. Copied from JextractTool.
     protected static final int SUCCESS       = 0;

--- a/test/testng/org/openjdk/jextract/test/toolprovider/ConstantsTest.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/ConstantsTest.java
@@ -106,7 +106,7 @@ public class ConstantsTest extends JextractToolRunner {
     }
 
     static Consumer<MemorySegment> equalsToJavaStr(String expected) {
-        return actual -> assertEquals(actual.getUtf8String(0), expected);
+        return actual -> assertEquals(actual.getString(0), expected);
     }
 
     static Consumer<MemorySegment> equalsPtrContents(long expected) {

--- a/test/testng/org/openjdk/jextract/test/toolprovider/TestClassGeneration.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/TestClassGeneration.java
@@ -44,7 +44,7 @@ import static org.testng.Assert.assertNotNull;
 
 public class TestClassGeneration extends JextractToolRunner {
 
-    private static final VarHandle VH_bytes = MemoryLayout.sequenceLayout(C_CHAR).varHandle(sequenceElement());
+    private static final VarHandle VH_bytes = C_CHAR.arrayElementVarHandle();
 
     private Path outputDir;
     private TestUtils.Loader loader;


### PR DESCRIPTION
This PR contains some initial changes to enable jextract support for the latest Panama repo (and JDK 22 in general).

It contains the usual updates to source, build and readme files (e.g. to replace jdk21 with jdk22).

On top of that there are some changes to support the latest API changes in the Panama repo such as:
* removal of implicit sequence layout factory
* renaming of XYZUtf8String -> XYZString

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/123/head:pull/123` \
`$ git checkout pull/123`

Update a local copy of the PR: \
`$ git checkout pull/123` \
`$ git pull https://git.openjdk.org/jextract.git pull/123/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 123`

View PR using the GUI difftool: \
`$ git pr show -t 123`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/123.diff">https://git.openjdk.org/jextract/pull/123.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/123#issuecomment-1592731382)