### PR TITLE
Tweak jextract to work with latest API changes

### DIFF
--- a/src/main/java/org/openjdk/jextract/clang/Index.java
+++ b/src/main/java/org/openjdk/jextract/clang/Index.java
@@ -71,10 +71,10 @@ public class Index extends ClangDisposable {
     public TranslationUnit parseTU(String file, Consumer<Diagnostic> dh, int options, String... args)
             throws ParsingFailedException {
         try (Arena arena = Arena.ofConfined()) {
-            MemorySegment src = arena.allocateString(file);
-            MemorySegment cargs = args.length == 0 ? null : arena.allocateArray(C_POINTER, args.length);
+            MemorySegment src = arena.allocateFrom(file);
+            MemorySegment cargs = args.length == 0 ? null : arena.allocate(C_POINTER, args.length);
             for (int i = 0 ; i < args.length ; i++) {
-                cargs.set(C_POINTER, i * C_POINTER.byteSize(), arena.allocateString(args[i]));
+                cargs.set(C_POINTER, i * C_POINTER.byteSize(), arena.allocateFrom(args[i]));
             }
             MemorySegment outAddress = arena.allocate(C_POINTER);
             ErrorCode code = ErrorCode.valueOf(Index_h.clang_parseTranslationUnit2(

--- a/src/main/java/org/openjdk/jextract/clang/LibClang.java
+++ b/src/main/java/org/openjdk/jextract/clang/LibClang.java
@@ -47,7 +47,7 @@ public class LibClang {
     private static final SegmentAllocator IMPLICIT_ALLOCATOR = (size, align) -> Arena.ofAuto().allocate(size, align);
 
     private final static MemorySegment disableCrashRecovery =
-            IMPLICIT_ALLOCATOR.allocateString("LIBCLANG_DISABLE_CRASH_RECOVERY=" + CRASH_RECOVERY);
+            IMPLICIT_ALLOCATOR.allocateFrom("LIBCLANG_DISABLE_CRASH_RECOVERY=" + CRASH_RECOVERY);
 
     static {
         if (!CRASH_RECOVERY) {

--- a/src/main/java/org/openjdk/jextract/clang/TranslationUnit.java
+++ b/src/main/java/org/openjdk/jextract/clang/TranslationUnit.java
@@ -57,7 +57,7 @@ public class TranslationUnit extends ClangDisposable {
 
     public final void save(Path path) throws TranslationUnitSaveException {
         try (Arena arena = Arena.ofConfined()) {
-            MemorySegment pathStr = arena.allocateString(path.toAbsolutePath().toString());
+            MemorySegment pathStr = arena.allocateFrom(path.toAbsolutePath().toString());
             SaveError res = SaveError.valueOf(Index_h.clang_saveTranslationUnit(ptr, pathStr, 0));
             if (res != SaveError.None) {
                 throw new TranslationUnitSaveException(path, res);
@@ -82,11 +82,11 @@ public class TranslationUnit extends ClangDisposable {
         try (Arena arena = Arena.ofConfined()) {
             MemorySegment files = inMemoryFiles.length == 0 ?
                     null :
-                    arena.allocateArray(CXUnsavedFile.$LAYOUT(), inMemoryFiles.length);
+                    arena.allocate(CXUnsavedFile.$LAYOUT(), inMemoryFiles.length);
             for (int i = 0; i < inMemoryFiles.length; i++) {
                 MemorySegment start = files.asSlice(i * CXUnsavedFile.$LAYOUT().byteSize());
-                start.set(C_POINTER, FILENAME_OFFSET, arena.allocateString(inMemoryFiles[i].file));
-                start.set(C_POINTER, CONTENTS_OFFSET, arena.allocateString(inMemoryFiles[i].contents));
+                start.set(C_POINTER, FILENAME_OFFSET, arena.allocateFrom(inMemoryFiles[i].file));
+                start.set(C_POINTER, CONTENTS_OFFSET, arena.allocateFrom(inMemoryFiles[i].contents));
                 start.set(C_INT, LENGTH_OFFSET, inMemoryFiles[i].contents.length());
             }
             ErrorCode code;

--- a/src/main/java/org/openjdk/jextract/clang/Type.java
+++ b/src/main/java/org/openjdk/jextract/clang/Type.java
@@ -106,7 +106,7 @@ public final class Type extends ClangDisposable.Owned {
     // Struct/RecordType
     private long getOffsetOf0(String fieldName) {
         try (Arena arena = Arena.ofConfined()) {
-            MemorySegment cfname = arena.allocateString(fieldName);
+            MemorySegment cfname = arena.allocateFrom(fieldName);
             return Index_h.clang_Type_getOffsetOf(segment, cfname);
         }
     }

--- a/src/main/java/org/openjdk/jextract/clang/libclang/CXString.java
+++ b/src/main/java/org/openjdk/jextract/clang/libclang/CXString.java
@@ -61,7 +61,7 @@ public class CXString {
      * }
      */
     public static MemorySegment data$get(MemorySegment seg) {
-        return (java.lang.foreign.MemorySegment)CXString.data$VH.get(seg);
+        return (java.lang.foreign.MemorySegment)CXString.data$VH.get(seg, 0L);
     }
     /**
      * Setter for field:
@@ -70,7 +70,7 @@ public class CXString {
      * }
      */
     public static void data$set(MemorySegment seg, MemorySegment x) {
-        CXString.data$VH.set(seg, x);
+        CXString.data$VH.set(seg, 0L, x);
     }
     public static MemorySegment data$get(MemorySegment seg, long index) {
         return (java.lang.foreign.MemorySegment)CXString.data$VH.get(seg.asSlice(index*sizeof()));
@@ -89,7 +89,7 @@ public class CXString {
      * }
      */
     public static int private_flags$get(MemorySegment seg) {
-        return (int)CXString.private_flags$VH.get(seg);
+        return (int)CXString.private_flags$VH.get(seg, 0L);
     }
     /**
      * Setter for field:
@@ -98,7 +98,7 @@ public class CXString {
      * }
      */
     public static void private_flags$set(MemorySegment seg, int x) {
-        CXString.private_flags$VH.set(seg, x);
+        CXString.private_flags$VH.set(seg, 0L, x);
     }
     public static int private_flags$get(MemorySegment seg, long index) {
         return (int)CXString.private_flags$VH.get(seg.asSlice(index*sizeof()));

--- a/src/main/java/org/openjdk/jextract/clang/libclang/CXToken.java
+++ b/src/main/java/org/openjdk/jextract/clang/libclang/CXToken.java
@@ -63,7 +63,7 @@ public class CXToken {
      * }
      */
     public static MemorySegment ptr_data$get(MemorySegment seg) {
-        return (java.lang.foreign.MemorySegment)CXToken.ptr_data$VH.get(seg);
+        return (java.lang.foreign.MemorySegment)CXToken.ptr_data$VH.get(seg, 0L);
     }
     /**
      * Setter for field:
@@ -72,7 +72,7 @@ public class CXToken {
      * }
      */
     public static void ptr_data$set(MemorySegment seg, MemorySegment x) {
-        CXToken.ptr_data$VH.set(seg, x);
+        CXToken.ptr_data$VH.set(seg, 0L, x);
     }
     public static MemorySegment ptr_data$get(MemorySegment seg, long index) {
         return (java.lang.foreign.MemorySegment)CXToken.ptr_data$VH.get(seg.asSlice(index*sizeof()));

--- a/src/main/java/org/openjdk/jextract/clang/libclang/CXType.java
+++ b/src/main/java/org/openjdk/jextract/clang/libclang/CXType.java
@@ -61,7 +61,7 @@ public class CXType {
      * }
      */
     public static int kind$get(MemorySegment seg) {
-        return (int)CXType.kind$VH.get(seg);
+        return (int)CXType.kind$VH.get(seg, 0L);
     }
     /**
      * Setter for field:
@@ -70,7 +70,7 @@ public class CXType {
      * }
      */
     public static void kind$set(MemorySegment seg, int x) {
-        CXType.kind$VH.set(seg, x);
+        CXType.kind$VH.set(seg, 0L, x);
     }
     public static int kind$get(MemorySegment seg, long index) {
         return (int)CXType.kind$VH.get(seg.asSlice(index*sizeof()));

--- a/src/main/java/org/openjdk/jextract/clang/libclang/CXUnsavedFile.java
+++ b/src/main/java/org/openjdk/jextract/clang/libclang/CXUnsavedFile.java
@@ -62,7 +62,7 @@ public class CXUnsavedFile {
      * }
      */
     public static MemorySegment Filename$get(MemorySegment seg) {
-        return (java.lang.foreign.MemorySegment)CXUnsavedFile.Filename$VH.get(seg);
+        return (java.lang.foreign.MemorySegment)CXUnsavedFile.Filename$VH.get(seg, 0L);
     }
     /**
      * Setter for field:
@@ -71,7 +71,7 @@ public class CXUnsavedFile {
      * }
      */
     public static void Filename$set(MemorySegment seg, MemorySegment x) {
-        CXUnsavedFile.Filename$VH.set(seg, x);
+        CXUnsavedFile.Filename$VH.set(seg, 0L, x);
     }
     public static MemorySegment Filename$get(MemorySegment seg, long index) {
         return (java.lang.foreign.MemorySegment)CXUnsavedFile.Filename$VH.get(seg.asSlice(index*sizeof()));
@@ -90,7 +90,7 @@ public class CXUnsavedFile {
      * }
      */
     public static MemorySegment Contents$get(MemorySegment seg) {
-        return (java.lang.foreign.MemorySegment)CXUnsavedFile.Contents$VH.get(seg);
+        return (java.lang.foreign.MemorySegment)CXUnsavedFile.Contents$VH.get(seg, 0L);
     }
     /**
      * Setter for field:
@@ -99,7 +99,7 @@ public class CXUnsavedFile {
      * }
      */
     public static void Contents$set(MemorySegment seg, MemorySegment x) {
-        CXUnsavedFile.Contents$VH.set(seg, x);
+        CXUnsavedFile.Contents$VH.set(seg, 0L, x);
     }
     public static MemorySegment Contents$get(MemorySegment seg, long index) {
         return (java.lang.foreign.MemorySegment)CXUnsavedFile.Contents$VH.get(seg.asSlice(index*sizeof()));
@@ -118,7 +118,7 @@ public class CXUnsavedFile {
      * }
      */
     public static long Length$get(MemorySegment seg) {
-        return (long)CXUnsavedFile.Length$VH.get(seg);
+        return (long)CXUnsavedFile.Length$VH.get(seg, 0L);
     }
     /**
      * Setter for field:
@@ -127,7 +127,7 @@ public class CXUnsavedFile {
      * }
      */
     public static void Length$set(MemorySegment seg, long x) {
-        CXUnsavedFile.Length$VH.set(seg, x);
+        CXUnsavedFile.Length$VH.set(seg, 0L, x);
     }
     public static long Length$get(MemorySegment seg, long index) {
         return (long)CXUnsavedFile.Length$VH.get(seg.asSlice(index*sizeof()));

--- a/src/main/java/org/openjdk/jextract/impl/Constants.java
+++ b/src/main/java/org/openjdk/jextract/impl/Constants.java
@@ -427,7 +427,7 @@ public class Constants {
             append("MemorySegment ");
             NamedConstant segConstant = new NamedConstant(MemorySegment.class);
             append(segConstant.constantName);
-            append(" = RuntimeHelper.CONSTANT_ALLOCATOR.allocateString(\"");
+            append(" = RuntimeHelper.CONSTANT_ALLOCATOR.allocateFrom(\"");
             append(Utils.quote(Objects.toString(value)));
             append("\");\n");
             decrAlign();

--- a/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
@@ -263,7 +263,7 @@ abstract class HeaderFileBuilder extends ClassSourceBuilder {
         append(segmentConstant.accessExpression());
         append(", \"");
         append(nativeName);
-        append("\"));\n");
+        append("\"), 0L);\n");
         decrAlign();
         indent();
         append("}\n");
@@ -281,7 +281,7 @@ abstract class HeaderFileBuilder extends ClassSourceBuilder {
         append(segmentConstant.accessExpression());
         append(", \"");
         append(nativeName);
-        append("\"), x);\n");
+        append("\"), 0L, x);\n");
         decrAlign();
         indent();
         append("}\n");

--- a/src/main/java/org/openjdk/jextract/impl/StructBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/StructBuilder.java
@@ -195,7 +195,7 @@ class StructBuilder extends ClassSourceBuilder {
         incrAlign();
         indent();
         append("return (" + type.getName() + ")"
-                + vhConstant.accessExpression() + ".get(" + seg + ");\n");
+                + vhConstant.accessExpression() + ".get(" + seg + ", 0L);\n");
         decrAlign();
         indent();
         append("}\n");
@@ -211,7 +211,7 @@ class StructBuilder extends ClassSourceBuilder {
         append(MEMBER_MODS + " void " + javaName + "$set(" + param + ", " + type.getSimpleName() + " " + x + ") {\n");
         incrAlign();
         indent();
-        append(vhConstant.accessExpression() + ".set(" + seg + ", " + x + ");\n");
+        append(vhConstant.accessExpression() + ".set(" + seg + ", 0L, " + x + ");\n");
         decrAlign();
         indent();
         append("}\n");
@@ -297,10 +297,8 @@ class StructBuilder extends ClassSourceBuilder {
         append("return (" + type.getName() + ")");
         append(vhConstant.accessExpression());
         append(".get(");
-        append(seg);
-        append(".asSlice(");
-        append(index);
-        append("*sizeof()));\n");
+        append(seg + ", ");
+        append(index + " * sizeof());");
         decrAlign();
         indent();
         append("}\n");
@@ -320,10 +318,8 @@ class StructBuilder extends ClassSourceBuilder {
         indent();
         append(vhConstant.accessExpression());
         append(".set(");
-        append(seg);
-        append(".asSlice(");
-        append(index);
-        append("*sizeof()), ");
+        append(seg + ", ");
+        append(index + " * sizeof(), ");
         append(x);
         append(");\n");
         decrAlign();

--- a/test/jtreg/generator/test8244412/LibTest8244412Test.java
+++ b/test/jtreg/generator/test8244412/LibTest8244412Test.java
@@ -52,7 +52,7 @@ public class LibTest8244412Test {
     @Test
     public void test() {
         try (var arena = Arena.ofConfined()) {
-            var addr = arena.allocate(mysize_t, 0L);
+            var addr = arena.allocateFrom(mysize_t, 0L);
             assertEquals(addr.get(C_LONG_LONG, 0), 0L);
             addr.set(C_LONG_LONG, 0, 13455566L);
             assertEquals(addr.get(C_LONG_LONG, 0), 13455566L);

--- a/test/jtreg/generator/test8244959/Test8244959.java
+++ b/test/jtreg/generator/test8244959/Test8244959.java
@@ -52,7 +52,7 @@ public class Test8244959 {
         try (Arena arena = Arena.ofConfined()) {
             MemorySegment s = arena.allocate(1024);
             my_sprintf(s,
-                    arena.allocateString("%hhd %c %.2f %.2f %lld %lld %d %hd %d %d %lld %c"), 12,
+                    arena.allocateFrom("%hhd %c %.2f %.2f %lld %lld %d %hd %d %d %lld %c"), 12,
                     (byte) 1, 'b', -1.25f, 5.5d, -200L, Long.MAX_VALUE, (byte) -2, (short) 2, 3, (short) -4, 5L, 'a');
             String str = s.getString(0);
             assertEquals(str, "1 b -1.25 5.50 -200 " + Long.MAX_VALUE + " -2 2 3 -4 5 a");

--- a/test/jtreg/generator/test8252121/Test8252121.java
+++ b/test/jtreg/generator/test8252121/Test8252121.java
@@ -52,7 +52,7 @@ public class Test8252121 {
     public void test() {
         try (var arena = Arena.ofConfined()) {
             int[] array = { 3, 5, 89, 34, -33 };
-            MemorySegment seg = arena.allocateArray(C_INT, array);
+            MemorySegment seg = arena.allocateFrom(C_INT, array);
             assertEquals(IntStream.of(array).sum(), sum(seg));
             assertEquals(IntStream.of(array).reduce(1, (a,b) -> a*b), mul(seg));
         }

--- a/test/testng/org/openjdk/jextract/test/toolprovider/TestClassGeneration.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/TestClassGeneration.java
@@ -44,7 +44,7 @@ import static org.testng.Assert.assertNotNull;
 
 public class TestClassGeneration extends JextractToolRunner {
 
-    private static final VarHandle VH_bytes = C_CHAR.arrayElementVarHandle();
+    private static final VarHandle VH_bytes = C_CHAR.varHandle();
 
     private Path outputDir;
     private TestUtils.Loader loader;
@@ -171,7 +171,7 @@ public class TestClassGeneration extends JextractToolRunner {
         Method vh_getter = checkMethod(cls, name + "$VH", VarHandle.class);
         VarHandle vh = (VarHandle) vh_getter.invoke(null);
         assertEquals(vh.varType(), expectedType);
-        assertEquals(vh.get(segment), expectedValue);
+        assertEquals(vh.get(segment, 0L), expectedValue);
 
         checkMethod(cls, name + "$get", expectedType);
         checkMethod(cls, name + "$set", void.class, expectedType);


### PR DESCRIPTION
This PR fixes a bunch of issues with jextract that were introduced by the latest changes in the Panama repo:

* All var handles now take an extra offset parameter. This required changes to the libclang generated bindings, as well as changes in the code generated by jextract.
* The name of some allocation factories in SegmentAllocator has changed. This PR fixes jextract to use the right names.
* ValueLayout::arrayElementVarHandle is no longer present

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Reviewers
 * [Athijegannathan Sundararajan](https://openjdk.org/census#sundar) (@sundararajana - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/124/head:pull/124` \
`$ git checkout pull/124`

Update a local copy of the PR: \
`$ git checkout pull/124` \
`$ git pull https://git.openjdk.org/jextract.git pull/124/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 124`

View PR using the GUI difftool: \
`$ git pr show -t 124`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/124.diff">https://git.openjdk.org/jextract/pull/124.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/124#issuecomment-1643842832)