### PR TITLE
7903542: jextract sample compilation scripts can avoid specifying standard include directory in Mac OS

### DIFF
--- a/samples/cblas/compile.sh
+++ b/samples/cblas/compile.sh
@@ -1,4 +1,3 @@
 jextract -D FORCE_OPENBLAS_COMPLEX_STRUCT \
-  -I /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include \
   -l openblas -t blas /usr/local/opt/openblas/include/cblas.h
 

--- a/samples/cblas/compilesource.sh
+++ b/samples/cblas/compilesource.sh
@@ -1,5 +1,4 @@
 jextract --source -D FORCE_OPENBLAS_COMPLEX_STRUCT \
-  -I /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include \
   -l openblas -t blas /usr/local/opt/openblas/include/cblas.h
 
 javac --enable-preview --source=22 blas/*.java

--- a/samples/dlopen/compile.sh
+++ b/samples/dlopen/compile.sh
@@ -1,5 +1,4 @@
 cc --shared -o libhello.dylib hello.c
 
 jextract -t org.unix \
-  -I /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include \
   /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/dlfcn.h

--- a/samples/dlopen/compilesource.sh
+++ b/samples/dlopen/compilesource.sh
@@ -1,7 +1,6 @@
 cc --shared -o libhello.dylib hello.c
 
 jextract --source -t org.unix \
-  -I /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include \
   /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/dlfcn.h
 
 javac --enable-preview --source=22 org/unix/*.java

--- a/samples/lapack/compile.sh
+++ b/samples/lapack/compile.sh
@@ -1,4 +1,3 @@
 jextract \
-   -I /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include \
    -l lapacke -t lapack \
    /usr/local/opt/lapack/include/lapacke.h 

--- a/samples/lapack/compilesource.sh
+++ b/samples/lapack/compilesource.sh
@@ -1,5 +1,4 @@
 jextract --source \
-   -I /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include \
    -l lapacke -t lapack \
    /usr/local/opt/lapack/include/lapacke.h 
 

--- a/samples/libclang/compile.sh
+++ b/samples/libclang/compile.sh
@@ -1,5 +1,4 @@
 jextract -t org.llvm.clang -lclang \
-  -I /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/ \
   -I ${LIBCLANG_HOME}/include/ \
   -I ${LIBCLANG_HOME}/include/clang-c \
   ${LIBCLANG_HOME}/include/clang-c/Index.h

--- a/samples/libclang/compilesource.sh
+++ b/samples/libclang/compilesource.sh
@@ -1,5 +1,4 @@
 jextract --source -t org.llvm.clang -lclang \
-  -I /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/ \
   -I ${LIBCLANG_HOME}/include/ \
   -I ${LIBCLANG_HOME}/include/clang-c \
   ${LIBCLANG_HOME}/include/clang-c/Index.h

--- a/samples/libcurl/compile.sh
+++ b/samples/libcurl/compile.sh
@@ -1,4 +1,2 @@
 jextract -t org.jextract -lcurl \
-  -I /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/ \
-  -I /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/curl/ \
   /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/curl/curl.h

--- a/samples/libcurl/compilesource.sh
+++ b/samples/libcurl/compilesource.sh
@@ -1,6 +1,4 @@
 jextract --source -t org.jextract -lcurl \
-  -I /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/ \
-  -I /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/curl/ \
   /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/curl/curl.h
 
 javac --enable-preview --source=22 org/jextract/*.java

--- a/samples/libffmpeg/compile.sh
+++ b/samples/libffmpeg/compile.sh
@@ -1,5 +1,4 @@
 jextract -t libffmpeg \
-  -I /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include \
   -I /usr/local/Cellar/ffmpeg@4/4.4.4/include \
   -l avcodec \
   -l avformat \

--- a/samples/libffmpeg/compilesource.sh
+++ b/samples/libffmpeg/compilesource.sh
@@ -1,5 +1,4 @@
 jextract --source -t libffmpeg \
-  -I /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include \
   -I /usr/local/Cellar/ffmpeg@4/4.4.4/include \
   -l avcodec \
   -l avformat \

--- a/samples/libjimage/extract.sh
+++ b/samples/libjimage/extract.sh
@@ -1,5 +1,4 @@
 jextract \
-  -I /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include \
   -t org.openjdk \
   --source \
   jimage.h

--- a/samples/libproc/compile.sh
+++ b/samples/libproc/compile.sh
@@ -1,3 +1,2 @@
 jextract -t org.unix \
-  -I /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include \
   /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/libproc.h

--- a/samples/libproc/compilesource.sh
+++ b/samples/libproc/compilesource.sh
@@ -1,5 +1,4 @@
 jextract --source -t org.unix \
-  -I /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include \
   /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/libproc.h
 
 javac --enable-preview --source=22 org/unix/*.java

--- a/samples/lp_solve/compile.sh
+++ b/samples/lp_solve/compile.sh
@@ -3,6 +3,5 @@
  
 jextract \
   -t net.sourceforge.lpsolve \
-  -I /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include \
   -l lpsolve55 \
   /usr/local/Cellar/lp_solve/5.5.2.11/include/lp_lib.h

--- a/samples/lp_solve/compilesource.sh
+++ b/samples/lp_solve/compilesource.sh
@@ -4,7 +4,6 @@
 jextract \
   --source \
   -t net.sourceforge.lpsolve \
-  -I /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include \
   -l lpsolve55 \
   /usr/local/Cellar/lp_solve/5.5.2.11/include/lp_lib.h
 

--- a/samples/python3/compile.sh
+++ b/samples/python3/compile.sh
@@ -1,7 +1,6 @@
 ANACONDA3_HOME=/opt/anaconda3
 
 jextract -l python3.8 \
-  -I /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include \
   -I ${ANACONDA3_HOME}/include/python3.8 \
   -t org.python \
   ${ANACONDA3_HOME}/include/python3.8/Python.h

--- a/samples/python3/compilesource.sh
+++ b/samples/python3/compilesource.sh
@@ -1,7 +1,6 @@
 ANACONDA3_HOME=/opt/anaconda3
 
 jextract --source -l python3.8 \
-  -I /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include \
   -I ${ANACONDA3_HOME}/include/python3.8 \
   -t org.python \
   ${ANACONDA3_HOME}/include/python3.8/Python.h

--- a/samples/readline/compile.sh
+++ b/samples/readline/compile.sh
@@ -1,5 +1,4 @@
 jextract -l readline -t org.unix \
-  -I /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include \
   --header-class-name readline_h \
   --include-function readline \
   --include-function free \

--- a/samples/readline/compilesource.sh
+++ b/samples/readline/compilesource.sh
@@ -1,5 +1,4 @@
 jextract --source -l readline -t org.unix \
-  -I /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include \
   --header-class-name readline_h \
   --include-function readline \
   --include-function free \

--- a/samples/sqlite/compile.sh
+++ b/samples/sqlite/compile.sh
@@ -1,4 +1,3 @@
 jextract \
-  -I /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include \
   /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sqlite3.h \
   -t org.sqlite -lsqlite3 

--- a/samples/sqlite/compilesource.sh
+++ b/samples/sqlite/compilesource.sh
@@ -1,5 +1,4 @@
 jextract --source \
-  -I /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include \
   /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sqlite3.h \
   -t org.sqlite -lsqlite3
 

--- a/samples/tcl/compile.sh
+++ b/samples/tcl/compile.sh
@@ -1,3 +1,2 @@
 jextract -l tcl -t org.tcl \
-  -I /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include \
    /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/tcl.h

--- a/samples/tcl/compilesource.sh
+++ b/samples/tcl/compilesource.sh
@@ -1,5 +1,4 @@
 jextract --source -l tcl -t org.tcl \
-  -I /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include \
    /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/tcl.h
 
 javac --enable-preview --source=22 org/tcl/*.java

--- a/samples/tensorflow/compile.sh
+++ b/samples/tensorflow/compile.sh
@@ -1,5 +1,4 @@
 jextract \
-  -I /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/ \
   -t org.tensorflow \
   -I ${LIBTENSORFLOW_HOME}/include \
   -l ${LIBTENSORFLOW_HOME}/lib/libtensorflow.dylib \

--- a/samples/tensorflow/compilesource.sh
+++ b/samples/tensorflow/compilesource.sh
@@ -1,5 +1,4 @@
 jextract --source \
-  -I /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/ \
   -t org.tensorflow \
   -I ${LIBTENSORFLOW_HOME}/include \
   -l ${LIBTENSORFLOW_HOME}/lib/libtensorflow.dylib \

--- a/samples/time/compile.sh
+++ b/samples/time/compile.sh
@@ -1,3 +1,2 @@
 jextract -t org.unix \
-  -I /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include \
    /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/time.h

--- a/samples/time/compilesource.sh
+++ b/samples/time/compilesource.sh
@@ -1,5 +1,4 @@
 jextract --source -t org.unix \
-  -I /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include \
    /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/time.h
 
 javac --enable-preview --source=22 org/unix/*.java


### PR DESCRIPTION
jextract infers standard include directory automatically.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Issue
 * [CODETOOLS-7903542](https://bugs.openjdk.org/browse/CODETOOLS-7903542): jextract sample compilation scripts can avoid specifying standard include directory in Mac OS (**Bug** - P4)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/127/head:pull/127` \
`$ git checkout pull/127`

Update a local copy of the PR: \
`$ git checkout pull/127` \
`$ git pull https://git.openjdk.org/jextract.git pull/127/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 127`

View PR using the GUI difftool: \
`$ git pr show -t 127`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/127.diff">https://git.openjdk.org/jextract/pull/127.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/127#issuecomment-1697267084)