### PR TITLE
7903547: libffmpeg sample crashes JVM

### DIFF
--- a/samples/libffmpeg/LibffmpegMain.java
+++ b/samples/libffmpeg/LibffmpegMain.java
@@ -32,14 +32,14 @@
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.List;
 import java.lang.foreign.*;
+
 import libffmpeg.AVCodecContext;
 import libffmpeg.AVFormatContext;
 import libffmpeg.AVFrame;
 import libffmpeg.AVPacket;
 import libffmpeg.AVStream;
+
 import static libffmpeg.Libffmpeg.*;
 import static java.lang.foreign.MemorySegment.NULL;
 
@@ -49,36 +49,17 @@ import static java.lang.foreign.MemorySegment.NULL;
  *
  * This sample extracts first five frames of the video stream
  * from a given .mp4 file and stores those as .ppm image files.
-*/
+ */
 public class LibffmpegMain {
     private static int NUM_FRAMES_TO_CAPTURE = 5;
 
-    record Exit(String message, int exitCode) {}
+    record Exit(String message, int exitCode) {
+    }
 
     public static void main(String[] args) {
         var exit = run(args);
         System.err.println(exit.message());
         System.exit(exit.exitCode());
-    }
-
-    private static class ArenaCleanup implements AutoCloseable {
-        private Arena arena = Arena.ofConfined();
-        private final List<Runnable> preCloseActions = new ArrayList<>();
-
-        void addCleanup(Runnable runnable) {
-            preCloseActions.add(runnable);
-        }
-
-        Arena arena() {
-            return arena;
-        }
-
-        @Override
-        public void close() {
-            preCloseActions.forEach(Runnable::run);
-            System.out.println("cleanup done");
-            arena.close();
-        }
     }
 
     private static Exit run(String[] args) {
@@ -88,186 +69,189 @@ public class LibffmpegMain {
 
         av_register_all();
 
+        var ppFormatCtx = NULL;
         var pCodecCtxOrig = NULL;
         var pCodecCtx = NULL;
         var pFrame = NULL;
         var pFrameRGB = NULL;
         var buffer = NULL;
 
-        try (var arenaCleanup = new ArenaCleanup()) {
-            var arena = arenaCleanup.arena();
-            // AVFormatContext *ppFormatCtx;
-            var ppFormatCtx = arena.allocate(C_POINTER);
-            // char* fileName;
-            var fileName = arena.allocateFrom(args[0]);
+        try (var arena = Arena.ofConfined()) {
+            try {
+                // AVFormatContext *ppFormatCtx;
+                ppFormatCtx = arena.allocate(C_POINTER);
 
-            // open video file
-            if (avformat_open_input(ppFormatCtx, fileName, NULL, NULL) != 0) {
-                return new Exit("Cannot open " + args[0], 1);
-            }
-            System.out.println("opened " + args[0]);
-            // AVFormatContext *pFormatCtx;
-            var pFormatCtx = ppFormatCtx.get(C_POINTER, 0);
+                // char* fileName;
+                var fileName = arena.allocateFrom(args[0]);
 
-            // Retrieve stream info
-            if (avformat_find_stream_info(pFormatCtx, NULL) < 0) {
-                return new Exit("Could not find stream information", 1);
-
-            }
-
-            arenaCleanup.addCleanup(() -> {
-                // Close the video file
-                avformat_close_input(ppFormatCtx);
-            });
-
-            // Dump AV format info on stderr
-            av_dump_format(pFormatCtx, 0, fileName, 0);
-
-            // Find the first video stream
-            int videoStream = -1;
-            // AVFrameContext formatCtx;
-            // formatCtx.nb_streams
-            int nb_streams = AVFormatContext.nb_streams$get(pFormatCtx);
-            System.out.println("number of streams: " + nb_streams);
-            // formatCtx.streams
-            var pStreams = AVFormatContext.streams$get(pFormatCtx);
-
-            // AVCodecContext* pVideoCodecCtx;
-            var pVideoCodecCtx = NULL;
-            // AVCodec* pCodec;
-            var pCodec = NULL;
-            for (int i = 0; i < nb_streams; i++) {
-                // AVStream* pStream;
-                var pStream = pStreams.getAtIndex(C_POINTER, i);
-                // AVCodecContext* pCodecCtx;
-                pCodecCtx = AVStream.codec$get(pStream);
-                if (AVCodecContext.codec_type$get(pCodecCtx) == AVMEDIA_TYPE_VIDEO()) {
-                    videoStream = i;
-                    pVideoCodecCtx = pCodecCtx;
-                    // Find the decoder for the video stream
-                    pCodec = avcodec_find_decoder(AVCodecContext.codec_id$get(pCodecCtx));
-                    break;
+                // open video file
+                if (avformat_open_input(ppFormatCtx, fileName, NULL, NULL) != 0) {
+                    return new Exit("Cannot open " + args[0], 1);
                 }
-            }
+                System.out.println("opened " + args[0]);
+                // AVFormatContext *pFormatCtx;
+                var pFormatCtx = ppFormatCtx.get(C_POINTER, 0);
 
-            if (videoStream == -1) {
-                return new Exit("Didn't find a video stream", 1);
-            } else {
-                System.out.println("Found video stream (index: " + videoStream + ")");
-            }
+                // Retrieve stream info
+                if (avformat_find_stream_info(pFormatCtx, NULL) < 0) {
+                    return new Exit("Could not find stream information", 1);
 
-            if (pCodec.equals(NULL)) {
-                return new Exit("Unsupported codec", 1);
-            }
+                }
 
-            // Copy context
-            // AVCodecContext *pCodecCtxOrig;
-            pCodecCtxOrig = pVideoCodecCtx;
-            // AVCodecContext *pCodecCtx;
-            pCodecCtx = avcodec_alloc_context3(pCodec);
-            if (avcodec_copy_context(pCodecCtx, pCodecCtxOrig) != 0) {
-                return new Exit("Cannot copy context", 1);
-            }
+                // Dump AV format info on stderr
+                av_dump_format(pFormatCtx, 0, fileName, 0);
 
-            // Open codec
-            if (avcodec_open2(pCodecCtx, pCodec, NULL) < 0) {
-                return new Exit("Cannot open codec", 1);
-            }
+                // Find the first video stream
+                int videoStream = -1;
+                // AVFrameContext formatCtx;
+                // formatCtx.nb_streams
+                int nb_streams = AVFormatContext.nb_streams$get(pFormatCtx);
+                System.out.println("number of streams: " + nb_streams);
+                // formatCtx.streams
+                var pStreams = AVFormatContext.streams$get(pFormatCtx);
 
-            // Allocate video frame
-            // AVFrame* pFrame;
-            pFrame = av_frame_alloc();
-            // Allocate an AVFrame structure
-            // AVFrame* pFrameRGB;
-            pFrameRGB = av_frame_alloc();
+                // AVCodecContext* pVideoCodecCtx;
+                var pVideoCodecCtx = NULL;
+                // AVCodec* pCodec;
+                var pCodec = NULL;
+                for (int i = 0; i < nb_streams; i++) {
+                    // AVStream* pStream;
+                    var pStream = pStreams.getAtIndex(C_POINTER, i);
+                    // AVCodecContext* pCodecCtx;
+                    pCodecCtx = AVStream.codec$get(pStream);
+                    if (AVCodecContext.codec_type$get(pCodecCtx) == AVMEDIA_TYPE_VIDEO()) {
+                        videoStream = i;
+                        pVideoCodecCtx = pCodecCtx;
+                        // Find the decoder for the video stream
+                        pCodec = avcodec_find_decoder(AVCodecContext.codec_id$get(pCodecCtx));
+                        break;
+                    }
+                }
 
-            // Determine required buffer size and allocate buffer
-            int width = AVCodecContext.width$get(pCodecCtx);
-            int height = AVCodecContext.height$get(pCodecCtx);
-            int numBytes = avpicture_get_size(AV_PIX_FMT_RGB24(), width, height);
-            buffer = av_malloc(numBytes * C_CHAR.byteSize());
+                if (videoStream == -1) {
+                    return new Exit("Didn't find a video stream", 1);
+                } else {
+                    System.out.println("Found video stream (index: " + videoStream + ")");
+                }
+
+                if (pCodec.equals(NULL)) {
+                    return new Exit("Unsupported codec", 1);
+                }
+
+                // Copy context
+                // AVCodecContext *pCodecCtxOrig;
+                pCodecCtxOrig = pVideoCodecCtx;
+                // AVCodecContext *pCodecCtx;
+                pCodecCtx = avcodec_alloc_context3(pCodec);
+                if (avcodec_copy_context(pCodecCtx, pCodecCtxOrig) != 0) {
+                    return new Exit("Cannot copy context", 1);
+                }
+
+                // Open codec
+                if (avcodec_open2(pCodecCtx, pCodec, NULL) < 0) {
+                    return new Exit("Cannot open codec", 1);
+                }
+
+                // Allocate video frame
+                // AVFrame* pFrame;
+                pFrame = av_frame_alloc();
+                // Allocate an AVFrame structure
+                // AVFrame* pFrameRGB;
+                pFrameRGB = av_frame_alloc();
+
+                // Determine required buffer size and allocate buffer
+                int width = AVCodecContext.width$get(pCodecCtx);
+                int height = AVCodecContext.height$get(pCodecCtx);
+                int numBytes = avpicture_get_size(AV_PIX_FMT_RGB24(), width, height);
+                buffer = av_malloc(numBytes * C_CHAR.byteSize());
 
 
-            if (pFrame.equals(NULL)) {
-                return new Exit("Cannot allocate frame", 1);
-            }
-            if (pFrameRGB.equals(NULL)) {
-                return new Exit("Cannot allocate RGB frame", 1);
-            }
-            if (buffer.equals(NULL)) {
-                return new Exit("cannot allocate buffer", 1);
-            }
+                if (pFrame.equals(NULL)) {
+                    return new Exit("Cannot allocate frame", 1);
+                }
+                if (pFrameRGB.equals(NULL)) {
+                    return new Exit("Cannot allocate RGB frame", 1);
+                }
+                if (buffer.equals(NULL)) {
+                    return new Exit("cannot allocate buffer", 1);
+                }
 
-            // Assign appropriate parts of buffer to image planes in pFrameRGB
-            // Note that pFrameRGB is an AVFrame, but AVFrame is a superset
-            // of AVPicture
-            avpicture_fill(pFrameRGB, buffer, AV_PIX_FMT_RGB24(), width, height);
+                // Assign appropriate parts of buffer to image planes in pFrameRGB
+                // Note that pFrameRGB is an AVFrame, but AVFrame is a superset
+                // of AVPicture
+                avpicture_fill(pFrameRGB, buffer, AV_PIX_FMT_RGB24(), width, height);
 
-            // initialize SWS context for software scaling
-            int pix_fmt = AVCodecContext.pix_fmt$get(pCodecCtx);
-            var sws_ctx = sws_getContext(width, height, pix_fmt, width, height,
-                AV_PIX_FMT_RGB24(), SWS_BILINEAR(), NULL, NULL, NULL);
+                // initialize SWS context for software scaling
+                int pix_fmt = AVCodecContext.pix_fmt$get(pCodecCtx);
+                var sws_ctx = sws_getContext(width, height, pix_fmt, width, height,
+                        AV_PIX_FMT_RGB24(), SWS_BILINEAR(), NULL, NULL, NULL);
 
-            int i = 0;
-            // ACPacket packet;
-            var packet = AVPacket.allocate(arena);
-            // int* pFrameFinished;
-            var pFrameFinished = arena.allocate(C_INT);
+                int i = 0;
+                // ACPacket packet;
+                var packet = AVPacket.allocate(arena);
+                // int* pFrameFinished;
+                var pFrameFinished = arena.allocate(C_INT);
 
-            while (av_read_frame(pFormatCtx, packet) >= 0) {
-                // Is this a packet from the video stream?
-                // packet.stream_index == videoStream
-                if (AVPacket.stream_index$get(packet) == videoStream) {
-                    // Decode video frame
-                    avcodec_decode_video2(pCodecCtx, pFrame, pFrameFinished, packet);
+                while (av_read_frame(pFormatCtx, packet) >= 0) {
+                    // Is this a packet from the video stream?
+                    // packet.stream_index == videoStream
+                    if (AVPacket.stream_index$get(packet) == videoStream) {
+                        // Decode video frame
+                        avcodec_decode_video2(pCodecCtx, pFrame, pFrameFinished, packet);
 
-                    int frameFinished = pFrameFinished.get(C_INT, 0);
-                    // Did we get a video frame?
-                    if (frameFinished != 0) {
-                        // Convert the image from its native format to RGB
-                        sws_scale(sws_ctx, AVFrame.data$slice(pFrame),
-                            AVFrame.linesize$slice(pFrame), 0, height,
-                            AVFrame.data$slice(pFrameRGB), AVFrame.linesize$slice(pFrameRGB));
+                        int frameFinished = pFrameFinished.get(C_INT, 0);
+                        // Did we get a video frame?
+                        if (frameFinished != 0) {
+                            // Convert the image from its native format to RGB
+                            sws_scale(sws_ctx, AVFrame.data$slice(pFrame),
+                                    AVFrame.linesize$slice(pFrame), 0, height,
+                                    AVFrame.data$slice(pFrameRGB), AVFrame.linesize$slice(pFrameRGB));
 
-                        // Save the frame to disk
-                        if (++i <= NUM_FRAMES_TO_CAPTURE) {
-                            try {
-                                saveFrame(pFrameRGB, arena, width, height, i);
-                            } catch (Exception exp) {
-                                exp.printStackTrace();
-                                return new Exit("save frame failed for frame " + i, 1);
+                            // Save the frame to disk
+                            if (++i <= NUM_FRAMES_TO_CAPTURE) {
+                                try {
+                                    saveFrame(pFrameRGB, arena, width, height, i);
+                                } catch (Exception exp) {
+                                    exp.printStackTrace();
+                                    return new Exit("save frame failed for frame " + i, 1);
+                                }
                             }
                         }
-                     }
-                 }
+                    }
 
-                 // Free the packet that was allocated by av_read_frame
-                 av_free_packet(packet);
-            }
-        } finally {
-            // clean-up everything
+                    // Free the packet that was allocated by av_read_frame
+                    av_free_packet(packet);
+                }
+            } finally {
+                // clean-up everything
 
-            // Free the RGB image
-            if (!buffer.equals(NULL)) {
-                av_free(buffer);
-            }
+                // Free the RGB image
+                if (!buffer.equals(NULL)) {
+                    av_free(buffer);
+                }
 
-            if (!pFrameRGB.equals(NULL)) {
-                av_free(pFrameRGB);
-            }
+                if (!pFrameRGB.equals(NULL)) {
+                    av_free(pFrameRGB);
+                }
 
-            // Free the YUV frame
-            if (!pFrame.equals(NULL)) {
-                av_free(pFrame);
-            }
+                // Free the YUV frame
+                if (!pFrame.equals(NULL)) {
+                    av_free(pFrame);
+                }
 
-            // Close the codecs
-            if (!pCodecCtx.equals(NULL)) {
-                avcodec_close(pCodecCtx);
-            }
+                // Close the codecs
+                if (!pCodecCtx.equals(NULL)) {
+                    avcodec_close(pCodecCtx);
+                }
 
-            if (!pCodecCtxOrig.equals(NULL)) {
-                avcodec_close(pCodecCtxOrig);
+                if (!pCodecCtxOrig.equals(NULL)) {
+                    avcodec_close(pCodecCtxOrig);
+                }
+
+                if (!ppFormatCtx.equals(NULL)) {
+                    // Close the video file
+                    avformat_close_input(ppFormatCtx);
+                }
             }
         }
 
@@ -275,7 +259,7 @@ public class LibffmpegMain {
     }
 
     private static void saveFrame(MemorySegment frameRGB, Arena arena,
-            int width, int height, int iFrame)
+                                  int width, int height, int iFrame)
             throws IOException {
         var header = String.format("P6\n%d %d\n255\n", width, height);
         var path = Paths.get("frame" + iFrame + ".ppm");
@@ -291,7 +275,7 @@ public class LibffmpegMain {
             for (int y = 0; y < height; y++) {
                 // frameRGB.data[0] + y*frameRGB.linesize[0] is the pointer. And 3*width size of data
                 var pixelArray = pdata.asSlice(y * linesize)
-                                      .reinterpret(3*width, arena, null);
+                        .reinterpret(3 * width, arena, null);
                 // dump the pixel byte buffer to file
                 os.write(pixelArray.toArray(C_CHAR));
             }


### PR DESCRIPTION
try..finally is moved inside another enclosing try-with-resources for the confined Arena object. Repeated runs of sample many times do not crash anymore.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Issue
 * [CODETOOLS-7903547](https://bugs.openjdk.org/browse/CODETOOLS-7903547): libffmpeg sample crashes JVM (**Bug** - P4)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/128/head:pull/128` \
`$ git checkout pull/128`

Update a local copy of the PR: \
`$ git checkout pull/128` \
`$ git pull https://git.openjdk.org/jextract.git pull/128/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 128`

View PR using the GUI difftool: \
`$ git pr show -t 128`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/128.diff">https://git.openjdk.org/jextract/pull/128.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/128#issuecomment-1700705454)