### PR TITLE
fix normalize method in RuntimeHelper.java.template

### DIFF
--- a/src/main/resources/org/openjdk/jextract/impl/resources/RuntimeHelper.java.template
+++ b/src/main/resources/org/openjdk/jextract/impl/resources/RuntimeHelper.java.template
@@ -224,7 +224,7 @@ final class RuntimeHelper {
             if (c.isPrimitive()) {
                 return promote(c);
             }
-            if (c == MemorySegment.class) {
+            if (MemorySegment.class.isAssignableFrom(c)) {
                 return MemorySegment.class;
             }
             throw new IllegalArgumentException("Invalid type for ABI: " + c.getTypeName());


### PR DESCRIPTION
This was failing for non-primitive types. Here's an example that demonstrates the behavior.

`jextract --source -t org.unix -I /usr/include /usr/include/stdio.h`

```
import java.lang.foreign.Arena;
import java.lang.foreign.MemorySegment;

import static org.unix.stdio_h.*;

public class Testing {
    public static void main(String[] args) {
        Arena arena = Arena.ofConfined();
        MemorySegment hello = arena.allocateUtf8String("Hello %s\n");
        MemorySegment world = arena.allocateUtf8String("World");
        printf(hello, world);
        fflush(NULL());
    }
}
```
Exception in thread "main" java.lang.AssertionError: should not reach here
	at org.unix.stdio_h.printf(stdio_h.java:1520)
	at org.jt70.panama_article.Testing.main(Testing.java:13)
Caused by: java.lang.IllegalArgumentException: Invalid type for ABI: jdk.internal.foreign.NativeMemorySegmentImpl
	at org.unix.RuntimeHelper$VarargsInvoker.normalize(RuntimeHelper.java:231)
	at org.unix.RuntimeHelper$VarargsInvoker.invoke(RuntimeHelper.java:166)
	at org.unix.stdio_h.printf(stdio_h.java:1518)
	... 1 more

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/131/head:pull/131` \
`$ git checkout pull/131`

Update a local copy of the PR: \
`$ git checkout pull/131` \
`$ git pull https://git.openjdk.org/jextract.git pull/131/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 131`

View PR using the GUI difftool: \
`$ git pr show -t 131`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/131.diff">https://git.openjdk.org/jextract/pull/131.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/131#issuecomment-1793247550)