### PR TITLE
7903573: Jextract does not support atomic types

### DIFF
--- a/src/main/java/org/openjdk/jextract/clang/Type.java
+++ b/src/main/java/org/openjdk/jextract/clang/Type.java
@@ -98,6 +98,10 @@ public final class Type extends ClangDisposable.Owned {
         var elementType = Index_h.clang_getElementType(owner, segment);
         return new Type(elementType, owner);
     }
+    public Type getValueType() {
+        var valueType = Index_h.clang_getValueType(owner, segment);
+        return new Type(valueType, owner);
+    }
 
     public long getNumberOfElements() {
         return Index_h.clang_getNumElements(segment);

--- a/src/main/java/org/openjdk/jextract/clang/libclang/Index_h.java
+++ b/src/main/java/org/openjdk/jextract/clang/libclang/Index_h.java
@@ -4833,6 +4833,7 @@ public class Index_h  {
     public static MethodHandle clang_getElementType$MH() {
         return RuntimeHelper.requireNonNull(constants$11.clang_getElementType$MH,"clang_getElementType");
     }
+
     /**
      * {@snippet :
      * CXType clang_getElementType(CXType T);
@@ -4840,6 +4841,24 @@ public class Index_h  {
      */
     public static MemorySegment clang_getElementType(SegmentAllocator allocator, MemorySegment T) {
         var mh$ = clang_getElementType$MH();
+        try {
+            return (java.lang.foreign.MemorySegment)mh$.invokeExact(allocator, T);
+        } catch (Throwable ex$) {
+            throw new AssertionError("should not reach here", ex$);
+        }
+    }
+
+    public static MethodHandle clang_getValueType$MH() {
+        return RuntimeHelper.requireNonNull(constants$11.clang_getValueType$MH,"clang_Type_getValueType");
+    }
+
+    /**
+     * {@snippet :
+     * CXType clang_getValueType(CXType T);
+     * }
+     */
+    public static MemorySegment clang_getValueType(SegmentAllocator allocator, MemorySegment T) {
+        var mh$ = clang_getValueType$MH();
         try {
             return (java.lang.foreign.MemorySegment)mh$.invokeExact(allocator, T);
         } catch (Throwable ex$) {

--- a/src/main/java/org/openjdk/jextract/clang/libclang/constants$11.java
+++ b/src/main/java/org/openjdk/jextract/clang/libclang/constants$11.java
@@ -119,6 +119,11 @@ final class constants$11 {
         "clang_getElementType",
         constants$11.clang_getElementType$FUNC
     );
+
+    static final MethodHandle clang_getValueType$MH = RuntimeHelper.downcallHandle(
+            "clang_Type_getValueType",
+            constants$11.clang_getElementType$FUNC
+    );
 }
 
 

--- a/src/main/java/org/openjdk/jextract/impl/TypeMaker.java
+++ b/src/main/java/org/openjdk/jextract/impl/TypeMaker.java
@@ -229,6 +229,10 @@ class TypeMaker {
                 Type iType = Type.primitive(Primitive.Kind.Int128);
                 return Type.qualified(Delegated.Kind.UNSIGNED, iType);
             }
+            case Atomic: {
+                Type aType = makeType(t.getValueType());
+                return Type.qualified(Delegated.Kind.ATOMIC, aType);
+            }
             default:
                 return TypeImpl.ERROR;
         }

--- a/test/testng/org/openjdk/jextract/test/api/TestAtomic.java
+++ b/test/testng/org/openjdk/jextract/test/api/TestAtomic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/testng/org/openjdk/jextract/test/api/TestAtomic.java
+++ b/test/testng/org/openjdk/jextract/test/api/TestAtomic.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.jextract.test.api;
+
+import org.openjdk.jextract.Declaration;
+import org.openjdk.jextract.Type;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import testlib.JextractApiTestBase;
+
+import static org.testng.Assert.*;
+import static org.openjdk.jextract.Type.Primitive.Kind.*;
+import static org.openjdk.jextract.Type.Delegated.Kind.*;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.EnumSet;
+
+public class TestAtomic extends JextractApiTestBase {
+    Declaration.Scoped atomic;
+
+    @BeforeClass
+    public void parse() {
+        // We need stdatomic.h
+        Path builtinInc = Paths.get(System.getProperty("java.home"), "conf", "jextract");
+        atomic = parse("atomic.h", "-I", builtinInc.toString());
+    }
+
+    @Test(dataProvider = "atomicTypes")
+    public void testAtomic(String varName, Type expected) {
+        Declaration.Variable var = findDecl(atomic, varName, Declaration.Variable.class);
+        var kinds = EnumSet.of(ATOMIC);
+        if (varName.startsWith("U_")) {
+            kinds.add(UNSIGNED);
+        }
+        if (varName.startsWith("S_")) {
+            kinds.add(SIGNED);
+        }
+        checkType(var.type(), kinds, expected);
+    }
+
+    @DataProvider
+    static Object[][] atomicTypes() {
+        return new Object[][]{
+                new Object[] { "BOOL", Type.primitive(Bool) },
+                new Object[] { "CHAR", Type.primitive(Char) },
+                new Object[] { "S_CHAR", Type.primitive(Char) },
+                new Object[] { "U_CHAR", Type.primitive(Char) },
+                new Object[] { "SHORT", Type.primitive(Short) },
+                new Object[] { "U_SHORT", Type.primitive(Short) },
+                new Object[] { "INT", Type.primitive(Int) },
+                new Object[] { "U_INT", Type.primitive(Int) },
+                new Object[] { "LONG", Type.primitive(Long) },
+                new Object[] { "U_LONG", Type.primitive(Long) },
+                new Object[] { "LONGLONG", Type.primitive(LongLong) },
+                new Object[] { "U_LONGLONG", Type.primitive(LongLong) },
+        };
+    }
+
+    static void checkType(Type t, EnumSet<Type.Delegated.Kind> kinds, Type expected) {
+        while (t instanceof Type.Delegated delegated) {
+            kinds.remove(delegated.kind());
+            t = delegated.type();
+        }
+        assertTrue(kinds.isEmpty(), "Missing kinds: " + kinds);
+        assertEquals(t, expected);
+    }
+}

--- a/test/testng/org/openjdk/jextract/test/api/atomic.h
+++ b/test/testng/org/openjdk/jextract/test/api/atomic.h
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
 #include <stdatomic.h>
 
 atomic_bool	BOOL;

--- a/test/testng/org/openjdk/jextract/test/api/atomic.h
+++ b/test/testng/org/openjdk/jextract/test/api/atomic.h
@@ -1,0 +1,14 @@
+#include <stdatomic.h>
+
+atomic_bool	BOOL;
+atomic_char	CHAR;
+atomic_schar S_CHAR;
+atomic_uchar U_CHAR;
+atomic_short SHORT;
+atomic_ushort U_SHORT;
+atomic_int INT;
+atomic_uint	U_INT;
+atomic_long	LONG;
+atomic_ulong U_LONG;
+atomic_llong LONGLONG;
+atomic_ullong U_LONGLONG;

--- a/test/testng/org/openjdk/jextract/test/api/atomic.h
+++ b/test/testng/org/openjdk/jextract/test/api/atomic.h
@@ -23,15 +23,15 @@
 
 #include <stdatomic.h>
 
-atomic_bool	BOOL;
-atomic_char	CHAR;
+atomic_bool BOOL;
+atomic_char CHAR;
 atomic_schar S_CHAR;
 atomic_uchar U_CHAR;
 atomic_short SHORT;
 atomic_ushort U_SHORT;
 atomic_int INT;
-atomic_uint	U_INT;
-atomic_long	LONG;
+atomic_uint U_INT;
+atomic_long LONG;
 atomic_ulong U_LONG;
 atomic_llong LONGLONG;
 atomic_ullong U_LONGLONG;


### PR DESCRIPTION
This PR fixes a crash when jextract processes atomic types. These types are exposed in libclang in a weird way: their kind is set to `Atomic` but they do not reveal what the underlying type is (except for the type spelling). The underlying type has to be discovered using the `clang_Type_getValueType` function on the `Atomic` type.

This PR does just that, and also adds a test for various atomic types.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Issue
 * [CODETOOLS-7903573](https://bugs.openjdk.org/browse/CODETOOLS-7903573): Jextract does not support atomic types (**Bug** - P3)


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/132/head:pull/132` \
`$ git checkout pull/132`

Update a local copy of the PR: \
`$ git checkout pull/132` \
`$ git pull https://git.openjdk.org/jextract.git pull/132/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 132`

View PR using the GUI difftool: \
`$ git pr show -t 132`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/132.diff">https://git.openjdk.org/jextract/pull/132.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/132#issuecomment-1773118722)