### PR TITLE
(jdk22 port) 7903435: TestDocComments fails on Windows

### DIFF
--- a/test/lib/testlib/JextractToolRunner.java
+++ b/test/lib/testlib/JextractToolRunner.java
@@ -112,7 +112,7 @@ public class JextractToolRunner {
         }
 
         public JextractResult checkSuccess() {
-            assertEquals(exitCode, SUCCESS, "Sucess expected, failed: " + exitCode);
+            assertEquals(exitCode, SUCCESS, "Sucess expected, failed: " + exitCode + ", Output: " + output);
             return this;
         }
 

--- a/test/testng/org/openjdk/jextract/test/toolprovider/Test7903257/TestDocComments.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/Test7903257/TestDocComments.java
@@ -67,7 +67,7 @@ public class TestDocComments extends JextractToolRunner {
     public void testTypedefs() throws IOException {
         var comments = getDocComments("typedefs.h", "typedefs_h.java");
         assertEquals(comments, List.of(
-            "typedef unsigned long size_t;",
+            "typedef unsigned long long size_t;",
             "typedef int INT_32;",
             "typedef int* INT_PTR;",
             "typedef struct Foo* OPAQUE_PTR;"));

--- a/test/testng/org/openjdk/jextract/test/toolprovider/Test7903257/typedefs.h
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/Test7903257/typedefs.h
@@ -21,7 +21,7 @@
  * questions.
  */
 
-typedef unsigned long size_t;
+typedef unsigned long long size_t;
 typedef int INT_32;
 typedef int* INT_PTR;
 typedef struct Foo* OPAQUE_PTR;


### PR DESCRIPTION
Port of https://github.com/openjdk/jextract/pull/106 for jdk 22 branch

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/133/head:pull/133` \
`$ git checkout pull/133`

Update a local copy of the PR: \
`$ git checkout pull/133` \
`$ git pull https://git.openjdk.org/jextract.git pull/133/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 133`

View PR using the GUI difftool: \
`$ git pr show -t 133`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/133.diff">https://git.openjdk.org/jextract/pull/133.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/133#issuecomment-1773068397)