### PR TITLE
Update GHA for jdk22

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,10 +21,10 @@ jobs:
         include:
           - os: ubuntu-20.04
             TARGET: linux-gnu-ubuntu-20.04
-            JAVA19_HOME: /tmp/deps/jdk-19
+            JAVA22_HOME: /tmp/deps/jdk-22
           - os: macos-latest
             TARGET: apple-darwin
-            JAVA19_HOME: /tmp/deps/jdk-19/jdk-19.jdk/Contents/Home
+            JAVA22_HOME: /tmp/deps/jdk-22/jdk-22.jdk/Contents/Home
 
     steps:
     - name: 'Check out repository'
@@ -38,30 +38,30 @@ jobs:
         mkdir -p deps/jtreg
         mkdir -p /tmp/deps
 
-    - name: 'Download JDK 19'
-      id: download_jdk_19
+    - name: 'Download JDK 22'
+      id: download_jdk_22
       uses: oracle-actions/setup-java@v1.1.1
       with:
         website: jdk.java.net
-        release: 19
+        release: 22
         install: false
         
-    - name: 'Extract JDK 19'
+    - name: 'Extract JDK 22'
       shell: sh
       run: |
-        mkdir -p /tmp/deps/jdk-19
-        tar --strip-components=1 -xvf ${{ steps.download_jdk_19.outputs.archive }} -C /tmp/deps/jdk-19
-        ls -lah /tmp/deps/jdk-19
+        mkdir -p /tmp/deps/jdk-22
+        tar --strip-components=1 -xvf ${{ steps.download_jdk_22.outputs.archive }} -C /tmp/deps/jdk-22
+        ls -lah /tmp/deps/jdk-22
 
-    - name: 'Check Java 19 version'
+    - name: 'Check Java 22 version'
       shell: sh
       run: |
         ${{ matrix.JAVA19_HOME }}/bin/java --version
 
-    - name: 'Setup Java 18'
+    - name: 'Setup Java 17'
       uses: oracle-actions/setup-java@v1.1.1
       with:
-        release: 18
+        release: 17
 
     - name: 'Check default Java version'
       shell: sh
@@ -80,7 +80,7 @@ jobs:
     - name: 'Build Jextract'
       shell: sh
       run: |
-        sh ./gradlew -Pjdk19_home=${{ matrix.JAVA19_HOME }} -Pllvm_home=/tmp/deps/clang_llvm clean verify        
+        sh ./gradlew -Pjdk22_home=${{ matrix.JAVA22_HOME }} -Pllvm_home=/tmp/deps/clang_llvm clean verify        
 
     - name: 'Check out JTReg'
       uses: actions/checkout@v2
@@ -100,4 +100,4 @@ jobs:
     - name: 'Run tests'
       shell: sh
       run: |
-        sh ./gradlew -Pjdk19_home=${{ matrix.JAVA19_HOME }} -Pllvm_home=/tmp/deps/clang_llvm -Pjtreg_home=./deps/jtreg/build/images/jtreg jtreg
+        sh ./gradlew -Pjdk22_home=${{ matrix.JAVA22_HOME }} -Pllvm_home=/tmp/deps/clang_llvm -Pjtreg_home=./deps/jtreg/build/images/jtreg jtreg

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
 
     - name: 'Download JDK 22'
       id: download_jdk_22
-      uses: oracle-actions/setup-java@v1.1.1
+      uses: oracle-actions/setup-java@v1.3.2
       with:
         website: jdk.java.net
         release: 22
@@ -56,7 +56,7 @@ jobs:
     - name: 'Check Java 22 version'
       shell: sh
       run: |
-        ${{ matrix.JAVA19_HOME }}/bin/java --version
+        ${{ matrix.JAVA22_HOME }}/bin/java --version
 
     - name: 'Setup Java 17'
       uses: oracle-actions/setup-java@v1.1.1


### PR DESCRIPTION
Update GHA to run on jdk 22. Also switched the gradle runner JDK to 17, since that is LTS with Oracle (which is where we get it from).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/134/head:pull/134` \
`$ git checkout pull/134`

Update a local copy of the PR: \
`$ git checkout pull/134` \
`$ git pull https://git.openjdk.org/jextract.git pull/134/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 134`

View PR using the GUI difftool: \
`$ git pr show -t 134`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/134.diff">https://git.openjdk.org/jextract/pull/134.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/134#issuecomment-1773182652)