### PR TITLE
7903574: jextract should add lang=c to snippets containing C sources

### DIFF
--- a/src/main/java/org/openjdk/jextract/impl/ClassSourceBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/ClassSourceBuilder.java
@@ -213,7 +213,7 @@ abstract class ClassSourceBuilder extends JavaSourceBuilder {
             append("\n");
         }
         indent();
-        append(" * {@snippet :\n");
+        append(" * {@snippet lang=c :\n");
         append(CDeclarationPrinter.declaration(decl, " ".repeat(align*4) + " * "));
         indent();
         append(" * }\n");
@@ -225,7 +225,7 @@ abstract class ClassSourceBuilder extends JavaSourceBuilder {
         indent();
         append("/**\n");
         indent();
-        append(" * {@snippet :\n");
+        append(" * {@snippet lang=c :\n");
         append(" * ");
         append(CDeclarationPrinter.declaration(funcType, name));
         append(";\n");


### PR DESCRIPTION
add the tag when snippet is generated.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Issue
 * [CODETOOLS-7903574](https://bugs.openjdk.org/browse/CODETOOLS-7903574): jextract should add lang=c to snippets containing C sources (**Bug** - P4)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/137/head:pull/137` \
`$ git checkout pull/137`

Update a local copy of the PR: \
`$ git checkout pull/137` \
`$ git pull https://git.openjdk.org/jextract.git pull/137/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 137`

View PR using the GUI difftool: \
`$ git pr show -t 137`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/137.diff">https://git.openjdk.org/jextract/pull/137.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/137#issuecomment-1774083481)