### PR TITLE
Integrating java.logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 .gradle
 **/build/
 .idea
+/.classpath
+/.project
+/.settings
+/bin/

--- a/src/main/java/org/openjdk/jextract/LoggerNameFilter.java
+++ b/src/main/java/org/openjdk/jextract/LoggerNameFilter.java
@@ -1,0 +1,19 @@
+package org.openjdk.jextract;
+
+import java.util.logging.Filter;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+
+/**
+ * Filters out logs which does not belong to jextract package
+ */
+public class LoggerNameFilter implements Filter {
+
+    @Override
+    public boolean isLoggable(LogRecord record) {
+        if (record.getLevel().intValue() >= Level.WARNING.intValue()) return true;
+        var name = record.getSourceClassName();
+        if (name == null) return false;
+        return name.startsWith(LoggerNameFilter.class.getPackageName());
+    }
+}

--- a/src/main/java/org/openjdk/jextract/impl/ClangUtils.java
+++ b/src/main/java/org/openjdk/jextract/impl/ClangUtils.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ *  Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  *  This code is free software; you can redistribute it and/or modify it
@@ -24,11 +24,30 @@
  *
  */
 
-module org.openjdk.jextract {
-    requires transitive java.compiler;
-    requires java.logging;
-    exports org.openjdk.jextract;
+package org.openjdk.jextract.impl;
 
-    provides java.util.spi.ToolProvider with
-        org.openjdk.jextract.JextractTool.JextractToolProvider;
+import java.util.Objects;
+import java.util.Optional;
+import org.openjdk.jextract.clang.Cursor;
+import org.openjdk.jextract.clang.SourceLocation;
+import org.openjdk.jextract.clang.Type;
+
+/**
+ * General utility functions for Clang
+ */
+class ClangUtils {
+
+    public static String toString(Cursor c) {
+        var str = String.format("name [%s], kind [%s]", c.displayName(), c.kind());
+        if (!Objects.equals(c.displayName(), c.spelling()))
+            str += ", spelling [" + c.spelling() + "]";
+        str += Optional.ofNullable(c.getSourceLocation()).map(SourceLocation::getFileLocation).map(loc -> {
+            return String.format(", file location %s(%s)", loc.path(), loc.line());
+        }).orElse("");
+        return "clang cursor[" + str + "]";
+    }
+
+    public static String toString(Type t) {
+        return String.format("clang type[type [%s], kind [%s], canonical type [%s]]", t.spelling(), t.kind(), t.canonicalType().spelling());
+    }
 }

--- a/src/main/java/org/openjdk/jextract/impl/MacroParserImpl.java
+++ b/src/main/java/org/openjdk/jextract/impl/MacroParserImpl.java
@@ -29,7 +29,6 @@ package org.openjdk.jextract.impl;
 import org.openjdk.jextract.Declaration;
 import org.openjdk.jextract.Position;
 import org.openjdk.jextract.Type;
-import org.openjdk.jextract.JextractTool;
 import org.openjdk.jextract.clang.Cursor;
 import org.openjdk.jextract.clang.CursorKind;
 import org.openjdk.jextract.clang.Diagnostic;
@@ -46,11 +45,13 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 class MacroParserImpl implements AutoCloseable {
-
+    private static final Logger LOGGER = Logger.getLogger(MacroParserImpl.class.getSimpleName());
     private final ClangReparser reparser;
     private final TreeMaker treeMaker;
     final MacroTable macroTable;
@@ -125,16 +126,16 @@ class MacroParserImpl implements AutoCloseable {
                     // precompiled header
                     "-include-pch", precompiled.toAbsolutePath().toString()),
                 args.stream()).toArray(String[]::new);
+            LOGGER.log(Level.FINE, "Running macro parser");
             this.macroUnit = macroIndex.parse(macro.toAbsolutePath().toString(),
                     this::processDiagnostics,
                     false, //add serialization support (needed for macros)
                     patchedArgs);
+            LOGGER.log(Level.FINE, "Macro parser completed");
         }
 
         void processDiagnostics(Diagnostic diag) {
-            if (JextractTool.DEBUG) {
-                System.err.println("Error while processing macro: " + diag.spelling());
-            }
+            LOGGER.log(Level.FINE, "Error while processing macro: {0}", diag.spelling());
         }
 
         public Cursor reparse(String snippet) {

--- a/src/main/java/org/openjdk/jextract/impl/TreeMaker.java
+++ b/src/main/java/org/openjdk/jextract/impl/TreeMaker.java
@@ -32,6 +32,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 import java.lang.foreign.MemoryLayout;
@@ -45,6 +47,7 @@ import org.openjdk.jextract.clang.LinkageKind;
 import org.openjdk.jextract.clang.SourceLocation;
 
 class TreeMaker {
+    private static final Logger LOGGER = Logger.getLogger(TreeMaker.class.getSimpleName());
     public TreeMaker() {}
 
     TypeMaker typeMaker = new TypeMaker(this);
@@ -54,6 +57,7 @@ class TreeMaker {
     }
 
     Map<String, List<Constable>> collectAttributes(Cursor c) {
+        LOGGER.log(Level.FINER, "Collecting attributes for {0} kind {1}", new Object[]{c.displayName(), c.kind()});
         Map<String, List<Constable>> attributeMap = new HashMap<>();
         c.forEach(child -> {
             if (child.isAttribute()) {
@@ -61,6 +65,7 @@ class TreeMaker {
                 attrs.add(child.spelling());
             }
         });
+        LOGGER.log(Level.FINER, "Attributes collected");
         return attributeMap;
     }
 
@@ -91,11 +96,12 @@ class TreeMaker {
             return null;
         }
         var rv = (DeclarationImpl) createTreeInternal(c);
+        LOGGER.log(Level.FINER, "Tree created");
         return (rv == null) ? null : rv.withAttributes(collectAttributes(c));
     }
 
     private Declaration createTreeInternal(Cursor c) {
-        return switch (c.kind()) {
+        var r = switch (c.kind()) {
             case EnumDecl -> createEnum(c);
             case EnumConstantDecl -> createEnumConstant(c);
             case FieldDecl -> createVar(c, Declaration.Variable.Kind.FIELD);
@@ -107,6 +113,8 @@ class TreeMaker {
             case VarDecl -> createVar(c, Declaration.Variable.Kind.GLOBAL);
             default -> null; // skip
         };
+        LOGGER.log(Level.FINER, "Tree created");
+        return r;
     }
 
     static class CursorPosition implements Position {
@@ -178,12 +186,15 @@ class TreeMaker {
     }
 
     public Declaration.Function createFunction(Cursor c) {
+        LOGGER.log(Level.FINER, "Creating function: {0}", c.displayName());
         checkCursor(c, CursorKind.FunctionDecl);
         List<Declaration.Variable> params = new ArrayList<>();
         for (int i = 0 ; i < c.numberOfArgs() ; i++) {
             params.add((Declaration.Variable)createTree(c.getArgument(i)));
         }
+        LOGGER.log(Level.FINER, "Creating type");
         Type type = toType(c);
+        LOGGER.log(Level.FINER, "Creating canonical type");
         Type funcType = canonicalType(type);
         return Declaration.function(CursorPosition.of(c), c.spelling(), (Type.Function)funcType,
                 params.toArray(new Declaration.Variable[0]));
@@ -198,6 +209,7 @@ class TreeMaker {
     }
 
     public Declaration.Scoped createHeader(Cursor c, List<Declaration> decls) {
+        LOGGER.log(Level.FINER, "Creating heaader");
         return Declaration.toplevel(CursorPosition.of(c), filterNestedDeclarations(decls).toArray(new Declaration[0]));
     }
 
@@ -328,7 +340,7 @@ class TreeMaker {
 
     private void checkCursor(Cursor c, CursorKind k) {
         if (c.kind() != k) {
-            throw new IllegalArgumentException("Invalid cursor kind");
+            throw new IllegalArgumentException(String.format("Invalid cursor kind: expected %s, actual %s", c.kind(), k));
         }
     }
 

--- a/src/main/java/org/openjdk/jextract/impl/TypeMaker.java
+++ b/src/main/java/org/openjdk/jextract/impl/TypeMaker.java
@@ -34,13 +34,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Supplier;
-
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.lang.foreign.MemoryLayout;
 import org.openjdk.jextract.Declaration;
 import org.openjdk.jextract.Type;
 import org.openjdk.jextract.Type.Delegated;
 import org.openjdk.jextract.Type.Primitive;
 import org.openjdk.jextract.clang.Cursor;
+import org.openjdk.jextract.clang.Index;
 import org.openjdk.jextract.clang.TypeKind;
 
 class TypeMaker {
@@ -67,6 +69,7 @@ class TypeMaker {
             Objects.requireNonNull(derived, "Clang type cannot be resolved: " + origin.spelling());
         }
 
+        @Override
         public Type get() {
             Objects.requireNonNull(derived, "Type is not yet resolved.");
             return derived;
@@ -170,7 +173,7 @@ class TypeMaker {
             case Elaborated:
                 org.openjdk.jextract.clang.Type canonical = t.canonicalType();
                 if (canonical.equalType(t)) {
-                    throw new TypeException("Unknown type with same canonical type: " + t.spelling());
+                    throw new TypeException(String.format("Unknown type with same canonical type: %s: %s", t.spelling(), ClangUtils.toString(t.getDeclarationCursor())));
                 }
                 return makeType(canonical);
             case ConstantArray: {

--- a/src/main/resources/logging-jextract-debug.properties
+++ b/src/main/resources/logging-jextract-debug.properties
@@ -1,0 +1,7 @@
+handlers = java.util.logging.ConsoleHandler
+.level=ALL
+java.util.logging.SimpleFormatter.format = %1$tF %1$tT [%4$-7s] %2$s - %5$s%6$s%n
+# to turn on the tracing mode change to FINER
+java.util.logging.ConsoleHandler.level = FINE
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+java.util.logging.ConsoleHandler.filter = org.openjdk.jextract.LoggerNameFilter

--- a/src/main/resources/logging-jextract.properties
+++ b/src/main/resources/logging-jextract.properties
@@ -1,0 +1,6 @@
+handlers = java.util.logging.ConsoleHandler
+.level=ALL
+java.util.logging.SimpleFormatter.format = %5$s%n
+java.util.logging.ConsoleHandler.level = INFO
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+java.util.logging.ConsoleHandler.filter = org.openjdk.jextract.LoggerNameFilter


### PR DESCRIPTION
See details in the [email thread](https://mail.openjdk.org/pipermail/jextract-dev/2023-August/000816.html)

# Changes in output

There is none, except one extra empty line at the end (I believe it is make the output more readable but we can revert back). Example:

Before:
```
 % jextract --version
jextract 21
JDK version 22-ea+21-1679
clang version 16.0.0
%
```

After:
```
% jextract --version
jextract 21
JDK version 22-ea+21-1679
clang version 16.0.0

%
```

# Changes in debug output

As discussed in the email thread we now print entire clang command line when run in debug mode

Before:
```
% jextract --source -t xxorg.jextract /tmp/point.h
Scoped: TOPLEVEL <toplevel>
    Scoped: STRUCT Point2d layout = [d64(x)d64(y)](Point2d)
        Variable: FIELD x type = Double(layout = d64)
        Variable: FIELD y type = Double(layout = d64)
    Function: distance type = Double(layout = d64)(Declared([d64(x)d64(y)](Point2d)))
        Variable: PARAMETER  type = Declared([d64(x)d64(y)](Point2d))
```

After:
```
% jextract --source -t xxorg.jextract /tmp/point.h
2023-10-28 18:38:42 [FINE   ] org.openjdk.jextract.clang.Index parseTU - Calling clang to parse translation unit
2023-10-28 18:38:42 [FINE   ] org.openjdk.jextract.clang.Index parseTU - clang arguments [-I/home/xxx/workspace/jextract/build/jextract/conf/jextract]
2023-10-28 18:38:42 [FINE   ] org.openjdk.jextract.clang.Index parseTU - input file /tmp/point.h
2023-10-28 18:38:42 [FINE   ] org.openjdk.jextract.clang.Index parseTU - Processing clang diagnostics results
2023-10-28 18:38:42 [FINE   ] org.openjdk.jextract.clang.Index parseTU - Translation unit parsing completed
2023-10-28 18:38:42 [FINE   ] org.openjdk.jextract.impl.MacroParserImpl$ClangReparser <init> - Running macro parser
2023-10-28 18:38:42 [FINE   ] org.openjdk.jextract.clang.Index parseTU - Calling clang to parse translation unit
2023-10-28 18:38:42 [FINE   ] org.openjdk.jextract.clang.Index parseTU - clang arguments [-nostdinc, -ferror-limit=0, -include-pch, /tmp/jextract$10749074042289976505.pch, -I/home/xxx/workspace/jextract/build/jextract/conf/jextract]
2023-10-28 18:38:42 [FINE   ] org.openjdk.jextract.clang.Index parseTU - input file /tmp/jextract$14534419023286799562.h
2023-10-28 18:38:42 [FINE   ] org.openjdk.jextract.clang.Index parseTU - Processing clang diagnostics results
2023-10-28 18:38:42 [FINE   ] org.openjdk.jextract.clang.Index parseTU - Translation unit parsing completed
2023-10-28 18:38:42 [FINE   ] org.openjdk.jextract.impl.MacroParserImpl$ClangReparser <init> - Macro parser completed
Scoped: TOPLEVEL <toplevel>
    Scoped: STRUCT Point2d layout = [d8(x)d8(y)](Point2d)
        Variable: FIELD x type = Double(layout = d8)
        Variable: FIELD y type = Double(layout = d8)
    Function: distance type = Double(layout = d8)(Declared([d8(x)d8(y)](Point2d)))
        Variable: PARAMETER  type = Declared([d8(x)d8(y)](Point2d))
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/138/head:pull/138` \
`$ git checkout pull/138`

Update a local copy of the PR: \
`$ git checkout pull/138` \
`$ git pull https://git.openjdk.org/jextract.git pull/138/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 138`

View PR using the GUI difftool: \
`$ git pr show -t 138`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/138.diff">https://git.openjdk.org/jextract/pull/138.diff</a>

</details>
