### PR TITLE
Update jextract 21 with latest fixes

### DIFF
--- a/src/main/java/org/openjdk/jextract/clang/Type.java
+++ b/src/main/java/org/openjdk/jextract/clang/Type.java
@@ -98,6 +98,10 @@ public final class Type extends ClangDisposable.Owned {
         var elementType = Index_h.clang_getElementType(owner, segment);
         return new Type(elementType, owner);
     }
+    public Type getValueType() {
+        var valueType = Index_h.clang_getValueType(owner, segment);
+        return new Type(valueType, owner);
+    }
 
     public long getNumberOfElements() {
         return Index_h.clang_getNumElements(segment);

--- a/src/main/java/org/openjdk/jextract/clang/libclang/Index_h.java
+++ b/src/main/java/org/openjdk/jextract/clang/libclang/Index_h.java
@@ -4833,6 +4833,7 @@ public class Index_h  {
     public static MethodHandle clang_getElementType$MH() {
         return RuntimeHelper.requireNonNull(constants$11.clang_getElementType$MH,"clang_getElementType");
     }
+
     /**
      * {@snippet :
      * CXType clang_getElementType(CXType T);
@@ -4840,6 +4841,24 @@ public class Index_h  {
      */
     public static MemorySegment clang_getElementType(SegmentAllocator allocator, MemorySegment T) {
         var mh$ = clang_getElementType$MH();
+        try {
+            return (java.lang.foreign.MemorySegment)mh$.invokeExact(allocator, T);
+        } catch (Throwable ex$) {
+            throw new AssertionError("should not reach here", ex$);
+        }
+    }
+
+    public static MethodHandle clang_getValueType$MH() {
+        return RuntimeHelper.requireNonNull(constants$11.clang_getValueType$MH,"clang_Type_getValueType");
+    }
+
+    /**
+     * {@snippet :
+     * CXType clang_getValueType(CXType T);
+     * }
+     */
+    public static MemorySegment clang_getValueType(SegmentAllocator allocator, MemorySegment T) {
+        var mh$ = clang_getValueType$MH();
         try {
             return (java.lang.foreign.MemorySegment)mh$.invokeExact(allocator, T);
         } catch (Throwable ex$) {

--- a/src/main/java/org/openjdk/jextract/clang/libclang/constants$11.java
+++ b/src/main/java/org/openjdk/jextract/clang/libclang/constants$11.java
@@ -119,6 +119,11 @@ final class constants$11 {
         "clang_getElementType",
         constants$11.clang_getElementType$FUNC
     );
+
+    static final MethodHandle clang_getValueType$MH = RuntimeHelper.downcallHandle(
+            "clang_Type_getValueType",
+            constants$11.clang_getElementType$FUNC
+    );
 }
 
 

--- a/src/main/java/org/openjdk/jextract/impl/ClassSourceBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/ClassSourceBuilder.java
@@ -213,7 +213,7 @@ abstract class ClassSourceBuilder extends JavaSourceBuilder {
             append("\n");
         }
         indent();
-        append(" * {@snippet :\n");
+        append(" * {@snippet lang=c :\n");
         append(CDeclarationPrinter.declaration(decl, " ".repeat(align*4) + " * "));
         indent();
         append(" * }\n");
@@ -225,7 +225,7 @@ abstract class ClassSourceBuilder extends JavaSourceBuilder {
         indent();
         append("/**\n");
         indent();
-        append(" * {@snippet :\n");
+        append(" * {@snippet lang=c :\n");
         append(" * ");
         append(CDeclarationPrinter.declaration(funcType, name));
         append(";\n");

--- a/src/main/java/org/openjdk/jextract/impl/TypeMaker.java
+++ b/src/main/java/org/openjdk/jextract/impl/TypeMaker.java
@@ -229,6 +229,10 @@ class TypeMaker {
                 Type iType = Type.primitive(Primitive.Kind.Int128);
                 return Type.qualified(Delegated.Kind.UNSIGNED, iType);
             }
+            case Atomic: {
+                Type aType = makeType(t.getValueType());
+                return Type.qualified(Delegated.Kind.ATOMIC, aType);
+            }
             default:
                 return TypeImpl.ERROR;
         }

--- a/src/main/resources/org/openjdk/jextract/impl/resources/RuntimeHelper.java.template
+++ b/src/main/resources/org/openjdk/jextract/impl/resources/RuntimeHelper.java.template
@@ -223,7 +223,7 @@ final class RuntimeHelper {
             if (c.isPrimitive()) {
                 return promote(c);
             }
-            if (c == MemorySegment.class) {
+            if (MemorySegment.class.isAssignableFrom(c)) {
                 return MemorySegment.class;
             }
             throw new IllegalArgumentException("Invalid type for ABI: " + c.getTypeName());

--- a/test/testng/org/openjdk/jextract/test/api/TestAtomic.java
+++ b/test/testng/org/openjdk/jextract/test/api/TestAtomic.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.jextract.test.api;
+
+import org.openjdk.jextract.Declaration;
+import org.openjdk.jextract.Type;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import testlib.JextractApiTestBase;
+
+import static org.testng.Assert.*;
+import static org.openjdk.jextract.Type.Primitive.Kind.*;
+import static org.openjdk.jextract.Type.Delegated.Kind.*;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.EnumSet;
+
+public class TestAtomic extends JextractApiTestBase {
+    Declaration.Scoped atomic;
+
+    @BeforeClass
+    public void parse() {
+        // We need stdatomic.h
+        Path builtinInc = Paths.get(System.getProperty("java.home"), "conf", "jextract");
+        atomic = parse("atomic.h", "-I", builtinInc.toString());
+    }
+
+    @Test(dataProvider = "atomicTypes")
+    public void testAtomic(String varName, Type expected) {
+        Declaration.Variable var = findDecl(atomic, varName, Declaration.Variable.class);
+        var kinds = EnumSet.of(ATOMIC);
+        if (varName.startsWith("U_")) {
+            kinds.add(UNSIGNED);
+        }
+        if (varName.startsWith("S_")) {
+            kinds.add(SIGNED);
+        }
+        checkType(var.type(), kinds, expected);
+    }
+
+    @DataProvider
+    static Object[][] atomicTypes() {
+        return new Object[][]{
+                new Object[] { "BOOL", Type.primitive(Bool) },
+                new Object[] { "CHAR", Type.primitive(Char) },
+                new Object[] { "S_CHAR", Type.primitive(Char) },
+                new Object[] { "U_CHAR", Type.primitive(Char) },
+                new Object[] { "SHORT", Type.primitive(Short) },
+                new Object[] { "U_SHORT", Type.primitive(Short) },
+                new Object[] { "INT", Type.primitive(Int) },
+                new Object[] { "U_INT", Type.primitive(Int) },
+                new Object[] { "LONG", Type.primitive(Long) },
+                new Object[] { "U_LONG", Type.primitive(Long) },
+                new Object[] { "LONGLONG", Type.primitive(LongLong) },
+                new Object[] { "U_LONGLONG", Type.primitive(LongLong) },
+        };
+    }
+
+    static void checkType(Type t, EnumSet<Type.Delegated.Kind> kinds, Type expected) {
+        while (t instanceof Type.Delegated delegated) {
+            kinds.remove(delegated.kind());
+            t = delegated.type();
+        }
+        assertTrue(kinds.isEmpty(), "Missing kinds: " + kinds);
+        assertEquals(t, expected);
+    }
+}

--- a/test/testng/org/openjdk/jextract/test/api/atomic.h
+++ b/test/testng/org/openjdk/jextract/test/api/atomic.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include <stdatomic.h>
+
+atomic_bool BOOL;
+atomic_char CHAR;
+atomic_schar S_CHAR;
+atomic_uchar U_CHAR;
+atomic_short SHORT;
+atomic_ushort U_SHORT;
+atomic_int INT;
+atomic_uint U_INT;
+atomic_long LONG;
+atomic_ulong U_LONG;
+atomic_llong LONGLONG;
+atomic_ullong U_LONGLONG;


### PR DESCRIPTION
This PR brings three changesets to the `master` branch, so that we can release updated binaries:

* https://git.openjdk.org/jextract/pull/132
* https://git.openjdk.org/jextract/pull/131
* https://github.com/openjdk/jextract/pull/137 
