### PR TITLE
TestDocComments fixes

### DIFF
--- a/test/lib/testlib/JextractToolRunner.java
+++ b/test/lib/testlib/JextractToolRunner.java
@@ -112,7 +112,7 @@ public class JextractToolRunner {
         }
 
         public JextractResult checkSuccess() {
-            assertEquals(exitCode, SUCCESS, "Sucess expected, failed: " + exitCode);
+            assertEquals(exitCode, SUCCESS, "Sucess expected, failed: " + exitCode + ", Output: " + output);
             return this;
         }
 

--- a/test/testng/org/openjdk/jextract/test/toolprovider/Test7903257/TestDocComments.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/Test7903257/TestDocComments.java
@@ -196,7 +196,7 @@ public class TestDocComments extends JextractToolRunner {
                 .replaceAll("\n\\s+\\*", "")
 
                 // get rid of "{@snippet :" prefix
-                .replaceAll("\\{@snippet :", "")
+                .replaceAll("\\{@snippet lang=c :", "")
 
                 // replace one or more whitespaces as single whitespace
                 .replaceAll("\\s+", " ")

--- a/test/testng/org/openjdk/jextract/test/toolprovider/Test7903257/TestDocComments.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/Test7903257/TestDocComments.java
@@ -67,7 +67,7 @@ public class TestDocComments extends JextractToolRunner {
     public void testTypedefs() throws IOException {
         var comments = getDocComments("typedefs.h", "typedefs_h.java");
         assertEquals(comments, List.of(
-            "typedef unsigned long size_t;",
+            "typedef unsigned long long size_t;",
             "typedef int INT_32;",
             "typedef int* INT_PTR;",
             "typedef struct Foo* OPAQUE_PTR;"));

--- a/test/testng/org/openjdk/jextract/test/toolprovider/Test7903257/typedefs.h
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/Test7903257/typedefs.h
@@ -21,7 +21,7 @@
  * questions.
  */
 
-typedef unsigned long size_t;
+typedef unsigned long long size_t;
 typedef int INT_32;
 typedef int* INT_PTR;
 typedef struct Foo* OPAQUE_PTR;


### PR DESCRIPTION
This PR contains a port for:

https://github.com/openjdk/jextract/commit/0aaf75cdfe14df6f3a3f4e3d80f5384414a78ade

As well as a fix that is required by the changes in: https://git.openjdk.org/jextract/pull/137

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/140/head:pull/140` \
`$ git checkout pull/140`

Update a local copy of the PR: \
`$ git checkout pull/140` \
`$ git pull https://git.openjdk.org/jextract.git pull/140/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 140`

View PR using the GUI difftool: \
`$ git pr show -t 140`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/140.diff">https://git.openjdk.org/jextract/pull/140.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/140#issuecomment-1819630335)