### PR TITLE
7903591: Do not re-run cmake tasks if inputs didn't change

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -154,6 +154,12 @@ task createRuntimeImageForTest(type: Exec) {
 }
 
 task cmakeConfigure(type: Exec) {
+    // note that we want to re-run this task if the set of files is different,
+    // not when one of the files has changed
+    inputs.property("libSources", fileTree(dir: "test", include: "**/*lib*.c").files)
+    inputs.file("test/test-support/CMakeLists.txt")
+    outputs.dir("$buildDir/testlib-build")
+
     executable = "cmake"
     args = [
         "-B", "$buildDir/testlib-build",
@@ -166,6 +172,9 @@ task cmakeConfigure(type: Exec) {
 
 task cmakeBuild(type: Exec) {
     dependsOn cmakeConfigure
+
+    inputs.files(fileTree(dir: "test", includes: ["**/*lib*.c", "**/*.h"]))
+    outputs.dir("$buildDir/testlib-install")
 
     executable = "cmake"
     args = [

--- a/test/test-support/CMakeLists.txt
+++ b/test/test-support/CMakeLists.txt
@@ -3,7 +3,7 @@ project(TestSupportLibs)
 
 option(TEST_SOURCE_ROOT "src directory with test files")
 
-file(GLOB_RECURSE TEST_LIBS ${TEST_SOURCE_ROOT}/../*lib*.c)
+file(GLOB_RECURSE TEST_LIBS ${TEST_SOURCE_ROOT}/*lib*.c)
 
 foreach(TEST_LIB ${TEST_LIBS})
     message(STATUS "Processing test lib: ${TEST_LIB}")
@@ -23,5 +23,3 @@ foreach(TEST_LIB ${TEST_LIBS})
        ${LIB_NAME}
     )
 endforeach()
-
-


### PR DESCRIPTION
Defines inputs and outputs for the cmake* tasks, to avoid re-running them every time.

I also noticed that the CMakeLists.txt still uses a glob corresponding to the old test directory structure. It will essentially look for `*lib*.c` files from the project root. I've fixed this to only look in the `test` sub directory.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Issue
 * [CODETOOLS-7903591](https://bugs.openjdk.org/browse/CODETOOLS-7903591): Do not re-run cmake tasks if inputs didn't change (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/142/head:pull/142` \
`$ git checkout pull/142`

Update a local copy of the PR: \
`$ git checkout pull/142` \
`$ git pull https://git.openjdk.org/jextract.git pull/142/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 142`

View PR using the GUI difftool: \
`$ git pr show -t 142`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/142.diff">https://git.openjdk.org/jextract/pull/142.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/142#issuecomment-1822771955)