### PR TITLE
7903592: Add test source set

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,21 @@ plugins {
     id "java"
 }
 
+sourceSets {
+    test {
+        java {
+            srcDirs = ['test/jtreg', file("test/jtreg/generator").listFiles(), 'test/lib', 'test/testng']
+            // exclude all test files from compilation. Jtreg compiles these for us when tests run
+            exclude "**/*"
+        }
+    }
+}
+
+dependencies {
+    // add jtreg jars as dependencies of tests
+    testImplementation fileTree(dir: findProperty("jtreg_home") + "/lib/", include: "*.jar")
+}
+
 def static checkPath(String p) {
     if (!Files.exists(Path.of(p))) {
         throw new IllegalArgumentException("Error: the path ${p} does not exist");


### PR DESCRIPTION
Add a source set for the test source directories in gradle. And add the jtreg jars as dependencies of test compilation. Intellij will then automatically mark the directories as test source directories, and add the jtreg jar files to the class path of the tests (so that e.g. the `@Test` annotation and other testng imports are recognized)

i.e. these changes are for better Intellij (and maybe other IDE) integration.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Issue
 * [CODETOOLS-7903592](https://bugs.openjdk.org/browse/CODETOOLS-7903592): Add test source set (**Enhancement** - P4)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/143/head:pull/143` \
`$ git checkout pull/143`

Update a local copy of the PR: \
`$ git checkout pull/143` \
`$ git pull https://git.openjdk.org/jextract.git pull/143/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 143`

View PR using the GUI difftool: \
`$ git pr show -t 143`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/143.diff">https://git.openjdk.org/jextract/pull/143.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/143#issuecomment-1822875328)