### PR TITLE
Make attributes mutable

### DIFF
--- a/src/main/java/org/openjdk/jextract/Attributed.java
+++ b/src/main/java/org/openjdk/jextract/Attributed.java
@@ -1,3 +1,29 @@
+/*
+ *  Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ *  This code is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License version 2 only, as
+ *  published by the Free Software Foundation.  Oracle designates this
+ *  particular file as subject to the "Classpath" exception as provided
+ *  by Oracle in the LICENSE file that accompanied this code.
+ *
+ *  This code is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ *  version 2 for more details (a copy is included in the LICENSE file that
+ *  accompanied this code).
+ *
+ *  You should have received a copy of the GNU General Public License version
+ *  2 along with this work; if not, write to the Free Software Foundation,
+ *  Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *   Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ *  or visit www.oracle.com if you need additional information or have any
+ *  questions.
+ *
+ */
+
 package org.openjdk.jextract;
 
 import java.util.Collection;

--- a/src/main/java/org/openjdk/jextract/Attributed.java
+++ b/src/main/java/org/openjdk/jextract/Attributed.java
@@ -52,7 +52,8 @@ public interface Attributed {
     <R extends Record> Optional<R> getAttribute(Class<R> attributeClass);
 
     /**
-     * Adds a new attribute to this entity.
+     * Adds a new attribute to this entity. This method is idempotent, that is, it allows adding an attribute
+     * that is identical to the one already stored.
      * @param attribute the attribute to be added.
      * @param <R> the attribute's type.
      */

--- a/src/main/java/org/openjdk/jextract/Attributed.java
+++ b/src/main/java/org/openjdk/jextract/Attributed.java
@@ -1,0 +1,34 @@
+package org.openjdk.jextract;
+
+import java.util.Collection;
+import java.util.Optional;
+
+/**
+ * Subtypes of this interface can be customized with a variable number of attributes. Each attribute
+ * is modelled as an instance of a record class. The record class is used to lookup attributes.
+ * There can be at most one attribute associated with a given record class. Moreover, the set of
+ * attributes associated with an entity implementing this interface can only monotonically increase over time
+ * (that is, removing or replacing attributes is not supported).
+ */
+public interface Attributed {
+
+    /**
+     * {@return the attributes associated with this entity}
+     */
+    Collection<Record> attributes();
+
+    /**
+     * Obtains an attribute from this entity.
+     * @param attributeClass the class of the attribute to be obtained.
+     * @param <R> the attribute's type.
+     * @return the attribute (if any).
+     */
+    <R extends Record> Optional<R> getAttribute(Class<R> attributeClass);
+
+    /**
+     * Adds a new attribute to this entity.
+     * @param attribute the attribute to be added.
+     * @param <R> the attribute's type.
+     */
+    <R extends Record> void addAttribute(R attribute);
+}

--- a/src/main/java/org/openjdk/jextract/Declaration.java
+++ b/src/main/java/org/openjdk/jextract/Declaration.java
@@ -27,7 +27,9 @@
 package org.openjdk.jextract;
 
 import java.lang.constant.Constable;
+import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.lang.foreign.MemoryLayout;
@@ -39,7 +41,7 @@ import org.openjdk.jextract.impl.DeclarationImpl;
  * support the <em>visitor</em> pattern (see {@link Declaration#accept(Visitor, Object)} and
  * {@link Visitor}).
  */
-public interface Declaration {
+public interface Declaration extends Attributed {
 
     /**
      * The position associated with this declaration.
@@ -52,36 +54,6 @@ public interface Declaration {
      * @return The name associated with this declaration.
      */
     String name();
-
-    /**
-     * Get a declaration with specified attribute.
-     * Set the values to the specified attribute while other attributes remains unchanged. If the specified attribute
-     * already exist, the new values are replacing the old ones. By not specifying any value, the attribute will become
-     * empty as {@link #getAttribute(String) getAttribute(name).isEmpty()} will return true.
-     * @param name The attribute name
-     * @param values More attribute values
-     * @return the Declaration with attributes
-     */
-    Declaration withAttribute(String name, Constable... values);
-
-    /**
-     * Get a declaration without current attributes
-     * @return the Declatation without any attributes
-     */
-    Declaration stripAttributes();
-
-    /**
-     * The values of the specified attribute.
-     * @param name The attribute to retrieve
-     * @return The list of values associate with this attribute
-     */
-    Optional<List<Constable>> getAttribute(String name);
-
-    /**
-     * The attributes associated with this declaration
-     * @return The attributes associated with this declaration
-     */
-    Set<String> attributeNames();
 
     /**
      * Entry point for visiting declaration instances.
@@ -583,4 +555,10 @@ public interface Declaration {
     static Declaration.Typedef typedef(Position pos, String name, Type type) {
         return new DeclarationImpl.TypedefImpl(type, name, pos, null);
     }
+
+    /**
+     * A record used to capture clang attributes attached to a declaration.
+     * @param attributes a map from attribute name to attribute values.
+     */
+    record ClangAttributes(Map<String, List<String>> attributes) { }
 }

--- a/src/main/java/org/openjdk/jextract/Type.java
+++ b/src/main/java/org/openjdk/jextract/Type.java
@@ -44,7 +44,7 @@ import java.util.stream.Stream;
  * Instances of this class support the <em>visitor</em> pattern (see {@link Type#accept(Type.Visitor, Object)} and
  * {@link Type.Visitor}).
  */
-public interface Type {
+public interface Type extends Attributed {
 
     /**
      * Is this type the erroneous type?

--- a/src/main/java/org/openjdk/jextract/impl/AttributedImpl.java
+++ b/src/main/java/org/openjdk/jextract/impl/AttributedImpl.java
@@ -50,7 +50,8 @@ public abstract class AttributedImpl implements Attributed {
 
     @Override
     public <R extends Record> void addAttribute(R attribute) {
-        if (attributes.containsKey(attribute.getClass())) {
+        Record attr = attributes.get(attribute.getClass());
+        if (attr != null && !attr.equals(attribute)) {
             throw new IllegalStateException("Attribute already exists: " + attribute.getClass().getSimpleName());
         }
         attributes.put(attribute.getClass(), attribute);

--- a/src/main/java/org/openjdk/jextract/impl/AttributedImpl.java
+++ b/src/main/java/org/openjdk/jextract/impl/AttributedImpl.java
@@ -1,0 +1,37 @@
+package org.openjdk.jextract.impl;
+
+import org.openjdk.jextract.Attributed;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+public abstract class AttributedImpl implements Attributed {
+
+    private final Map<Class<?>, Record> attributes = new HashMap<>();
+
+    public Collection<Record> attributes() {
+        return attributes.values();
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <R extends Record> Optional<R> getAttribute(Class<R> attributeClass) {
+        return Optional.ofNullable((R)attributes.get(attributeClass));
+    }
+
+    public <R extends Record> void addAttribute(R attribute) {
+        if (attributes.containsKey(attribute.getClass())) {
+            throw new IllegalStateException("Attribute already exists: " + attribute.getClass().getSimpleName());
+        }
+        attributes.put(attribute.getClass(), attribute);
+    }
+
+    public <R extends Record> void dropAttribute(Class<R> attributeClass) {
+        if (!attributes.containsKey(attributeClass)) {
+            throw new IllegalStateException("No attribute: " + attributeClass.getSimpleName());
+        }
+        attributes.remove(attributeClass);
+    }
+}

--- a/src/main/java/org/openjdk/jextract/impl/AttributedImpl.java
+++ b/src/main/java/org/openjdk/jextract/impl/AttributedImpl.java
@@ -37,6 +37,7 @@ public abstract class AttributedImpl implements Attributed {
 
     private final Map<Class<?>, Record> attributes = new HashMap<>();
 
+    @Override
     public Collection<Record> attributes() {
         return attributes.values();
     }
@@ -47,17 +48,11 @@ public abstract class AttributedImpl implements Attributed {
         return Optional.ofNullable((R)attributes.get(attributeClass));
     }
 
+    @Override
     public <R extends Record> void addAttribute(R attribute) {
         if (attributes.containsKey(attribute.getClass())) {
             throw new IllegalStateException("Attribute already exists: " + attribute.getClass().getSimpleName());
         }
         attributes.put(attribute.getClass(), attribute);
-    }
-
-    public <R extends Record> void dropAttribute(Class<R> attributeClass) {
-        if (!attributes.containsKey(attributeClass)) {
-            throw new IllegalStateException("No attribute: " + attributeClass.getSimpleName());
-        }
-        attributes.remove(attributeClass);
     }
 }

--- a/src/main/java/org/openjdk/jextract/impl/AttributedImpl.java
+++ b/src/main/java/org/openjdk/jextract/impl/AttributedImpl.java
@@ -1,3 +1,29 @@
+/*
+ *  Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ *  This code is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License version 2 only, as
+ *  published by the Free Software Foundation.  Oracle designates this
+ *  particular file as subject to the "Classpath" exception as provided
+ *  by Oracle in the LICENSE file that accompanied this code.
+ *
+ *  This code is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ *  version 2 for more details (a copy is included in the LICENSE file that
+ *  accompanied this code).
+ *
+ *  You should have received a copy of the GNU General Public License version
+ *  2 along with this work; if not, write to the Free Software Foundation,
+ *  Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *   Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ *  or visit www.oracle.com if you need additional information or have any
+ *  questions.
+ *
+ */
+
 package org.openjdk.jextract.impl;
 
 import org.openjdk.jextract.Attributed;

--- a/src/main/java/org/openjdk/jextract/impl/DeclarationImpl.java
+++ b/src/main/java/org/openjdk/jextract/impl/DeclarationImpl.java
@@ -345,7 +345,13 @@ public abstract class DeclarationImpl extends AttributedImpl implements Declarat
         }
     }
 
+    /**
+     * An attribute to mark anonymous struct declarations.
+     */
     record AnonymousStruct() { }
 
-    record EnumConstant(Scoped enumParent) { }
+    /**
+     * An attribute to mark enum constants, with a link to the name of their parent enum.
+     */
+    record EnumConstant(String enumName) { }
 }

--- a/src/main/java/org/openjdk/jextract/impl/DeclarationImpl.java
+++ b/src/main/java/org/openjdk/jextract/impl/DeclarationImpl.java
@@ -27,6 +27,7 @@
 package org.openjdk.jextract.impl;
 
 import java.lang.constant.Constable;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -39,16 +40,14 @@ import org.openjdk.jextract.Declaration;
 import org.openjdk.jextract.Position;
 import org.openjdk.jextract.Type;
 
-public abstract class DeclarationImpl implements Declaration {
+public abstract class DeclarationImpl extends AttributedImpl implements Declaration {
 
     private final String name;
     private final Position pos;
-    private final Optional<Map<String, List<Constable>>> attributes;
 
     public DeclarationImpl(String name, Position pos, Map<String, List<Constable>> attrs) {
         this.name = name;
         this.pos = pos;
-        this.attributes = Optional.ofNullable(attrs);
     }
 
     public String toString() {
@@ -63,28 +62,6 @@ public abstract class DeclarationImpl implements Declaration {
     public Position pos() {
         return pos;
     }
-
-    @Override
-    public Optional<List<Constable>> getAttribute(String name) {
-        return attributes.map(attrs -> attrs.get(name));
-    }
-
-    @Override
-    public Set<String> attributeNames() { return Collections.unmodifiableSet(
-            attributes.map(Map::keySet).orElse(Collections.emptySet()));
-    }
-
-    @Override
-    public Declaration withAttribute(String name, Constable... values) {
-        if (values == null || values.length == 0) {
-            return withAttributes(null);
-        }
-        var attrs = attributes.map(HashMap::new).orElseGet(HashMap::new);
-        attrs.put(name, List.of(values));
-        return withAttributes(attrs);
-    }
-
-    abstract protected Declaration withAttributes(Map<String, List<Constable>> attrs);
 
     @Override
     public boolean equals(Object o) {
@@ -115,16 +92,6 @@ public abstract class DeclarationImpl implements Declaration {
         @Override
         public Type type() {
             return type;
-        }
-
-        @Override
-        public Typedef withAttributes(Map<String, List<Constable>> attrs) {
-            return new TypedefImpl(type, name(), pos(), attrs);
-        }
-
-        @Override
-        public Typedef stripAttributes() {
-            return new TypedefImpl(type, name(), pos(), null);
         }
 
         @Override
@@ -178,16 +145,6 @@ public abstract class DeclarationImpl implements Declaration {
         }
 
         @Override
-        public Variable withAttributes(Map<String, List<Constable>> attrs) {
-            return new VariableImpl(type, layout, kind, name(), pos(), attrs);
-        }
-
-        @Override
-        public Variable stripAttributes() {
-            return new VariableImpl(type, layout, kind, name(), pos(), null);
-        }
-
-        @Override
         public boolean equals(Object o) {
             if (this == o) return true;
             if (!(o instanceof Declaration.Variable variable)) return false;
@@ -225,16 +182,6 @@ public abstract class DeclarationImpl implements Declaration {
         @Override
         public long width() {
             return width;
-        }
-
-        @Override
-        public Variable withAttributes(Map<String, List<Constable>> attrs) {
-            return new BitfieldImpl(type, offset, width, name(), pos(), attrs);
-        }
-
-        @Override
-        public Variable stripAttributes() {
-            return new BitfieldImpl(type, offset, width, name(), pos(), null);
         }
 
         @Override
@@ -280,16 +227,6 @@ public abstract class DeclarationImpl implements Declaration {
         @Override
         public Type.Function type() {
             return type;
-        }
-
-        @Override
-        public Function withAttributes(Map<String, List<Constable>> attrs) {
-            return new FunctionImpl(type, params, name(), pos(), attrs);
-        }
-
-        @Override
-        public Function stripAttributes() {
-            return new FunctionImpl(type, params, name(), pos(), null);
         }
 
         @Override
@@ -349,16 +286,6 @@ public abstract class DeclarationImpl implements Declaration {
         }
 
         @Override
-        public Scoped withAttributes(Map<String, List<Constable>> attrs) {
-            return new ScopedImpl(kind, optLayout, declarations, name(), pos(), attrs);
-        }
-
-        @Override
-        public Scoped stripAttributes() {
-            return new ScopedImpl(kind, optLayout, declarations, name(), pos(), null);
-        }
-
-        @Override
         public boolean equals(Object o) {
             if (this == o) return true;
             if (!(o instanceof Declaration.Scoped scoped)) return false;
@@ -404,16 +331,6 @@ public abstract class DeclarationImpl implements Declaration {
         }
 
         @Override
-        public Constant withAttributes(Map<String, List<Constable>> attrs) {
-            return new ConstantImpl(type, value, name(), pos(), attrs);
-        }
-
-        @Override
-        public Constant stripAttributes() {
-            return new ConstantImpl(type, value, name(), pos(), null);
-        }
-
-        @Override
         public boolean equals(Object o) {
             if (this == o) return true;
             if (!(o instanceof Declaration.Constant constant)) return false;
@@ -427,4 +344,8 @@ public abstract class DeclarationImpl implements Declaration {
             return Objects.hash(super.hashCode(), value, type);
         }
     }
+
+    record AnonymousStruct() { }
+
+    record EnumConstant(Scoped enumParent) { }
 }

--- a/src/main/java/org/openjdk/jextract/impl/EnumConstantLifter.java
+++ b/src/main/java/org/openjdk/jextract/impl/EnumConstantLifter.java
@@ -26,6 +26,8 @@ package org.openjdk.jextract.impl;
 
 import org.openjdk.jextract.Declaration;
 import org.openjdk.jextract.Type;
+import org.openjdk.jextract.impl.DeclarationImpl.EnumConstant;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -41,7 +43,7 @@ final class EnumConstantLifter implements TreeTransformer, Declaration.Visitor<V
     }
 
     static Optional<String> enumName(Declaration.Constant constant) {
-        return constant.getAttribute(ENUM_NAME).map(attrs -> attrs.get(0).toString());
+        return constant.getAttribute(EnumConstant.class).map(ec -> ec.enumParent().name());
     }
 
     @Override
@@ -84,9 +86,10 @@ final class EnumConstantLifter implements TreeTransformer, Declaration.Visitor<V
         boolean isEnum = scoped.kind() == Declaration.Scoped.Kind.ENUM;
         if (isEnum) {
             // add the name of the enum as an attribute.
-            scoped.members().forEach(fieldTree -> fieldTree
-                .withAttribute(ENUM_NAME, scoped.name())
-                .accept(this, null));
+            scoped.members().forEach(fieldTree -> {
+                fieldTree.addAttribute(new EnumConstant(scoped));
+                fieldTree.accept(this, null);
+            });
         }
         return isEnum;
     }

--- a/src/main/java/org/openjdk/jextract/impl/EnumConstantLifter.java
+++ b/src/main/java/org/openjdk/jextract/impl/EnumConstantLifter.java
@@ -36,14 +36,13 @@ import java.util.Optional;
  * This visitor lifts enum constants to the top level and removes enum Trees.
  */
 final class EnumConstantLifter implements TreeTransformer, Declaration.Visitor<Void, Void> {
-    private static final String ENUM_NAME = "enum-name";
 
     private final List<Declaration> decls = new ArrayList<>();
     EnumConstantLifter() {
     }
 
     static Optional<String> enumName(Declaration.Constant constant) {
-        return constant.getAttribute(EnumConstant.class).map(ec -> ec.enumParent().name());
+        return constant.getAttribute(EnumConstant.class).map(EnumConstant::enumName);
     }
 
     @Override
@@ -87,7 +86,7 @@ final class EnumConstantLifter implements TreeTransformer, Declaration.Visitor<V
         if (isEnum) {
             // add the name of the enum as an attribute.
             scoped.members().forEach(fieldTree -> {
-                fieldTree.addAttribute(new EnumConstant(scoped));
+                fieldTree.addAttribute(new EnumConstant(scoped.name()));
                 fieldTree.accept(this, null);
             });
         }

--- a/src/main/java/org/openjdk/jextract/impl/NameMangler.java
+++ b/src/main/java/org/openjdk/jextract/impl/NameMangler.java
@@ -373,4 +373,6 @@ final class NameMangler implements Declaration.Visitor<Void, Declaration> {
             default -> false;
         };
     }
+
+    static final String JAVA_NAME = "java.name";
 }

--- a/src/main/java/org/openjdk/jextract/impl/NameMangler.java
+++ b/src/main/java/org/openjdk/jextract/impl/NameMangler.java
@@ -373,6 +373,4 @@ final class NameMangler implements Declaration.Visitor<Void, Declaration> {
             default -> false;
         };
     }
-
-    static final String JAVA_NAME = "java.name";
 }

--- a/src/main/java/org/openjdk/jextract/impl/PrettyPrinter.java
+++ b/src/main/java/org/openjdk/jextract/impl/PrettyPrinter.java
@@ -27,6 +27,7 @@
 package org.openjdk.jextract.impl;
 
 import java.lang.constant.Constable;
+import java.util.Collection;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.lang.foreign.MemoryLayout;
@@ -56,22 +57,20 @@ public class PrettyPrinter implements Declaration.Visitor<Void, Void> {
     StringBuilder builder = new StringBuilder();
 
     private void getAttributes(Declaration decl) {
-        Set<String> attrs = decl.attributeNames();
-        if (attrs.isEmpty()) {
-            return;
+        Collection<Record> attrs = decl.attributes();
+        if (!attrs.isEmpty()) {
+            incr();
+            builder.append("Attributes: ");
+            String sep = "\n";
+            for (Record attr : attrs) {
+                incr();
+                builder.append(sep);
+                builder.append(attr);
+                decr();
+                sep = ",\n";
+            }
+            decr();
         }
-        incr();
-        indent();
-        for (String k: attrs) {
-            builder.append("Attr: ");
-            builder.append(k);
-            builder.append(" -> [");
-            builder.append(decl.getAttribute(k).get().stream()
-                .map(Constable::toString)
-                .collect(Collectors.joining(", ")));
-            builder.append("]\n");
-        }
-        decr();
     }
 
     public String print(Declaration decl) {

--- a/src/main/java/org/openjdk/jextract/impl/RecordLayoutComputer.java
+++ b/src/main/java/org/openjdk/jextract/impl/RecordLayoutComputer.java
@@ -34,6 +34,7 @@ import org.openjdk.jextract.clang.Cursor;
 import org.openjdk.jextract.clang.CursorKind;
 import org.openjdk.jextract.clang.Type;
 import org.openjdk.jextract.clang.TypeKind;
+import org.openjdk.jextract.impl.DeclarationImpl.AnonymousStruct;
 
 import java.lang.foreign.SequenceLayout;
 import java.lang.foreign.StructLayout;
@@ -114,7 +115,7 @@ abstract class RecordLayoutComputer {
         Declaration.Scoped declaration = finishRecord(anonName != null ? anonName : declName, declName);
         if (cursor.isAnonymousStruct()) {
             // record this with a declaration attribute, so we don't have to rely on the cursor again later
-            declaration = (Declaration.Scoped)declaration.withAttribute("ANONYMOUS", true);
+            declaration.addAttribute(new AnonymousStruct());
         }
         return org.openjdk.jextract.Type.declared(declaration);
     }

--- a/src/main/java/org/openjdk/jextract/impl/TypeImpl.java
+++ b/src/main/java/org/openjdk/jextract/impl/TypeImpl.java
@@ -41,7 +41,7 @@ import org.openjdk.jextract.Type;
 
 import static java.lang.foreign.ValueLayout.ADDRESS;
 
-public abstract class TypeImpl implements Type {
+public abstract class TypeImpl extends AttributedImpl implements Type {
 
     public static final boolean IS_WINDOWS = System.getProperty("os.name").startsWith("Windows");
 


### PR DESCRIPTION
This PR makes the attribute list associated with a declaration (and a type) mutable. This means that we can now tweak a declaration/type after the fact. While the declaration/type is still immutable, the information attached to it can grow over time. This should be useful to reduce coupling between different steps in the extraction process. I plan to use this to simplify the way we deal with name mangling.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - Committer) ⚠️ Review applies to [a02f1e7c](https://git.openjdk.org/jextract/pull/146/files/a02f1e7cca48197013db3e0ce97323c9e69abf8a)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/146/head:pull/146` \
`$ git checkout pull/146`

Update a local copy of the PR: \
`$ git checkout pull/146` \
`$ git pull https://git.openjdk.org/jextract.git pull/146/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 146`

View PR using the GUI difftool: \
`$ git pr show -t 146`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/146.diff">https://git.openjdk.org/jextract/pull/146.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/146#issuecomment-1832474388)