### PR TITLE
Update GHA for panama branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,7 @@ jobs:
       shell: sh
       run: |
         mkdir -p /tmp/deps/jdk-toolchain
-        tar --strip-components=1 -xvf ${{ steps.download_jdk_22.outputs.archive }} -C /tmp/deps/jdk-toolchain
+        tar --strip-components=1 -xvf ${{ steps.download_toolchain_jdk.outputs.archive }} -C /tmp/deps/jdk-toolchain
         ls -lah /tmp/deps/jdk-toolchain
 
     - name: 'Check toolchain Java version'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,10 +21,10 @@ jobs:
         include:
           - os: ubuntu-20.04
             TARGET: linux-gnu-ubuntu-20.04
-            JAVA19_HOME: /tmp/deps/jdk-19
+            JAVA22_HOME: /tmp/deps/jdk-22
           - os: macos-latest
             TARGET: apple-darwin
-            JAVA19_HOME: /tmp/deps/jdk-19/jdk-19.jdk/Contents/Home
+            JAVA22_HOME: /tmp/deps/jdk-22/jdk-22.jdk/Contents/Home
 
     steps:
     - name: 'Check out repository'
@@ -38,30 +38,30 @@ jobs:
         mkdir -p deps/jtreg
         mkdir -p /tmp/deps
 
-    - name: 'Download JDK 19'
-      id: download_jdk_19
-      uses: oracle-actions/setup-java@v1.1.1
+    - name: 'Download JDK 22'
+      id: download_jdk_22
+      uses: oracle-actions/setup-java@v1.3.2
       with:
         website: jdk.java.net
-        release: 19
+        release: 22
         install: false
         
-    - name: 'Extract JDK 19'
+    - name: 'Extract JDK 22'
       shell: sh
       run: |
-        mkdir -p /tmp/deps/jdk-19
-        tar --strip-components=1 -xvf ${{ steps.download_jdk_19.outputs.archive }} -C /tmp/deps/jdk-19
-        ls -lah /tmp/deps/jdk-19
+        mkdir -p /tmp/deps/jdk-22
+        tar --strip-components=1 -xvf ${{ steps.download_jdk_22.outputs.archive }} -C /tmp/deps/jdk-22
+        ls -lah /tmp/deps/jdk-22
 
-    - name: 'Check Java 19 version'
+    - name: 'Check Java 22 version'
       shell: sh
       run: |
-        ${{ matrix.JAVA19_HOME }}/bin/java --version
+        ${{ matrix.JAVA22_HOME }}/bin/java --version
 
-    - name: 'Setup Java 18'
+    - name: 'Setup Java 17'
       uses: oracle-actions/setup-java@v1.1.1
       with:
-        release: 18
+        release: 17
 
     - name: 'Check default Java version'
       shell: sh
@@ -80,7 +80,7 @@ jobs:
     - name: 'Build Jextract'
       shell: sh
       run: |
-        sh ./gradlew -Pjdk19_home=${{ matrix.JAVA19_HOME }} -Pllvm_home=/tmp/deps/clang_llvm clean verify        
+        sh ./gradlew -Pjdk22_home=${{ matrix.JAVA22_HOME }} -Pllvm_home=/tmp/deps/clang_llvm clean verify        
 
     - name: 'Check out JTReg'
       uses: actions/checkout@v2
@@ -100,4 +100,4 @@ jobs:
     - name: 'Run tests'
       shell: sh
       run: |
-        sh ./gradlew -Pjdk19_home=${{ matrix.JAVA19_HOME }} -Pllvm_home=/tmp/deps/clang_llvm -Pjtreg_home=./deps/jtreg/build/images/jtreg jtreg
+        sh ./gradlew -Pjdk22_home=${{ matrix.JAVA22_HOME }} -Pllvm_home=/tmp/deps/clang_llvm -Pjtreg_home=./deps/jtreg/build/images/jtreg jtreg

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,14 +21,14 @@ jobs:
         include:
           - os: ubuntu-20.04
             TARGET: linux-gnu-ubuntu-20.04
-            JAVA22_HOME: /tmp/deps/jdk-22
+            TOOLCHAIN_JAVA_HOME: /tmp/deps/jdk-toolchain
           - os: macos-latest
             TARGET: apple-darwin
-            JAVA22_HOME: /tmp/deps/jdk-22/jdk-22.jdk/Contents/Home
+            TOOLCHAIN_JAVA_HOME: /tmp/deps/jdk-toolchain/jdk-22.jdk/Contents/Home
 
     steps:
     - name: 'Check out repository'
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4.1.1
       with:
         fetch-depth: 1
         
@@ -38,28 +38,28 @@ jobs:
         mkdir -p deps/jtreg
         mkdir -p /tmp/deps
 
-    - name: 'Download JDK 22'
-      id: download_jdk_22
+    - name: 'Download toolchain JDK'
+      id: download_toolchain_jdk
       uses: oracle-actions/setup-java@v1.3.2
       with:
         website: jdk.java.net
         release: 22
         install: false
         
-    - name: 'Extract JDK 22'
+    - name: 'Extract Toolchain JDK'
       shell: sh
       run: |
-        mkdir -p /tmp/deps/jdk-22
-        tar --strip-components=1 -xvf ${{ steps.download_jdk_22.outputs.archive }} -C /tmp/deps/jdk-22
-        ls -lah /tmp/deps/jdk-22
+        mkdir -p /tmp/deps/jdk-toolchain
+        tar --strip-components=1 -xvf ${{ steps.download_jdk_22.outputs.archive }} -C /tmp/deps/jdk-toolchain
+        ls -lah /tmp/deps/jdk-toolchain
 
-    - name: 'Check Java 22 version'
+    - name: 'Check toolchain Java version'
       shell: sh
       run: |
-        ${{ matrix.JAVA22_HOME }}/bin/java --version
+        ${{ matrix.TOOLCHAIN_JAVA_HOME }}/bin/java --version
 
     - name: 'Setup Java 17'
-      uses: oracle-actions/setup-java@v1.1.1
+      uses: oracle-actions/setup-java@v1.3.2
       with:
         release: 17
 
@@ -80,13 +80,13 @@ jobs:
     - name: 'Build Jextract'
       shell: sh
       run: |
-        sh ./gradlew -Pjdk22_home=${{ matrix.JAVA22_HOME }} -Pllvm_home=/tmp/deps/clang_llvm clean verify        
+        sh ./gradlew -Pjdk22_home=${{ matrix.TOOLCHAIN_JAVA_HOME }} -Pllvm_home=/tmp/deps/clang_llvm clean verify        
 
     - name: 'Check out JTReg'
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4.1.1
       with:
         repository: 'openjdk/jtreg'
-        ref: 'jtreg-6.2+1'
+        ref: 'jtreg-7.3.1+1'
         fetch-depth: 1
         path: deps/jtreg
 
@@ -100,4 +100,4 @@ jobs:
     - name: 'Run tests'
       shell: sh
       run: |
-        sh ./gradlew -Pjdk22_home=${{ matrix.JAVA22_HOME }} -Pllvm_home=/tmp/deps/clang_llvm -Pjtreg_home=./deps/jtreg/build/images/jtreg jtreg
+        sh ./gradlew -Pjdk22_home=${{ matrix.TOOLCHAIN_JAVA_HOME }} -Pllvm_home=/tmp/deps/clang_llvm -Pjtreg_home=./deps/jtreg/build/images/jtreg jtreg


### PR DESCRIPTION
Port of https://github.com/openjdk/jextract/pull/134 + some polish such as using the latest jtreg version, using the latest version of the setup-java and checkout actions, and avoiding use of explicit version numbers in variable names, to avoid having to update all of them again in the future.

Historically we've had the github tests disabled on the panama branch, since we technically require a JDK from that panama-foreign repo.

However, right now there is no difference between the Panama repo and JDK22, so we can use the JDK22 EA binary temporarily, and get some extra GHA testing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/147/head:pull/147` \
`$ git checkout pull/147`

Update a local copy of the PR: \
`$ git checkout pull/147` \
`$ git pull https://git.openjdk.org/jextract.git pull/147/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 147`

View PR using the GUI difftool: \
`$ git pr show -t 147`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/147.diff">https://git.openjdk.org/jextract/pull/147.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/147#issuecomment-1834351081)