### PR TITLE
Add build support for generating Jacoco coverage reports

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -190,27 +190,64 @@ task cmakeBuild(type: Exec) {
     ]
 }
 
-// run jtreg tests. Note: needs jtreg_home variable set to point to the jtreg
-task jtreg(type: JavaExec) {
-    dependsOn createRuntimeImageForTest,cmakeBuild
+void createJtregTask(String name, boolean coverage, String os_lib_dir) {
+    tasks.register(name, JavaExec) {
+        dependsOn createRuntimeImageForTest,cmakeBuild
+
+        doFirst {
+            if (findProperty("jtreg_home") == null) {
+                throw new GradleException("jtreg_home is not defined")
+            }
+            // e.g.: <jacoco repo>/org.jacoco.agent/target/classes/jacocoagent.jar
+            if (coverage && findProperty("jacoco_agent") == null) {
+                throw new GradleException("jacoco_agent is not defined")
+            }
+        }
+
+        workingDir = "$buildDir"
+
+        classpath = files(findProperty("jtreg_home") + "/lib/jtreg.jar")
+
+        args = [
+                "-jdk", "$buildDir/jextract-jdk-test-image",
+                "-nativepath:$buildDir/testlib-install/${os_lib_dir}",
+                "-javaoption:--enable-preview",
+                "-javaoption:--enable-native-access=org.openjdk.jextract,ALL-UNNAMED",
+                "-avm", "-conc:auto", "-verbose:summary",
+                "-retain:fail,error",
+        ]
+
+        if (coverage) {
+            String jacocoAgent = findProperty("jacoco_agent")
+            String coverageFile = "$buildDir/jacoco-run/jextract.exec"
+            String includes = "org.openjdk.jextract.*"
+            args += "-javaoption:-javaagent:$jacocoAgent=destfile=$coverageFile,includes=$includes"
+        }
+
+        args += "../test"
+    }
+}
+
+createJtregTask("jtreg", false, os_lib_dir)
+createJtregTask("jtregWithCoverage", true, os_lib_dir)
+
+task coverage(type: JavaExec) {
+    dependsOn jtregWithCoverage
 
     doFirst {
-        if (findProperty("jtreg_home") == null) {
-            throw new GradleException("jtreg_home is not defined")
+        // e.g.: <jacoco repo>/org.jacoco.cli/target/org.jacoco.cli-0.8.12-SNAPSHOT-nodeps.jar
+        if (findProperty("jacoco_cli") == null) {
+            throw new GradleException("jacoco_cli is not defined")
         }
     }
 
-    workingDir = "$buildDir"
-
-    classpath = files(findProperty("jtreg_home") + "/lib/jtreg.jar")
+    classpath = files(findProperty("jacoco_cli"))
 
     args = [
-            "-jdk", "$buildDir/jextract-jdk-test-image",
-            "-nativepath:$buildDir/testlib-install/${os_lib_dir}",
-            "-javaoption:--enable-preview",
-            "-javaoption:--enable-native-access=org.openjdk.jextract,ALL-UNNAMED",
-            "-avm", "-conc:auto", "-verbose:summary",
-            "-retain:fail,error",
-            "../test"
+            "report",
+            "$buildDir/jacoco-run/jextract.exec",
+            "--classfiles", "$buildDir/classes/java/main",
+            "--sourcefiles", "$projectDir/src/main/java",
+            "--html", "$buildDir/jacoco-report"
     ]
 }

--- a/build.gradle
+++ b/build.gradle
@@ -194,14 +194,12 @@ void createJtregTask(String name, boolean coverage, String os_lib_dir) {
     tasks.register(name, JavaExec) {
         dependsOn createRuntimeImageForTest,cmakeBuild
 
-        doFirst {
-            if (findProperty("jtreg_home") == null) {
-                throw new GradleException("jtreg_home is not defined")
-            }
-            // e.g.: <jacoco repo>/org.jacoco.agent/target/classes/jacocoagent.jar
-            if (coverage && findProperty("jacoco_agent") == null) {
-                throw new GradleException("jacoco_agent is not defined")
-            }
+        if (findProperty("jtreg_home") == null) {
+            throw new GradleException("jtreg_home is not defined")
+        }
+        // e.g.: <jacoco repo>/org.jacoco.agent/target/classes/jacocoagent.jar
+        if (coverage && findProperty("jacoco_agent") == null) {
+            throw new GradleException("jacoco_agent is not defined")
         }
 
         workingDir = "$buildDir"
@@ -231,14 +229,12 @@ void createJtregTask(String name, boolean coverage, String os_lib_dir) {
 createJtregTask("jtreg", false, os_lib_dir)
 createJtregTask("jtregWithCoverage", true, os_lib_dir)
 
-task coverage(type: JavaExec) {
+tasks.register("coverage", JavaExec) {
     dependsOn jtregWithCoverage
 
-    doFirst {
-        // e.g.: <jacoco repo>/org.jacoco.cli/target/org.jacoco.cli-0.8.12-SNAPSHOT-nodeps.jar
-        if (findProperty("jacoco_cli") == null) {
-            throw new GradleException("jacoco_cli is not defined")
-        }
+    // e.g.: <jacoco repo>/org.jacoco.cli/target/org.jacoco.cli-0.8.12-SNAPSHOT-nodeps.jar
+    if (findProperty("jacoco_cli") == null) {
+        throw new GradleException("jacoco_cli is not defined")
     }
 
     classpath = files(findProperty("jacoco_cli"))


### PR DESCRIPTION
Add a new `coverage` gradle task that can be used to generate a Jacoco test coverage report. Because we're on the bleeding edge, the user running the build needs to build Jacoco from source for this to work. Though, this is optional.

As an example: I've cloned Jacoco from here: https://github.com/jacoco/jacoco and built the project using:

    mvn package -DskipTests -Dbytecode.version=22
    
Then, I point gradle at the generated artifacts using:

    jacoco_cli=<jacoco repo>/org.jacoco.cli/target/org.jacoco.cli-0.8.12-SNAPSHOT-nodeps.jar
    jacoco_agent=<jacoco repo>/org.jacoco.agent/target/classes/jacocoagent.jar
    
I've put these in a local `gradle.properties` file instead of passing them on the command line.

I then run `./gradlew coverage` which generates an html coverage report under `./build/jacoco-report`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/153/head:pull/153` \
`$ git checkout pull/153`

Update a local copy of the PR: \
`$ git checkout pull/153` \
`$ git pull https://git.openjdk.org/jextract.git pull/153/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 153`

View PR using the GUI difftool: \
`$ git pr show -t 153`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/153.diff">https://git.openjdk.org/jextract/pull/153.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/153#issuecomment-1839555859)