### PR TITLE
7903609: Jextract can not handle some anonymous nested structs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -211,7 +211,7 @@ void createJtregTask(String name, boolean coverage, String os_lib_dir) {
                 "-nativepath:$buildDir/testlib-install/${os_lib_dir}",
                 "-javaoption:--enable-preview",
                 "-javaoption:--enable-native-access=org.openjdk.jextract,ALL-UNNAMED",
-                "-avm", "-conc:auto", "-verbose:summary",
+                "-avm", "-conc:auto", "-verbose:summary,fail,error",
                 "-retain:fail,error",
         ]
 

--- a/src/main/java/org/openjdk/jextract/impl/DeclarationImpl.java
+++ b/src/main/java/org/openjdk/jextract/impl/DeclarationImpl.java
@@ -322,15 +322,6 @@ public abstract class DeclarationImpl implements Declaration {
         }
     }
 
-    public static OptionalLong recordMemberOffset(Declaration member) {
-        if (member instanceof Variable) {
-            return ClangOffsetOf.get(member);
-        } else {
-            // anonymous struct
-            return AnonymousStruct.getOrThrow((Scoped) member).offset();
-        }
-    }
-
     // attributes
 
     /**

--- a/src/main/java/org/openjdk/jextract/impl/DeclarationImpl.java
+++ b/src/main/java/org/openjdk/jextract/impl/DeclarationImpl.java
@@ -327,10 +327,7 @@ public abstract class DeclarationImpl implements Declaration {
             return ClangOffsetOf.get(member);
         } else {
             // anonymous struct
-            Optional<Declaration> firstDecl = ((Scoped)member).members().stream().findFirst();
-            return firstDecl.isEmpty() ?
-                    OptionalLong.empty() :
-                    recordMemberOffset(firstDecl.get());
+            return AnonymousStruct.getOrThrow((Scoped) member).offset();
         }
     }
 
@@ -339,11 +336,13 @@ public abstract class DeclarationImpl implements Declaration {
     /**
      * An attribute to mark anonymous struct declarations.
      */
-    record AnonymousStruct() {
-        private static final AnonymousStruct INSTANCE = new AnonymousStruct();
+    record AnonymousStruct(OptionalLong offset) {
+        public static void with(Scoped scoped, OptionalLong offset) {
+            scoped.addAttribute(new AnonymousStruct(offset));
+        }
 
-        public static void with(Scoped scoped) {
-            scoped.addAttribute(INSTANCE);
+        public static AnonymousStruct getOrThrow(Scoped scoped) {
+            return scoped.getAttribute(AnonymousStruct.class).orElseThrow();
         }
 
         public static boolean isPresent(Scoped scoped) {

--- a/src/main/java/org/openjdk/jextract/impl/StructBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/StructBuilder.java
@@ -41,6 +41,7 @@ import java.util.ArrayList;
 import java.util.Deque;
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.stream.Collectors;
 
 /**
@@ -276,6 +277,15 @@ final class StructBuilder extends ClassSourceBuilder implements OutputFactory.Bu
         };
     }
 
+    private static long recordMemberOffset(Declaration member) {
+        if (member instanceof Variable) {
+            return ClangOffsetOf.get(member).orElseThrow();
+        } else {
+            // anonymous struct
+            return AnonymousStruct.getOrThrow((Scoped) member).offset().orElseThrow();
+        }
+    }
+
     private String structOrUnionLayoutString(long base, Declaration.Scoped scoped) {
         List<String> memberLayouts = new ArrayList<>();
 
@@ -287,7 +297,7 @@ final class StructBuilder extends ClassSourceBuilder implements OutputFactory.Bu
         long size = 0L; // bits
         for (Declaration member : scoped.members()) {
             if (!Skip.isPresent(member)) {
-                long nextOffset = DeclarationImpl.recordMemberOffset(member).getAsLong();
+                long nextOffset = recordMemberOffset(member);
                 long delta = nextOffset - offset;
                 if (delta > 0) {
                     memberLayouts.add(paddingLayoutString(delta / 8));

--- a/src/main/java/org/openjdk/jextract/impl/StructBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/StructBuilder.java
@@ -34,6 +34,7 @@ import org.openjdk.jextract.impl.DeclarationImpl.ClangAlignOf;
 import org.openjdk.jextract.impl.DeclarationImpl.ClangOffsetOf;
 import org.openjdk.jextract.impl.DeclarationImpl.ClangSizeOf;
 import org.openjdk.jextract.impl.DeclarationImpl.JavaName;
+import org.openjdk.jextract.impl.DeclarationImpl.Skip;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -285,9 +286,7 @@ final class StructBuilder extends ClassSourceBuilder implements OutputFactory.Bu
 
         long size = 0L; // bits
         for (Declaration member : scoped.members()) {
-            if (member instanceof Scoped nested && nested.kind() == Scoped.Kind.BITFIELDS) {
-                // skip
-            } else {
+            if (!Skip.isPresent(member)) {
                 long nextOffset = DeclarationImpl.recordMemberOffset(member).getAsLong();
                 long delta = nextOffset - offset;
                 if (delta > 0) {

--- a/src/main/java/org/openjdk/jextract/impl/TreeMaker.java
+++ b/src/main/java/org/openjdk/jextract/impl/TreeMaker.java
@@ -350,8 +350,12 @@ class TreeMaker {
                     result.set(OptionalLong.of(offsetToOutermost - offsetToAnon));
                     return false;
                 } else if (fc.isAnonymousStruct()) {
-                    result.set(offsetOfAnonymousRecord(outermostParent, anonRecord, fc));
-                    return false;
+                    OptionalLong nestedResult = offsetOfAnonymousRecord(outermostParent, anonRecord, fc);
+                    if (nestedResult.isPresent()) {
+                        result.set(nestedResult);
+                        return false;
+                    }
+                    return true;
                 }
             }
             return true;

--- a/src/main/java/org/openjdk/jextract/impl/TreeMaker.java
+++ b/src/main/java/org/openjdk/jextract/impl/TreeMaker.java
@@ -342,17 +342,19 @@ class TreeMaker {
      */
     private static OptionalLong offsetOfAnonymousRecord(Cursor outermostParent, Cursor anonRecord, Cursor record) {
         AtomicReference<OptionalLong> result = new AtomicReference<>(OptionalLong.empty());
-        record.forEach(fc -> {
-            if (result.get().isPresent()) return;
+        record.forEachShortCircuit(fc -> {
             if (Utils.isFlattenable(fc)) {
                 if (!fc.spelling().isEmpty()) {
                     long offsetToOutermost = outermostParent.type().getOffsetOf(fc.spelling());
                     long offsetToAnon = anonRecord.type().getOffsetOf(fc.spelling());
                     result.set(OptionalLong.of(offsetToOutermost - offsetToAnon));
+                    return false;
                 } else if (fc.isAnonymousStruct()) {
                     result.set(offsetOfAnonymousRecord(outermostParent, anonRecord, fc));
+                    return false;
                 }
             }
+            return true;
         });
         return result.get();
     }

--- a/src/main/java/org/openjdk/jextract/impl/TreeMaker.java
+++ b/src/main/java/org/openjdk/jextract/impl/TreeMaker.java
@@ -318,7 +318,7 @@ class TreeMaker {
         ClangSizeOf.with(structOrUnionDecl, recordCursor.type().size() * 8);
         ClangAlignOf.with(structOrUnionDecl, recordCursor.type().align() * 8);
         if (recordCursor.isAnonymousStruct()) {
-            AnonymousStruct.with(structOrUnionDecl, offsetOfAnonymousStruct(parent, recordCursor, recordCursor));
+            AnonymousStruct.with(structOrUnionDecl, offsetOfAnonymousRecord(parent, recordCursor, recordCursor));
         }
 
         return Type.declared(structOrUnionDecl);
@@ -342,7 +342,7 @@ class TreeMaker {
      *     };
      * };
      */
-    private static OptionalLong offsetOfAnonymousStruct(Cursor outermostParent, Cursor anonRecord, Cursor record) {
+    private static OptionalLong offsetOfAnonymousRecord(Cursor outermostParent, Cursor anonRecord, Cursor record) {
         AtomicReference<OptionalLong> result = new AtomicReference<>(OptionalLong.empty());
         record.forEach(fc -> {
             if (result.get().isPresent()) return;
@@ -352,7 +352,7 @@ class TreeMaker {
                     long offsetToAnon = anonRecord.type().getOffsetOf(fc.spelling());
                     result.set(OptionalLong.of(offsetToOutermost - offsetToAnon));
                 } else if (fc.isAnonymousStruct()) {
-                    result.set(offsetOfAnonymousStruct(outermostParent, anonRecord, fc));
+                    result.set(offsetOfAnonymousRecord(outermostParent, anonRecord, fc));
                 }
             }
         });

--- a/src/main/java/org/openjdk/jextract/impl/TreeMaker.java
+++ b/src/main/java/org/openjdk/jextract/impl/TreeMaker.java
@@ -275,8 +275,7 @@ class TreeMaker {
                     Type fieldType = toType(fc);
                     Variable bitfieldDecl = Declaration.bitfield(CursorPosition.of(fc), fc.spelling(), fc.getBitFieldWidth(), fieldType);
                     if (!fc.spelling().isEmpty()) {
-                        long offset = parent.type().getOffsetOf(fc.spelling());
-                        ClangOffsetOf.with(bitfieldDecl, offset);
+                        ClangOffsetOf.with(bitfieldDecl, parent.type().getOffsetOf(fc.spelling()));
                     }
                     pendingBitFields.add(bitfieldDecl);
                 } else {
@@ -292,8 +291,7 @@ class TreeMaker {
                         Declaration fieldDecl = createTree(fc);
                         ClangSizeOf.with(fieldDecl, fc.type().kind() == TypeKind.IncompleteArray ?
                                 0 : fc.type().size() * 8);
-                        long offset = parent.type().getOffsetOf(fc.spelling());
-                        ClangOffsetOf.with(fieldDecl, offset);
+                        ClangOffsetOf.with(fieldDecl, parent.type().getOffsetOf(fc.spelling()));
                         ClangAlignOf.with(fieldDecl, fc.type().align() * 8);
                         pendingFields.add(fieldDecl);
                     }

--- a/src/main/java/org/openjdk/jextract/impl/UnsupportedFilter.java
+++ b/src/main/java/org/openjdk/jextract/impl/UnsupportedFilter.java
@@ -240,7 +240,7 @@ public class UnsupportedFilter implements Declaration.Visitor<Void, Declaration>
                 return false;
             }
             if (AnonymousStruct.isPresent(scoped) &&
-                    DeclarationImpl.recordMemberOffset(scoped).isEmpty()) {
+                    AnonymousStruct.getOrThrow(scoped).offset().isEmpty()) {
                 return false;
             }
             return true;

--- a/src/main/java/org/openjdk/jextract/impl/UnsupportedFilter.java
+++ b/src/main/java/org/openjdk/jextract/impl/UnsupportedFilter.java
@@ -106,7 +106,7 @@ public class UnsupportedFilter implements Declaration.Visitor<Void, Declaration>
         Type type = varTree.type();
         if (type instanceof Type.Declared declared) {
             // declared type - visit declaration recursively
-            declared.tree().accept(this, null);
+            declared.tree().accept(this, varTree);
         }
 
         Type unsupportedType = firstUnsupportedType(varTree.type(), false);

--- a/test/lib/testlib/JextractToolRunner.java
+++ b/test/lib/testlib/JextractToolRunner.java
@@ -52,7 +52,7 @@ import static org.testng.Assert.fail;
 
 public class JextractToolRunner {
 
-    private static final boolean IS_WINDOWS = System.getProperty("os.name").startsWith("Windows");
+    public static final boolean IS_WINDOWS = System.getProperty("os.name").startsWith("Windows");
 
     public static final ValueLayout.OfBoolean C_BOOL = ValueLayout.JAVA_BOOLEAN;
     public static final ValueLayout.OfByte C_CHAR = ValueLayout.JAVA_BYTE;

--- a/test/testng/org/openjdk/jextract/test/toolprovider/nestedAnonOffset/TestNestedAnonOffset.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/nestedAnonOffset/TestNestedAnonOffset.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.jextract.test.toolprovider.nestedAnonOffset;
+
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import testlib.JextractToolRunner;
+
+import java.lang.foreign.MemoryLayout;
+import java.lang.foreign.StructLayout;
+import java.nio.file.Path;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+public class TestNestedAnonOffset extends JextractToolRunner {
+
+    Loader loader;
+
+    @BeforeClass
+    public void beforeClass() {
+        Path output = getOutputFilePath("TestAnon-anonymousStructs.h");
+        Path outputH = getInputFilePath("anonymousStructs.h");
+        run("--output",
+            output.toString(), outputH.toString()).checkSuccess();
+
+        loader = classLoader(output);
+    }
+
+    @AfterClass
+    public void afterClass() {
+        loader.close();
+    }
+
+    @Test
+    public void testFoo() {
+        Class<?> foo = loader.loadClass("Foo");
+        assertNotNull(foo);
+        StructLayout layout = (StructLayout) findLayout(foo);
+        assertEquals(C_CHAR.withName("c"), layout.memberLayouts().get(0));
+        assertEquals(MemoryLayout.paddingLayout(3), layout.memberLayouts().get(1));
+
+        StructLayout nestedAnon1 = (StructLayout) layout.memberLayouts().get(2);
+        assertEquals(MemoryLayout.paddingLayout(4), nestedAnon1.memberLayouts().get(0));
+
+        StructLayout nestedAnon2 = (StructLayout) nestedAnon1.memberLayouts().get(1);
+        assertEquals(MemoryLayout.paddingLayout(4), nestedAnon2.memberLayouts().get(0));
+        assertEquals(C_INT.withName("x"), nestedAnon2.memberLayouts().get(1));
+    }
+
+    @Test
+    public void testBar() {
+        Class<?> bar = loader.loadClass("Bar");
+        assertNotNull(bar);
+        StructLayout layout = (StructLayout) findLayout(bar);
+        assertEquals(C_CHAR.withName("c"), layout.memberLayouts().get(0));
+        assertEquals(MemoryLayout.paddingLayout(3), layout.memberLayouts().get(1));
+
+        StructLayout nestedAnon1 = (StructLayout) layout.memberLayouts().get(2);
+        assertEquals(MemoryLayout.paddingLayout(4), nestedAnon1.memberLayouts().get(0));
+
+        StructLayout nestedAnon2 = (StructLayout) nestedAnon1.memberLayouts().get(1);
+        assertEquals(MemoryLayout.paddingLayout(4), nestedAnon2.memberLayouts().get(0));
+        assertEquals(C_INT.withName("x"), nestedAnon2.memberLayouts().get(1));
+    }
+}

--- a/test/testng/org/openjdk/jextract/test/toolprovider/nestedAnonOffset/TestNestedAnonOffset.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/nestedAnonOffset/TestNestedAnonOffset.java
@@ -91,6 +91,7 @@ public class TestNestedAnonOffset extends JextractToolRunner {
         assertNotNull(baz);
         StructLayout layout = (StructLayout) findLayout(baz);
         assertEquals(layout.memberLayouts().get(0), C_CHAR.withName("c"));
-        assertEquals(layout.memberLayouts().get(1), MemoryLayout.paddingLayout(11));
+        // Note here: only on Windows, the bitfield needs to be aligned and requires more padding
+        assertEquals(layout.memberLayouts().get(1), MemoryLayout.paddingLayout(IS_WINDOWS ? 11 : 8));
     }
 }

--- a/test/testng/org/openjdk/jextract/test/toolprovider/nestedAnonOffset/TestNestedAnonOffset.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/nestedAnonOffset/TestNestedAnonOffset.java
@@ -94,4 +94,19 @@ public class TestNestedAnonOffset extends JextractToolRunner {
         // Note here: only on Windows, the bitfield needs to be aligned and requires more padding
         assertEquals(layout.memberLayouts().get(1), MemoryLayout.paddingLayout(IS_WINDOWS ? 11 : 8));
     }
+
+    @Test
+    public void testBoo() {
+        Class<?> boo = loader.loadClass("Boo");
+        assertNotNull(boo);
+        StructLayout layout = (StructLayout) findLayout(boo);
+        assertEquals(layout.memberLayouts().get(0), C_CHAR.withName("c"));
+        assertEquals(layout.memberLayouts().get(1), MemoryLayout.paddingLayout(3));
+
+        StructLayout nestedAnon1 = (StructLayout) layout.memberLayouts().get(2);
+        assertEquals(nestedAnon1.memberLayouts().get(0), MemoryLayout.paddingLayout(8));
+
+        StructLayout nestedAnon2 = (StructLayout) nestedAnon1.memberLayouts().get(1);
+        assertEquals(nestedAnon2.memberLayouts().get(0), C_INT.withName("x"));
+    }
 }

--- a/test/testng/org/openjdk/jextract/test/toolprovider/nestedAnonOffset/TestNestedAnonOffset.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/nestedAnonOffset/TestNestedAnonOffset.java
@@ -29,6 +29,7 @@ import testlib.JextractToolRunner;
 
 import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.StructLayout;
+import java.lang.foreign.UnionLayout;
 import java.nio.file.Path;
 
 import static org.testng.Assert.assertEquals;
@@ -58,15 +59,15 @@ public class TestNestedAnonOffset extends JextractToolRunner {
         Class<?> foo = loader.loadClass("Foo");
         assertNotNull(foo);
         StructLayout layout = (StructLayout) findLayout(foo);
-        assertEquals(C_CHAR.withName("c"), layout.memberLayouts().get(0));
-        assertEquals(MemoryLayout.paddingLayout(3), layout.memberLayouts().get(1));
+        assertEquals(layout.memberLayouts().get(0), C_CHAR.withName("c"));
+        assertEquals(layout.memberLayouts().get(1), MemoryLayout.paddingLayout(3));
 
         StructLayout nestedAnon1 = (StructLayout) layout.memberLayouts().get(2);
-        assertEquals(MemoryLayout.paddingLayout(4), nestedAnon1.memberLayouts().get(0));
+        assertEquals(nestedAnon1.memberLayouts().get(0), MemoryLayout.paddingLayout(4));
 
         StructLayout nestedAnon2 = (StructLayout) nestedAnon1.memberLayouts().get(1);
-        assertEquals(MemoryLayout.paddingLayout(4), nestedAnon2.memberLayouts().get(0));
-        assertEquals(C_INT.withName("x"), nestedAnon2.memberLayouts().get(1));
+        assertEquals(nestedAnon2.memberLayouts().get(0), MemoryLayout.paddingLayout(4));
+        assertEquals(nestedAnon2.memberLayouts().get(1), C_INT.withName("x"));
     }
 
     @Test
@@ -74,14 +75,22 @@ public class TestNestedAnonOffset extends JextractToolRunner {
         Class<?> bar = loader.loadClass("Bar");
         assertNotNull(bar);
         StructLayout layout = (StructLayout) findLayout(bar);
-        assertEquals(C_CHAR.withName("c"), layout.memberLayouts().get(0));
-        assertEquals(MemoryLayout.paddingLayout(3), layout.memberLayouts().get(1));
+        assertEquals(layout.memberLayouts().get(0), C_CHAR.withName("c"));
+        assertEquals(layout.memberLayouts().get(1), MemoryLayout.paddingLayout(3));
 
         StructLayout nestedAnon1 = (StructLayout) layout.memberLayouts().get(2);
-        assertEquals(MemoryLayout.paddingLayout(4), nestedAnon1.memberLayouts().get(0));
+        assertEquals(nestedAnon1.memberLayouts().get(0), MemoryLayout.paddingLayout(4));
 
-        StructLayout nestedAnon2 = (StructLayout) nestedAnon1.memberLayouts().get(1);
-        assertEquals(MemoryLayout.paddingLayout(4), nestedAnon2.memberLayouts().get(0));
-        assertEquals(C_INT.withName("x"), nestedAnon2.memberLayouts().get(1));
+        UnionLayout nestedAnon2 = (UnionLayout) nestedAnon1.memberLayouts().get(1);
+        assertEquals(nestedAnon2.memberLayouts().get(0), C_INT.withName("x"));
+    }
+
+    @Test
+    public void testBaz() {
+        Class<?> baz = loader.loadClass("Baz");
+        assertNotNull(baz);
+        StructLayout layout = (StructLayout) findLayout(baz);
+        assertEquals(layout.memberLayouts().get(0), C_CHAR.withName("c"));
+        assertEquals(layout.memberLayouts().get(1), MemoryLayout.paddingLayout(11));
     }
 }

--- a/test/testng/org/openjdk/jextract/test/toolprovider/nestedAnonOffset/anonymousStructs.h
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/nestedAnonOffset/anonymousStructs.h
@@ -45,9 +45,9 @@ struct Bar {
 
 struct Baz {
     char c;
-    struct {
+    struct { // should be skipped
         int: 32;
-        union {
+        struct {
             int: 32;
         };
     };

--- a/test/testng/org/openjdk/jextract/test/toolprovider/nestedAnonOffset/anonymousStructs.h
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/nestedAnonOffset/anonymousStructs.h
@@ -52,3 +52,16 @@ struct Baz {
         };
     };
 };
+
+struct Boo {
+    char c;
+    struct { // should have offset
+        int: 32;
+        struct { // should be skipped
+            int: 32;
+        };
+        struct {
+            int x; // named field in second
+        };
+    };
+};

--- a/test/testng/org/openjdk/jextract/test/toolprovider/nestedAnonOffset/anonymousStructs.h
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/nestedAnonOffset/anonymousStructs.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+struct Foo {
+    char c;
+    struct {
+        int: 32;
+        struct {
+            int: 32;
+            int x;
+        };
+    };
+};
+
+struct Bar {
+    char c;
+    struct {
+        int: 32;
+        union {
+            int: 32;
+            int x;
+        };
+    };
+};
+
+struct Baz {
+    char c;
+    struct {
+        int: 32;
+        union {
+            int: 32;
+        };
+    };
+};


### PR DESCRIPTION
Improve the handling of nested anonymous records (structs and unions).

The current way in which we find the offset of a nested anonymous record is by getting the offset of the first field relative to the first named (or unnamed outermost) parent. However, if the first field doesn't have a name, we bail out, as getting the offset of an unnamed field is not supported by libclang.

But, we can reliably compute the offset of a nested anonymous record that has at least one named field nested somewhere inside of it, by: 1.) getting the offset of the named field to the first named parent record. 2.) getting the offset of the first named field to the anonymous record for which we want to know the offset (also nested inside the same named parent). 3.) computing the offset of the anonymous record by subtracting the offset found in 2. by the offset found in 1.

This is also sufficient to address cases like these:

     struct Foo {
         char c; // offset = 0
         struct <anon1> { // offset = 96 - 64 = 32
             int: 32;
             struct <anon2> { // offset = 96 - 32 = 64
                 int: 32;
                 int x; // offset(Foo) = 96, offset(anon2) = 32, offset(anon1) = 64
             };
         };
     };

This offset is attached through the `AnonymousStruct` attribute during parsing (which is where we have the Cursors needed to compute these offsets).

Furthermore, this PR contains some additional improvements:
- We were manually skipping `BITFIELDS` scoped declaration in the record layout generating code. I've changed this to use a `Skip` that is added to the BITFIELDS declaration, rather than to the individual bitfields inside of it. We can then just look for the `Skip` when generating the layout, and that also handles skipped nested anonymous records correctly (which don't have any named fields).
- I also noticed that we don't print out the name of a skipped bitfield correctly, because we use the name of the immediate parent to generated the name of the field, which for a bitfield is always empty, since the immediate parent is a scoped BITFIELDS decl. This resulted in warnings about e.g. `.a` being skipped. I'm now propagating the first named parent instead of the immediate parent, which can then be used to generate a valid field name.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Issue
 * [CODETOOLS-7903609](https://bugs.openjdk.org/browse/CODETOOLS-7903609): Jextract can not handle some anonymous nested structs (**Bug** - P3)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/159/head:pull/159` \
`$ git checkout pull/159`

Update a local copy of the PR: \
`$ git checkout pull/159` \
`$ git pull https://git.openjdk.org/jextract.git pull/159/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 159`

View PR using the GUI difftool: \
`$ git pr show -t 159`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/159.diff">https://git.openjdk.org/jextract/pull/159.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/159#issuecomment-1854272943)