### PR TITLE
7903608: Cyclic initialization leads to NPE in header class with global variable

### DIFF
--- a/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
@@ -67,7 +67,7 @@ class HeaderFileBuilder extends ClassSourceBuilder {
             emitGlobalSetter(segmentConstant, layoutVar, javaName, varTree, "Setter for variable:");
             fiName.ifPresent(s -> emitFunctionalInterfaceGetter(s, javaName));
         } else {
-            throw new IllegalArgumentException("Tree type not handled: " + varTree.type());        
+            throw new IllegalArgumentException("Tree type not handled: " + varTree.type());
         }
     }
 

--- a/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
@@ -356,9 +356,7 @@ class HeaderFileBuilder extends ClassSourceBuilder {
             private static final \{javaType.getSimpleName()} \{constantName} = \{constantValue(javaType, value)};
 
             """);
-        if (declaration != null) {
-            emitDocComment(declaration);
-        }
+        emitDocComment(declaration);
         appendLines(STR."""
             \{MEMBER_MODS} \{javaType.getSimpleName()} \{constantName}() {
                 return \{constantName};
@@ -410,9 +408,7 @@ class HeaderFileBuilder extends ClassSourceBuilder {
 
     private void emitPrimitiveTypedefLayout(String javaName, Type type, Declaration declaration) {
         incrAlign();
-        if (declaration != null) {
-            emitDocComment(declaration);
-        }
+        emitDocComment(declaration);
         appendLines(STR."""
         public static final \{Utils.layoutCarrierFor(type).getSimpleName()} \{javaName} = \{layoutString(type)};
         """);

--- a/src/main/java/org/openjdk/jextract/impl/SourceFileBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/SourceFileBuilder.java
@@ -113,8 +113,12 @@ final class SourceFileBuilder {
         return align;
     }
 
+    public JavaFileObject toFile(String suffix, Function<String, String> finisher) {
+        return Utils.fileFromString(packageName, STR."\{className}\{suffix}", finisher.apply(sb.toString()));
+    }
+
     public JavaFileObject toFile(Function<String, String> finisher) {
-        return Utils.fileFromString(packageName, className, finisher.apply(sb.toString()));
+        return toFile("", finisher);
     }
 
     public JavaFileObject toFile() {

--- a/src/main/java/org/openjdk/jextract/impl/StructBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/StructBuilder.java
@@ -244,9 +244,9 @@ final class StructBuilder extends ClassSourceBuilder implements OutputFactory.Bu
 
     private void emitLayoutDecl() {
         appendIndentedLines(STR."""
-            private static final MemoryLayout $LAYOUT = \{structOrUnionLayoutString(structType)};
+            private static final GroupLayout $LAYOUT = \{structOrUnionLayoutString(structType)};
 
-            public static final MemoryLayout $LAYOUT() {
+            public static final GroupLayout $LAYOUT() {
                 return $LAYOUT;
             }
             """);

--- a/src/main/java/org/openjdk/jextract/impl/ToplevelBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/ToplevelBuilder.java
@@ -108,7 +108,7 @@ class ToplevelBuilder implements OutputFactory.Builder {
                 .map(SourceFileBuilder::toFile).toList());
         return files;
     }
-    
+
     public String mainHeaderClassName() {
         return headerDesc.displayName();
     }

--- a/src/main/java/org/openjdk/jextract/impl/ToplevelBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/ToplevelBuilder.java
@@ -97,8 +97,9 @@ class ToplevelBuilder implements OutputFactory.Builder {
                         "" : // main header class, drop the suffix
                         STR."_\{suffix}";
                 String prevSuffix = STR."_\{suffix + 1}";
-                files.add(header.toFile(currentSuffix, s -> s.replace("#{SUFFIX}", currentSuffix)
-                        .replace("#{PREV_SUFFIX}", prevSuffix)));
+                files.add(header.toFile(currentSuffix,
+                        s -> s.replace("#{SUFFIX}", currentSuffix)
+                              .replace("#{PREV_SUFFIX}", prevSuffix)));
                 suffix--;
             }
         }

--- a/src/main/java/org/openjdk/jextract/impl/Utils.java
+++ b/src/main/java/org/openjdk/jextract/impl/Utils.java
@@ -27,6 +27,7 @@
 package org.openjdk.jextract.impl;
 
 import org.openjdk.jextract.Declaration;
+import org.openjdk.jextract.Declaration.Constant;
 import org.openjdk.jextract.Type;
 import org.openjdk.jextract.Type.Delegated;
 import org.openjdk.jextract.Type.Delegated.Kind;
@@ -38,7 +39,9 @@ import javax.tools.JavaFileObject;
 import javax.tools.SimpleJavaFileObject;
 import java.lang.foreign.AddressLayout;
 import java.io.IOException;
+import java.lang.foreign.GroupLayout;
 import java.lang.foreign.MemorySegment;
+import java.lang.foreign.SequenceLayout;
 import java.lang.foreign.ValueLayout;
 import java.lang.invoke.MethodType;
 import java.net.URI;
@@ -227,15 +230,19 @@ class Utils {
         };
     }
 
-    public static Class<?> valueLayoutCarrierFor(Type t) {
-        if (t instanceof Delegated delegated && delegated.kind() == Delegated.Kind.POINTER) {
-            return AddressLayout.class;
-        } else if (t instanceof Type.Primitive p) {
-            Class<?> clazz = carrierFor(p);
-            return CARRIERS_TO_LAYOUT_CARRIERS.get(clazz);
-        } else {
-            throw new UnsupportedOperationException(t.toString());
-        }
+    public static Class<?> layoutCarrierFor(Type t) {
+        return switch (t) {
+            case Type.Array _ -> SequenceLayout.class;
+            case Delegated delegated when delegated.kind() == Kind.POINTER -> AddressLayout.class;
+            case Delegated delegated -> layoutCarrierFor(delegated.type());
+            case Type.Primitive primitive -> {
+                Class<?> clazz = carrierFor(primitive);
+                yield CARRIERS_TO_LAYOUT_CARRIERS.get(clazz);
+            }
+            case Type.Declared declared when isStructOrUnion(declared) -> GroupLayout.class;
+            case Type.Declared declared when isEnum(declared) -> layoutCarrierFor(((Constant)declared.tree().members().get(0)).type());
+            default -> throw new UnsupportedOperationException(t.toString());
+        };
     }
 
     static final Map<Class<?>, Class<?>> CARRIERS_TO_LAYOUT_CARRIERS = Map.of(

--- a/test/jtreg/generator/clinitCycles/TestGlobal.java
+++ b/test/jtreg/generator/clinitCycles/TestGlobal.java
@@ -31,14 +31,14 @@ import java.lang.foreign.ValueLayout;
 /*
  * @test id=classes
  * @library /lib
- * @run main/othervm JtregJextract -l Func -t test.jextract.clinit -Djextract.decls.per.header=1 clinit_global.h
+ * @run main/othervm JtregJextract -t test.jextract.clinit -Djextract.decls.per.header=1 clinit_global.h
  * @build TestGlobal
  * @run testng/othervm --enable-native-access=ALL-UNNAMED TestGlobal
  */
 /*
  * @test id=sources
  * @library /lib
- * @run main/othervm JtregJextractSources -l Func -t test.jextract.clinit -Djextract.decls.per.header=1 clinit_global.h
+ * @run main/othervm JtregJextractSources -t test.jextract.clinit -Djextract.decls.per.header=1 clinit_global.h
  * @build TestGlobal
  * @run testng/othervm --enable-native-access=ALL-UNNAMED TestGlobal
  */

--- a/test/jtreg/generator/clinitCycles/TestGlobal.java
+++ b/test/jtreg/generator/clinitCycles/TestGlobal.java
@@ -1,0 +1,54 @@
+/* Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+import test.jextract.clinit.*;
+
+import java.lang.foreign.ValueLayout;
+
+/*
+ * @test id=classes
+ * @library /lib
+ * @run main/othervm JtregJextract -l Func -t test.jextract.clinit -Djextract.decls.per.header=1 clinit_global.h
+ * @build TestGlobal
+ * @run testng/othervm --enable-native-access=ALL-UNNAMED TestGlobal
+ */
+/*
+ * @test id=sources
+ * @library /lib
+ * @run main/othervm JtregJextractSources -l Func -t test.jextract.clinit -Djextract.decls.per.header=1 clinit_global.h
+ * @build TestGlobal
+ * @run testng/othervm --enable-native-access=ALL-UNNAMED TestGlobal
+ */
+public class TestGlobal {
+
+    @Test
+    public void testGlobal() {
+        ValueLayout layout = clinit_global_h.C_INT;
+        assertNotNull(layout);
+        assertEquals(layout, clinit_global_h.global1$LAYOUT());
+        assertEquals(layout, clinit_global_h.global2$LAYOUT());
+    }
+}

--- a/test/jtreg/generator/clinitCycles/TestStruct.java
+++ b/test/jtreg/generator/clinitCycles/TestStruct.java
@@ -31,14 +31,14 @@ import static org.testng.Assert.*;
 /*
  * @test id=classes
  * @library /lib
- * @run main/othervm JtregJextract -l Func -t test.jextract.clinit -Djextract.decls.per.header=1 clinit_struct.h
+ * @run main/othervm JtregJextract -t test.jextract.clinit -Djextract.decls.per.header=1 clinit_struct.h
  * @build TestStruct
  * @run testng/othervm --enable-native-access=ALL-UNNAMED TestStruct
  */
 /*
  * @test id=sources
  * @library /lib
- * @run main/othervm JtregJextractSources -l Func -t test.jextract.clinit -Djextract.decls.per.header=1 clinit_struct.h
+ * @run main/othervm JtregJextractSources -t test.jextract.clinit -Djextract.decls.per.header=1 clinit_struct.h
  * @build TestStruct
  * @run testng/othervm --enable-native-access=ALL-UNNAMED TestStruct
  */

--- a/test/jtreg/generator/clinitCycles/TestStruct.java
+++ b/test/jtreg/generator/clinitCycles/TestStruct.java
@@ -1,0 +1,56 @@
+/* Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import org.testng.annotations.Test;
+import test.jextract.clinit.*;
+
+import java.lang.foreign.GroupLayout;
+import java.lang.foreign.ValueLayout;
+
+import static org.testng.Assert.*;
+
+/*
+ * @test id=classes
+ * @library /lib
+ * @run main/othervm JtregJextract -l Func -t test.jextract.clinit -Djextract.decls.per.header=1 clinit_struct.h
+ * @build TestStruct
+ * @run testng/othervm --enable-native-access=ALL-UNNAMED TestStruct
+ */
+/*
+ * @test id=sources
+ * @library /lib
+ * @run main/othervm JtregJextractSources -l Func -t test.jextract.clinit -Djextract.decls.per.header=1 clinit_struct.h
+ * @build TestStruct
+ * @run testng/othervm --enable-native-access=ALL-UNNAMED TestStruct
+ */
+public class TestStruct {
+
+    @Test
+    public void TestStruct() {
+        ValueLayout layout = clinit_struct_h.C_INT;
+        assertNotNull(layout);
+        GroupLayout pointLayout = Point.$LAYOUT();
+        assertNotNull(pointLayout);
+        assertEquals(pointLayout.memberLayouts().get(0).withoutName(), layout);
+        assertEquals(pointLayout.memberLayouts().get(1).withoutName(), layout);
+    }
+}

--- a/test/jtreg/generator/clinitCycles/TestTypedef.java
+++ b/test/jtreg/generator/clinitCycles/TestTypedef.java
@@ -1,0 +1,55 @@
+/* Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+import test.jextract.clinit.*;
+
+import java.lang.foreign.ValueLayout;
+
+/*
+ * @test id=classes
+ * @library /lib
+ * @run main/othervm JtregJextract -l Func -t test.jextract.clinit -Djextract.decls.per.header=1 clinit_typedef.h
+ * @build TestTypedef
+ * @run testng/othervm --enable-native-access=ALL-UNNAMED TestTypedef
+ */
+/*
+ * @test id=sources
+ * @library /lib
+ * @run main/othervm JtregJextractSources -l Func -t test.jextract.clinit -Djextract.decls.per.header=1 clinit_typedef.h
+ * @build TestTypedef
+ * @run testng/othervm --enable-native-access=ALL-UNNAMED TestTypedef
+ */
+public class TestTypedef {
+
+    @Test
+    public void TestTypedef() {
+        ValueLayout layout = clinit_typedef_h.C_INT;
+        assertNotNull(layout);
+        assertEquals(layout, clinit_typedef_h.one);
+        assertEquals(layout, clinit_typedef_h.two);
+        assertEquals(layout, clinit_typedef_h.three);
+    }
+}

--- a/test/jtreg/generator/clinitCycles/TestTypedef.java
+++ b/test/jtreg/generator/clinitCycles/TestTypedef.java
@@ -38,7 +38,7 @@ import java.lang.foreign.ValueLayout;
 /*
  * @test id=sources
  * @library /lib
- * @run main/othervm JtregJextractSources -l Func -t test.jextract.clinit -Djextract.decls.per.header=1 clinit_typedef.h
+ * @run main/othervm JtregJextractSources -t test.jextract.clinit -Djextract.decls.per.header=1 clinit_typedef.h
  * @build TestTypedef
  * @run testng/othervm --enable-native-access=ALL-UNNAMED TestTypedef
  */

--- a/test/jtreg/generator/clinitCycles/clinit_global.h
+++ b/test/jtreg/generator/clinitCycles/clinit_global.h
@@ -1,0 +1,30 @@
+/* Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#ifdef _WIN64
+#define EXPORT __declspec(dllexport)
+#else
+#define EXPORT
+#endif
+
+EXPORT int global1;
+EXPORT int global2;

--- a/test/jtreg/generator/clinitCycles/clinit_struct.h
+++ b/test/jtreg/generator/clinitCycles/clinit_struct.h
@@ -1,0 +1,26 @@
+/* Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+struct Point {
+   int x;
+   int y;
+};

--- a/test/jtreg/generator/clinitCycles/clinit_typedef.h
+++ b/test/jtreg/generator/clinitCycles/clinit_typedef.h
@@ -1,0 +1,25 @@
+/* Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+typedef int one;
+typedef one two;
+typedef two three;

--- a/test/jtreg/generator/packed/TestPackedStructs.java
+++ b/test/jtreg/generator/packed/TestPackedStructs.java
@@ -40,7 +40,7 @@ import test.jextract.packedstructs.*;
 /*
  * @test id=sources
  * @library /lib
- * @run main/othervm JtregJextractSources -l Func -t test.jextract.packedstructs packedstructs.h
+ * @run main/othervm JtregJextractSources -t test.jextract.packedstructs packedstructs.h
  * @build TestPackedStructs
  * @run testng/othervm --enable-native-access=ALL-UNNAMED TestPackedStructs
  */

--- a/test/lib/testlib/JextractToolRunner.java
+++ b/test/lib/testlib/JextractToolRunner.java
@@ -235,7 +235,7 @@ public class JextractToolRunner {
     protected Method checkMethod(Class<?> cls, String name, Class<?> returnType, Class<?>... args) {
         Method m = findMethod(cls, name, args);
         assertNotNull(m);
-        assertEquals(m.getReturnType(), returnType);
+        assertTrue(returnType.isAssignableFrom(m.getReturnType())); // tolerate more specific type
         assertEquals(m.getParameterTypes(), args);
         return m;
     }
@@ -243,7 +243,7 @@ public class JextractToolRunner {
     protected static MemoryLayout findLayout(Class<?> cls, String name) {
         Method method = findMethod(cls, name + "$LAYOUT");
         assertNotNull(method);
-        assertEquals(method.getReturnType(), MemoryLayout.class);
+        assertTrue(MemoryLayout.class.isAssignableFrom(method.getReturnType()));
         try {
             return (MemoryLayout)method.invoke(null);
         } catch (Exception exp) {

--- a/test/testng/org/openjdk/jextract/test/toolprovider/TestClassGeneration.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/TestClassGeneration.java
@@ -170,10 +170,8 @@ public class TestClassGeneration extends JextractToolRunner {
         Method addr_getter = checkMethod(cls, name + "$SEGMENT", MemorySegment.class);
         MemorySegment segment = (MemorySegment)addr_getter.invoke(null);
 
-        Method vh_getter = checkMethod(cls, name + "$VH", VarHandle.class);
-        VarHandle vh = (VarHandle) vh_getter.invoke(null);
-        assertEquals(vh.varType(), expectedType);
-        assertEquals(vh.get(segment, 0L), expectedValue);
+        Method getter = checkMethod(cls, name + "$get", expectedType);
+        assertEquals(getter.invoke(segment), expectedValue);
 
         checkMethod(cls, name + "$get", expectedType);
         checkMethod(cls, name + "$set", void.class, expectedType);


### PR DESCRIPTION
This PR fixes some new static initialization cycles that have been made possible by (a) the removal of constant classes and (b) the fact that we refer to struct layouts by name.

The fix consists in two parts:

* First, we make sure that whenever the header class needs to reference another layout, we do so behind a holder class idiom (this patch only touches globals, as all other cases are already using the holder idiom)

* Secondly, we invert the inheritance order of header classes (this is only relevant when using header file splitting). In the current order, symbols that are found "later" in the header files, are added in classes that are "higher up" in the inheritance chain. This leads to issues, as you can have e.g. a primitive typedef depending on a previous primitive typedef, which is in reality defined in a subclass (which leads to a cycle).

Since I was there, I decided to simplify the logic for global variables, and make it more uniform with the rest: now we only emit an accessor for the global segment and a layout. We no longer emit a var handle accessor - developers have all they need to get one. Global vars setters/getters have also been simplified to just use memory segment accessors.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Issue
 * [CODETOOLS-7903608](https://bugs.openjdk.org/browse/CODETOOLS-7903608): Cyclic initialization leads to NPE in header class with global variable (**Bug** - P3)


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/160/head:pull/160` \
`$ git checkout pull/160`

Update a local copy of the PR: \
`$ git checkout pull/160` \
`$ git pull https://git.openjdk.org/jextract.git pull/160/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 160`

View PR using the GUI difftool: \
`$ git pr show -t 160`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/160.diff">https://git.openjdk.org/jextract/pull/160.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/160#issuecomment-1855775267)