### PR TITLE
7903610: Missing handling for array fields with inline struct declaration

### DIFF
--- a/src/main/java/org/openjdk/jextract/impl/EnumConstantLifter.java
+++ b/src/main/java/org/openjdk/jextract/impl/EnumConstantLifter.java
@@ -59,7 +59,7 @@ final class EnumConstantLifter implements Declaration.Visitor<Void, Void> {
     @Override
     public Void visitTypedef(Declaration.Typedef tree, Void ignored) {
         Type type = tree.type();
-        if (type instanceof Type.Declared declared && Utils.isEnum(declared)) {
+        if (Utils.declarationFor(type).map(Utils::isEnum).orElse(false)) {
             // no need to do anything for a typedef enum, as the IR always
             // lifts the enum tree before the typedef.
             Skip.with(tree);

--- a/src/main/java/org/openjdk/jextract/impl/NameMangler.java
+++ b/src/main/java/org/openjdk/jextract/impl/NameMangler.java
@@ -185,9 +185,7 @@ final class NameMangler implements Declaration.Visitor<Void, Declaration> {
         }
 
         // handle if this typedef is of a struct/union/enum etc.
-        if (typedef.type() instanceof Type.Declared declared) {
-            declared.tree().accept(this, typedef);
-        }
+        Utils.declarationFor(typedef.type()).ifPresent(s -> s.accept(this, typedef));
 
         // We may potentially generate a class for a typedef. Make sure
         // class name is unique in the current nesting context.
@@ -205,10 +203,7 @@ final class NameMangler implements Declaration.Visitor<Void, Declaration> {
     public Void visitVariable(Declaration.Variable variable, Declaration parent) {
         JavaName.with(variable, makeJavaName(variable));
         var type = variable.type();
-        if (type instanceof Type.Declared declared) {
-            // declared type - visit declaration recursively
-            declared.tree().accept(this, variable);
-        }
+        Utils.declarationFor(type).ifPresent(s -> s.accept(this, variable));
         Type.Function func = Utils.getAsFunctionPointer(type);
         if (func != null) {
             String fiName = curScope.uniqueNestedClassName(variable.name());

--- a/src/main/java/org/openjdk/jextract/impl/UnsupportedFilter.java
+++ b/src/main/java/org/openjdk/jextract/impl/UnsupportedFilter.java
@@ -98,10 +98,7 @@ public class UnsupportedFilter implements Declaration.Visitor<Void, Declaration>
     @Override
     public Void visitVariable(Variable varTree, Declaration parent) {
         Type type = varTree.type();
-        if (type instanceof Type.Declared declared) {
-            // declared type - visit declaration recursively
-            declared.tree().accept(this, varTree);
-        }
+        Utils.declarationFor(type).ifPresent(s -> s.accept(this, varTree));
 
         Type unsupportedType = firstUnsupportedType(varTree.type(), false);
         String name = parent != null ? parent.name() + "." : "";

--- a/src/main/java/org/openjdk/jextract/impl/Utils.java
+++ b/src/main/java/org/openjdk/jextract/impl/Utils.java
@@ -43,6 +43,7 @@ import java.lang.foreign.ValueLayout;
 import java.lang.invoke.MethodType;
 import java.net.URI;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * General utility functions
@@ -103,6 +104,15 @@ class Utils {
                 ? String.valueOf(ch)
                 : String.format("\\u%04x", (int) ch);
         }
+    }
+
+    static Optional<Declaration.Scoped> declarationFor(Type type) {
+        return switch (type) {
+            case Type.Declared declared -> Optional.of(declared.tree());
+            case Type.Array array -> declarationFor(array.elementType());
+            case Delegated delegated when delegated.kind() != Kind.POINTER -> declarationFor(delegated.type());
+            default -> Optional.empty();
+        };
     }
 
     static boolean isStructOrUnion(Declaration declaration) {

--- a/test/jtreg/generator/nestedTypes/TestNestedTypes.java
+++ b/test/jtreg/generator/nestedTypes/TestNestedTypes.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.lang.foreign.GroupLayout;
+import java.lang.foreign.MemoryLayout;
+import java.lang.foreign.SequenceLayout;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+import test.jextract.nestedtypes.*;
+
+/*
+ * @test id=classes
+ * @library /lib
+ * @run main/othervm JtregJextract -l Func -t test.jextract.nestedtypes nested_types.h
+ * @build TestNestedTypes
+ * @run testng/othervm --enable-native-access=ALL-UNNAMED TestNestedTypes
+ */
+/*
+ * @test id=sources
+ * @library /lib
+ * @run main/othervm JtregJextractSources -l Func -t test.jextract.nestedtypes nested_types.h
+ * @build TestNestedTypes
+ * @run testng/othervm --enable-native-access=ALL-UNNAMED TestNestedTypes
+ */
+public class TestNestedTypes {
+
+    @Test
+    public void testNestedTypes() {
+        checkNestedLayout(NestedStructArray.$LAYOUT());
+        checkNestedLayout(NestedStructArrayTypedef.$LAYOUT());
+        checkNestedLayout(NestedStructArrayTypedefTypedef.$LAYOUT());
+    }
+
+    void checkNestedLayout(MemoryLayout layout) {
+        MemoryLayout nestedLayout = ((GroupLayout)layout).memberLayouts().get(0);
+        assertEquals(nestedLayout.name().get(), "nested");
+        assertTrue(nestedLayout instanceof SequenceLayout);
+        assertEquals(((SequenceLayout)nestedLayout).elementCount(), 1);
+        assertEquals(((SequenceLayout)nestedLayout).elementLayout().withoutName(), ELEM_NESTED_LAYOUT);
+    }
+
+    static final MemoryLayout ELEM_NESTED_LAYOUT = MemoryLayout.structLayout(nested_types_h.C_INT.withName("x"));
+}

--- a/test/jtreg/generator/nestedTypes/TestNestedTypes.java
+++ b/test/jtreg/generator/nestedTypes/TestNestedTypes.java
@@ -34,14 +34,14 @@ import test.jextract.nestedtypes.*;
 /*
  * @test id=classes
  * @library /lib
- * @run main/othervm JtregJextract -l Func -t test.jextract.nestedtypes nested_types.h
+ * @run main/othervm JtregJextract -t test.jextract.nestedtypes nested_types.h
  * @build TestNestedTypes
  * @run testng/othervm --enable-native-access=ALL-UNNAMED TestNestedTypes
  */
 /*
  * @test id=sources
  * @library /lib
- * @run main/othervm JtregJextractSources -l Func -t test.jextract.nestedtypes nested_types.h
+ * @run main/othervm JtregJextractSources -t test.jextract.nestedtypes nested_types.h
  * @build TestNestedTypes
  * @run testng/othervm --enable-native-access=ALL-UNNAMED TestNestedTypes
  */

--- a/test/jtreg/generator/nestedTypes/nested_types.h
+++ b/test/jtreg/generator/nestedTypes/nested_types.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+struct NestedStructArray {
+    struct {
+		int x;
+    } nested[1];
+};
+
+typedef struct {
+    int x;
+} T;
+
+struct NestedStructArrayTypedef {
+    T nested[1];
+};
+
+typedef T U;
+
+struct NestedStructArrayTypedefTypedef {
+    U nested[1];
+};

--- a/test/jtreg/generator/nestedTypes/nested_types.h
+++ b/test/jtreg/generator/nestedTypes/nested_types.h
@@ -23,7 +23,7 @@
 
 struct NestedStructArray {
     struct {
-		int x;
+        int x;
     } nested[1];
 };
 


### PR DESCRIPTION
This patch adds a new method in `Utils` which helps visitors to obtain a scoped declaration given a type. This is used whenever the visitor logic needs to recurse on a declared type e.g. in a variable, or a typedef. The current logic only tests for `Type.Declared` and, in doing so, misses some cases, such as arrays and typedefs which point back to a declared type.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Issue
 * [CODETOOLS-7903610](https://bugs.openjdk.org/browse/CODETOOLS-7903610): Missing handling for array fields with inline struct declaration (**Bug** - P3)


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/161/head:pull/161` \
`$ git checkout pull/161`

Update a local copy of the PR: \
`$ git checkout pull/161` \
`$ git pull https://git.openjdk.org/jextract.git pull/161/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 161`

View PR using the GUI difftool: \
`$ git pr show -t 161`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/161.diff">https://git.openjdk.org/jextract/pull/161.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/161#issuecomment-1855789795)