### PR TITLE
7903239: ofAddress factory of function pointer type is wrong for struct returns

### DIFF
--- a/src/main/java/org/openjdk/jextract/impl/FunctionalInterfaceBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/FunctionalInterfaceBuilder.java
@@ -78,6 +78,8 @@ final class FunctionalInterfaceBuilder extends ClassSourceBuilder {
     }
 
     private void emitFunctionalFactoryForPointer() {
+        boolean needsAllocator = Utils.isStructOrUnion(funcType.returnType());
+        String allocArg = needsAllocator ? ", (SegmentAllocator)arena" : "";
         appendIndentedLines(STR."""
             MethodHandle DOWN$MH = Linker.nativeLinker().downcallHandle($DESC);
 
@@ -85,7 +87,7 @@ final class FunctionalInterfaceBuilder extends ClassSourceBuilder {
                 MemorySegment symbol = addr.reinterpret(arena, null);
                 return (\{paramExprs("_")}) -> {
                     try {
-                        \{retExpr()} DOWN$MH.invokeExact(symbol\{otherArgExprs()});
+                        \{retExpr()} DOWN$MH.invokeExact(symbol\{allocArg}\{otherArgExprs()});
                     } catch (Throwable ex$) {
                         throw new AssertionError("should not reach here", ex$);
                     }

--- a/test/jtreg/generator/allocCallback/TestAllocCallback.java
+++ b/test/jtreg/generator/allocCallback/TestAllocCallback.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import org.testng.annotations.Test;
+import test.jextract.allocCallback.*;
+
+import java.lang.foreign.Arena;
+
+import static org.testng.Assert.assertEquals;
+
+/*
+ * @test id=classes
+ * @bug 7903239
+ * @summary ofAddress factory of function pointer type is wrong for struct returns
+ * @library /lib
+ * @run main/othervm JtregJextract -l AllocCallback -t test.jextract.allocCallback alloc_callback.h
+ * @build TestAllocCallback
+ * @run testng/othervm --enable-native-access=ALL-UNNAMED TestAllocCallback
+ */
+/*
+ * @test id=sources
+ * @bug 7903239
+ * @summary ofAddress factory of function pointer type is wrong for struct returns
+ * @library /lib
+ * @run main/othervm JtregJextractSources -l AllocCallback -t test.jextract.allocCallback alloc_callback.h
+ * @build TestAllocCallback
+ * @run testng/othervm --enable-native-access=ALL-UNNAMED TestAllocCallback
+ */
+public class TestAllocCallback {
+    @Test
+    public void testOfAddress() {
+        try (Arena arena = Arena.ofConfined()) {
+            var foo = alloc_callback_h.foo$SEGMENT();
+
+            var barA = Foo.a(foo, arena).apply();
+            var barB = Foo.b(foo, arena).apply(100);
+
+            assertEquals(Bar.a$get(barA), 5);
+            assertEquals(Bar.a$get(barB), 100);
+        }
+    }
+}

--- a/test/jtreg/generator/allocCallback/alloc_callback.h
+++ b/test/jtreg/generator/allocCallback/alloc_callback.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#ifdef _WIN64
+#define EXPORT __declspec(dllexport)
+#else
+#define EXPORT
+#endif
+
+struct Bar { int a; };
+
+struct Foo {
+    struct Bar (*a)(void);
+    struct Bar (*b)(int);
+};
+
+EXPORT struct Bar a();
+EXPORT struct Bar b(int v);
+EXPORT struct Foo foo;

--- a/test/jtreg/generator/allocCallback/libAllocCallback.c
+++ b/test/jtreg/generator/allocCallback/libAllocCallback.c
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include "alloc_callback.h"
+
+struct Bar a() {
+    return (struct Bar) { 5 };
+};
+
+struct Bar b(int v) {
+    return (struct Bar) { v };
+};
+
+struct Foo foo = { a, b };


### PR DESCRIPTION
This is a more up-to-date version of: https://github.com/openjdk/jextract/pull/58 which takes the recent re-writes into account.

For callbacks that return a struct by-value, we need a SegmentAllocator. We can re-use the Arena we use as a scope for the function pointer we are wrapping. If a user wants a different allocator in different circumstances, they can just re-wrap the pointer and pass another Arena.

/contributor add @lost-illusi0n

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Issue
 * [CODETOOLS-7903239](https://bugs.openjdk.org/browse/CODETOOLS-7903239): ofAddress factory of function pointer type is wrong for struct returns (**Bug** - P3)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - Committer)


### Contributors
 * Lost Illusion `<im@lostillusion.net>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/162/head:pull/162` \
`$ git checkout pull/162`

Update a local copy of the PR: \
`$ git checkout pull/162` \
`$ git pull https://git.openjdk.org/jextract.git pull/162/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 162`

View PR using the GUI difftool: \
`$ git pr show -t 162`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/162.diff">https://git.openjdk.org/jextract/pull/162.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/162#issuecomment-1856071155)