### PR TITLE
7903612: Nested struct typedefs fail to compile

### DIFF
--- a/src/main/java/org/openjdk/jextract/impl/ClassSourceBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/ClassSourceBuilder.java
@@ -26,7 +26,6 @@ package org.openjdk.jextract.impl;
 
 import org.openjdk.jextract.Declaration;
 import org.openjdk.jextract.Declaration.Constant;
-import org.openjdk.jextract.Declaration.Scoped;
 import org.openjdk.jextract.Type;
 import org.openjdk.jextract.Type.Array;
 import org.openjdk.jextract.Type.Declared;
@@ -35,7 +34,6 @@ import org.openjdk.jextract.Type.Function;
 import org.openjdk.jextract.Type.Primitive;
 import org.openjdk.jextract.impl.DeclarationImpl.JavaName;
 
-import java.lang.foreign.FunctionDescriptor;
 import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemorySegment;
 import java.lang.invoke.MethodHandle;
@@ -137,10 +135,10 @@ abstract class ClassSourceBuilder {
         sb.appendIndentedLines(s);
     }
 
-    final void emitPrivateDefaultConstructor() {
+    final void emitProtectedDefaultConstructor() {
         appendLines(STR."""
-            // Suppresses default constructor, ensuring non-instantiability.
-            private \{className}() {}
+            // Suppresses public default constructor, ensuring non-instantiability, but allow generated subclasses.
+            protected \{className}() {}
             """);
     }
 

--- a/src/main/java/org/openjdk/jextract/impl/StructBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/StructBuilder.java
@@ -41,7 +41,6 @@ import java.util.ArrayList;
 import java.util.Deque;
 import java.util.List;
 import java.util.Optional;
-import java.util.OptionalLong;
 import java.util.stream.Collectors;
 
 /**
@@ -112,10 +111,10 @@ final class StructBuilder extends ClassSourceBuilder implements OutputFactory.Bu
             pushNestedAnonDecl(tree);
             return this;
         } else {
-            StructBuilder builder = new StructBuilder(sourceFileBuilder(), "public static final",
+            StructBuilder builder = new StructBuilder(sourceFileBuilder(), "public static",
                     JavaName.getOrThrow(tree), this, runtimeHelperName(), tree);
             builder.begin();
-            builder.emitPrivateDefaultConstructor();
+            builder.emitProtectedDefaultConstructor();
             return builder;
         }
     }

--- a/src/main/java/org/openjdk/jextract/impl/TypedefBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/TypedefBuilder.java
@@ -26,9 +26,6 @@
 package org.openjdk.jextract.impl;
 
 import org.openjdk.jextract.Declaration;
-import org.openjdk.jextract.Type;
-
-import java.util.List;
 
 final class TypedefBuilder extends ClassSourceBuilder {
     private TypedefBuilder(SourceFileBuilder builder, String className, String superClass, String runtimeHelperName) {
@@ -40,7 +37,7 @@ final class TypedefBuilder extends ClassSourceBuilder {
         TypedefBuilder tdb = new TypedefBuilder(builder, className, superClass, runtimeHelperName);
         tdb.emitDocComment(typedefTree);
         tdb.classBegin();
-        tdb.emitPrivateDefaultConstructor();
+        tdb.emitProtectedDefaultConstructor();
         tdb.classEnd();
     }
 }

--- a/test/jtreg/generator/nestedStructTypedef/TestNestedStructTypedef.java
+++ b/test/jtreg/generator/nestedStructTypedef/TestNestedStructTypedef.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+import test.jextract.nested.typedef.*;
+
+import java.lang.foreign.GroupLayout;
+
+/*
+ * @test id=classes
+ * @library /lib
+ * @run main/othervm JtregJextract -t test.jextract.nested.typedef nestedStructTypedef.h
+ * @build TestNestedStructTypedef
+ * @run testng/othervm --enable-native-access=ALL-UNNAMED TestNestedStructTypedef
+ */
+/*
+ * @test id=sources
+ * @library /lib
+ * @run main/othervm JtregJextractSources -t test.jextract.nested.typedef nestedStructTypedef.h
+ * @build TestNestedStructTypedef
+ * @run testng/othervm --enable-native-access=ALL-UNNAMED TestNestedStructTypedef
+ */
+public class TestNestedStructTypedef {
+
+    @Test
+    public void testMacroFields() {
+        checkLayout(T.$LAYOUT());
+    }
+
+    void checkLayout(GroupLayout layout) {
+        assertEquals(layout.memberLayouts().get(0), nestedStructTypedef_h.C_INT.withName("x"));
+    }
+}

--- a/test/jtreg/generator/nestedStructTypedef/nestedStructTypedef.h
+++ b/test/jtreg/generator/nestedStructTypedef/nestedStructTypedef.h
@@ -1,0 +1,5 @@
+struct Outer {
+    struct Inner { int x; } a;
+};
+
+typedef struct Inner T;

--- a/test/jtreg/generator/packed/TestPackedStructs.java
+++ b/test/jtreg/generator/packed/TestPackedStructs.java
@@ -33,7 +33,7 @@ import test.jextract.packedstructs.*;
 /*
  * @test id=classes
  * @library /lib
- * @run main/othervm JtregJextract -l Func -t test.jextract.packedstructs packedstructs.h
+ * @run main/othervm JtregJextract -t test.jextract.packedstructs packedstructs.h
  * @build TestPackedStructs
  * @run testng/othervm --enable-native-access=ALL-UNNAMED TestPackedStructs
  */


### PR DESCRIPTION
This PR fixes a small issue with nested struct typedef, and another with typedef in general:

* nested struct classes are emitted with the `final` modifier, which prevents them from being subclassed (e.g. in typedefs)
* all structs have a private constructor to prevent clients from instantiating. Unfortunately this constructor also prevents subclassing (e.g. in typedef).

This patch drops the `final` modifier on nested struct/unions, and also tweaks the default constructor from `private` to `protected`.

