### PR TITLE
Don't chase typedefs in Utils::declarationFor

### DIFF
--- a/src/main/java/org/openjdk/jextract/impl/Utils.java
+++ b/src/main/java/org/openjdk/jextract/impl/Utils.java
@@ -110,10 +110,11 @@ class Utils {
     }
 
     static Optional<Declaration.Scoped> declarationFor(Type type) {
+        // @@@: we don't chase delegated types (typedefs or pointers). This could lead to declarations
+        // not being visited, which could result in missing generated code.
         return switch (type) {
             case Type.Declared declared -> Optional.of(declared.tree());
             case Type.Array array -> declarationFor(array.elementType());
-            case Delegated delegated when delegated.kind() != Kind.POINTER -> declarationFor(delegated.type());
             default -> Optional.empty();
         };
     }


### PR DESCRIPTION
The fix for https://git.openjdk.org/jextract/pull/161 introduced a method, namely `Utils::declarationFor` which gives us a scoped declaration from a given type.This routine was implemented "the right way", but that revealed issues with the underlying IR, especially when extracting big header files like windows.h. In some cases the order in which cursors are seen is slightly different, and that leads to the wrong name to be attached to the typedeff'ed entity. This problem is also existing in the jdk22 branch, but given that branch has a much more primitive logic for visiting declaration types, it was never exposed in full.

For now, the solution is to dumb down `Utils::declarationFor`. Of course a longer term solution is to make sure that declarations that need to be visited can be seen in the declaration tree, so that chasing types is no longer necessary.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/165/head:pull/165` \
`$ git checkout pull/165`

Update a local copy of the PR: \
`$ git checkout pull/165` \
`$ git pull https://git.openjdk.org/jextract.git pull/165/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 165`

View PR using the GUI difftool: \
`$ git pr show -t 165`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/165.diff">https://git.openjdk.org/jextract/pull/165.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/165#issuecomment-1857834136)