### PR TITLE
Improve formatting of generated source code

### DIFF
--- a/src/main/java/org/openjdk/jextract/impl/ClassSourceBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/ClassSourceBuilder.java
@@ -139,6 +139,7 @@ abstract class ClassSourceBuilder {
 
     final void emitDefaultConstructor() {
         appendIndentedLines(STR."""
+
             \{className}() {
                 // Suppresses public default constructor, ensuring non-instantiability,
                 // but allows generated subclasses in same package.

--- a/src/main/java/org/openjdk/jextract/impl/ClassSourceBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/ClassSourceBuilder.java
@@ -108,7 +108,7 @@ abstract class ClassSourceBuilder {
     }
 
     final void classEnd() {
-        appendIndentedLines("""
+        appendLines("""
             }
 
             """);

--- a/src/main/java/org/openjdk/jextract/impl/ClassSourceBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/ClassSourceBuilder.java
@@ -103,14 +103,12 @@ abstract class ClassSourceBuilder {
         }
         appendLines(STR."""
             \{modifiers} \{kind.kindName} \{className}\{extendsExpr} {
-
             """);
     }
 
     final void classEnd() {
         appendLines("""
             }
-
             """);
     }
 
@@ -127,6 +125,10 @@ abstract class ClassSourceBuilder {
     // append multiple lines (indentation is added automatically)
     void appendLines(String s) {
         sb.appendLines(s);
+    }
+
+    void appendBlankLine() {
+        appendLines("\n");
     }
 
     // increase indentation before appending lines

--- a/src/main/java/org/openjdk/jextract/impl/FunctionalInterfaceBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/FunctionalInterfaceBuilder.java
@@ -52,10 +52,11 @@ final class FunctionalInterfaceBuilder extends ClassSourceBuilder {
                                 Type.Function funcType, Optional<List<String>> parameterNames) {
         FunctionalInterfaceBuilder fib = new FunctionalInterfaceBuilder(builder, className, enclosing, runtimeHelperName,
                 funcType, parameterNames);
+        fib.appendBlankLine();
         fib.emitDocComment(funcType, className);
         fib.classBegin();
-        fib.emitDescriptorDecl();
         fib.emitFunctionalInterfaceMethod();
+        fib.emitDescriptorDecl();
         fib.emitFunctionalFactories();
         fib.emitFunctionalFactoryForPointer();
         fib.classEnd();
@@ -63,13 +64,15 @@ final class FunctionalInterfaceBuilder extends ClassSourceBuilder {
 
     private void emitFunctionalInterfaceMethod() {
         appendIndentedLines(STR."""
+
             \{methodType.returnType().getSimpleName()} apply(\{paramExprs("")});
             """);
     }
 
     private void emitFunctionalFactories() {
         appendIndentedLines(STR."""
-            MethodHandle UP$MH = \{runtimeHelperName()}.upcallHandle(\{className()}.class, \"apply\", $DESC);
+
+            MethodHandle UP$MH = \{runtimeHelperName()}.upcallHandle(\{className()}.class, "apply", $DESC);
 
             static MemorySegment allocate(\{className()} fi, Arena scope) {
                 return Linker.nativeLinker().upcallStub(UP$MH.bindTo(fi), $DESC, scope);
@@ -81,6 +84,7 @@ final class FunctionalInterfaceBuilder extends ClassSourceBuilder {
         boolean needsAllocator = Utils.isStructOrUnion(funcType.returnType());
         String allocArg = needsAllocator ? ", (SegmentAllocator)arena" : "";
         appendIndentedLines(STR."""
+
             MethodHandle DOWN$MH = Linker.nativeLinker().downcallHandle($DESC);
 
             static \{className()} ofAddress(MemorySegment addr, Arena arena) {
@@ -137,6 +141,7 @@ final class FunctionalInterfaceBuilder extends ClassSourceBuilder {
 
     private void emitDescriptorDecl() {
         appendIndentedLines(STR."""
+
             FunctionDescriptor $DESC = \{functionDescriptorString(0, funcType)};
             """);
     }

--- a/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
@@ -240,9 +240,7 @@ class HeaderFileBuilder extends ClassSourceBuilder {
         }
         decrAlign();
         appendIndentedLines("""
-                SymbolLookup loaderLookup = SymbolLookup.loaderLookup();
-                Linker linker = Linker.nativeLinker();
-                SYMBOL_LOOKUP = name -> loaderLookup.find(name).or(() -> linker.defaultLookup().find(name));
+                SYMBOL_LOOKUP = SymbolLookup.loaderLookup().or(Linker.nativeLinker().defaultLookup());
             }
             """);
     }

--- a/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
@@ -228,21 +228,25 @@ class HeaderFileBuilder extends ClassSourceBuilder {
     void emitFirstHeaderPreamble(List<String> libraries) {
         appendIndentedLines("""
 
-            static final SymbolLookup SYMBOL_LOOKUP;
+            static final SymbolLookup SYMBOL_LOOKUP
+                    = SymbolLookup.loaderLookup().or(Linker.nativeLinker().defaultLookup());
+            """);
+        if (!libraries.isEmpty()) {
+            appendIndentedLines("""
 
-            static {
-            """);
-        incrAlign();
-        for (String lib : libraries) {
-            String quotedLibName = lib.replace("\\", "\\\\"); // double up slashes
-            String method = quotedLibName.indexOf(File.separatorChar) != -1 ? "load" : "loadLibrary";
-            appendIndentedLines(STR."System.\{method}(\"\{quotedLibName}\");");
-        }
-        decrAlign();
-        appendIndentedLines("""
-                SYMBOL_LOOKUP = SymbolLookup.loaderLookup().or(Linker.nativeLinker().defaultLookup());
+                static {
+                """);
+            incrAlign();
+            for (String lib : libraries) {
+                String quotedLibName = lib.replace("\\", "\\\\"); // double up slashes
+                String method = quotedLibName.indexOf(File.separatorChar) != -1 ? "load" : "loadLibrary";
+                appendIndentedLines(STR."System.\{method}(\"\{quotedLibName}\");");
             }
-            """);
+            decrAlign();
+            appendIndentedLines("""
+                }
+                """);
+        }
     }
 
     void emitRuntimeHelperMethods() {

--- a/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
@@ -226,27 +226,25 @@ class HeaderFileBuilder extends ClassSourceBuilder {
     }
 
     void emitFirstHeaderPreamble(List<String> libraries) {
-        incrAlign();
-        appendLines("""
+        appendIndentedLines("""
 
             static final SymbolLookup SYMBOL_LOOKUP;
+
+            static {
             """);
-        appendLines("static {");
+        incrAlign();
         for (String lib : libraries) {
             String quotedLibName = lib.replace("\\", "\\\\"); // double up slashes
             String method = quotedLibName.indexOf(File.separatorChar) != -1 ? "load" : "loadLibrary";
             appendIndentedLines(STR."System.\{method}(\"\{quotedLibName}\");");
         }
-        if (!libraries.isEmpty()) {
-            appendBlankLine();
-        }
-        appendIndentedLines("""
-            SymbolLookup loaderLookup = SymbolLookup.loaderLookup();
-            Linker linker = Linker.nativeLinker();
-            SYMBOL_LOOKUP = name -> loaderLookup.find(name).or(() -> linker.defaultLookup().find(name));
-            """);
-        appendLines("}");
         decrAlign();
+        appendIndentedLines("""
+                SymbolLookup loaderLookup = SymbolLookup.loaderLookup();
+                Linker linker = Linker.nativeLinker();
+                SYMBOL_LOOKUP = name -> loaderLookup.find(name).or(() -> linker.defaultLookup().find(name));
+            }
+            """);
     }
 
     void emitRuntimeHelperMethods() {

--- a/src/main/java/org/openjdk/jextract/impl/SourceFileBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/SourceFileBuilder.java
@@ -105,7 +105,8 @@ final class SourceFileBuilder {
 
     public void appendLines(String s) {
         // we don't just simply use indent here, since that will also indent empty lines which adds trailing whitespace
-        s.lines().map(l -> l.isEmpty() ? "\n" : l.indent(align * 4)).forEach(sb::append);
+        String indent = "    ".repeat(align);
+        s.lines().map(l -> l.isEmpty() ? "\n" : indent + l + "\n").forEach(sb::append);
     }
 
     public void appendIndentedLines(String s) {

--- a/src/main/java/org/openjdk/jextract/impl/SourceFileBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/SourceFileBuilder.java
@@ -104,7 +104,8 @@ final class SourceFileBuilder {
     }
 
     public void appendLines(String s) {
-        sb.append(s.indent(align * 4));
+        // we don't just simply use indent here, since that will also indent empty lines which adds trailing whitespace
+        s.lines().map(l -> l.isEmpty() ? "\n" : l.indent(align * 4)).forEach(sb::append);
     }
 
     public void appendIndentedLines(String s) {

--- a/src/main/java/org/openjdk/jextract/impl/StructBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/StructBuilder.java
@@ -79,6 +79,7 @@ final class StructBuilder extends ClassSourceBuilder implements OutputFactory.Bu
             }
             emitDocComment(structTree);
             classBegin();
+            emitDefaultConstructor();
             emitLayoutDecl();
         }
     }
@@ -114,7 +115,6 @@ final class StructBuilder extends ClassSourceBuilder implements OutputFactory.Bu
             StructBuilder builder = new StructBuilder(sourceFileBuilder(), "public static",
                     JavaName.getOrThrow(tree), this, runtimeHelperName(), tree);
             builder.begin();
-            builder.emitDefaultConstructor();
             return builder;
         }
     }
@@ -243,7 +243,7 @@ final class StructBuilder extends ClassSourceBuilder implements OutputFactory.Bu
             """);
     }
 
-    private void emitLayoutDecl() {
+    public void emitLayoutDecl() {
         appendIndentedLines(STR."""
             private static final GroupLayout $LAYOUT = \{structOrUnionLayoutString(structType)};
 

--- a/src/main/java/org/openjdk/jextract/impl/StructBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/StructBuilder.java
@@ -117,8 +117,6 @@ final class StructBuilder extends ClassSourceBuilder implements OutputFactory.Bu
             StructBuilder builder = new StructBuilder(sourceFileBuilder(), "public static",
                     JavaName.getOrThrow(tree), this, runtimeHelperName(), tree);
             builder.begin();
-            builder.emitPrivateDefaultConstructor();
-            builder.emitLayoutDecl();
             return builder;
         }
     }
@@ -256,7 +254,7 @@ final class StructBuilder extends ClassSourceBuilder implements OutputFactory.Bu
             """);
     }
 
-    void emitLayoutDecl() {
+    private void emitLayoutDecl() {
         appendIndentedLines(STR."""
 
             private static final GroupLayout $LAYOUT = \{structOrUnionLayoutString(structType)};

--- a/src/main/java/org/openjdk/jextract/impl/ToplevelBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/ToplevelBuilder.java
@@ -62,6 +62,7 @@ class ToplevelBuilder implements OutputFactory.Builder {
         first.emitFirstHeaderPreamble(libraries);
         // emit basic primitive types
         first.appendIndentedLines(STR."""
+
             public static final ValueLayout.OfBoolean C_BOOL = ValueLayout.JAVA_BOOLEAN;
             public static final ValueLayout.OfByte C_CHAR = ValueLayout.JAVA_BYTE;
             public static final ValueLayout.OfShort C_SHORT = ValueLayout.JAVA_SHORT;
@@ -155,6 +156,7 @@ class ToplevelBuilder implements OutputFactory.Builder {
         otherBuilders.add(sfb);
         StructBuilder structBuilder = new StructBuilder(sfb, "public", sfb.className(), null, mainHeaderClassName(), tree);
         structBuilder.begin();
+        structBuilder.emitLayoutDecl();
         return structBuilder;
     }
 
@@ -173,6 +175,7 @@ class ToplevelBuilder implements OutputFactory.Builder {
             HeaderFileBuilder headerFileBuilder = new HeaderFileBuilder(sfb, className,
                     mainHeaderClassName() + "#{PREV_SUFFIX}", mainHeaderClassName());
             lastHeader.classEnd();
+            headerFileBuilder.appendBlankLine();
             headerFileBuilder.classBegin();
             headerFileBuilder.emitDefaultConstructor();
             headerBuilders.add(sfb);

--- a/src/main/java/org/openjdk/jextract/impl/ToplevelBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/ToplevelBuilder.java
@@ -59,8 +59,8 @@ class ToplevelBuilder implements OutputFactory.Builder {
         HeaderFileBuilder first = new HeaderFileBuilder(sfb, STR."\{sfb.className()}#{SUFFIX}", null, sfb.className());
         first.appendBlankLine();
         first.classBegin();
-        first.emitDefaultConstructor();
         first.emitFirstHeaderPreamble(libraries);
+        first.emitDefaultConstructor();
         // emit basic primitive types
         first.appendIndentedLines(STR."""
 

--- a/src/main/java/org/openjdk/jextract/impl/ToplevelBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/ToplevelBuilder.java
@@ -156,7 +156,6 @@ class ToplevelBuilder implements OutputFactory.Builder {
         otherBuilders.add(sfb);
         StructBuilder structBuilder = new StructBuilder(sfb, "public", sfb.className(), null, mainHeaderClassName(), tree);
         structBuilder.begin();
-        structBuilder.emitLayoutDecl();
         return structBuilder;
     }
 

--- a/src/main/java/org/openjdk/jextract/impl/ToplevelBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/ToplevelBuilder.java
@@ -57,6 +57,7 @@ class ToplevelBuilder implements OutputFactory.Builder {
 
     private static HeaderFileBuilder createFirstHeader(SourceFileBuilder sfb, List<String> libraries) {
         HeaderFileBuilder first = new HeaderFileBuilder(sfb, STR."\{sfb.className()}#{SUFFIX}", null, sfb.className());
+        first.appendBlankLine();
         first.classBegin();
         first.emitDefaultConstructor();
         first.emitFirstHeaderPreamble(libraries);

--- a/src/main/java/org/openjdk/jextract/impl/ToplevelBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/ToplevelBuilder.java
@@ -58,6 +58,7 @@ class ToplevelBuilder implements OutputFactory.Builder {
     private static HeaderFileBuilder createFirstHeader(SourceFileBuilder sfb, List<String> libraries) {
         HeaderFileBuilder first = new HeaderFileBuilder(sfb, STR."\{sfb.className()}#{SUFFIX}", null, sfb.className());
         first.classBegin();
+        first.emitDefaultConstructor();
         first.emitFirstHeaderPreamble(libraries);
         // emit basic primitive types
         first.appendIndentedLines(STR."""
@@ -173,6 +174,7 @@ class ToplevelBuilder implements OutputFactory.Builder {
                     mainHeaderClassName() + "#{PREV_SUFFIX}", mainHeaderClassName());
             lastHeader.classEnd();
             headerFileBuilder.classBegin();
+            headerFileBuilder.emitDefaultConstructor();
             headerBuilders.add(sfb);
             lastHeader = headerFileBuilder;
             declCount = 1;

--- a/src/main/java/org/openjdk/jextract/impl/TypedefBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/TypedefBuilder.java
@@ -35,6 +35,7 @@ final class TypedefBuilder extends ClassSourceBuilder {
     public static void generate(SourceFileBuilder builder, String className, String superClass, String runtimeHelperName,
                                 Declaration.Typedef typedefTree) {
         TypedefBuilder tdb = new TypedefBuilder(builder, className, superClass, runtimeHelperName);
+        tdb.appendBlankLine();
         tdb.emitDocComment(typedefTree);
         tdb.classBegin();
         tdb.emitDefaultConstructor();


### PR DESCRIPTION
As a main rule-of-thumb: we should generate a blank line before a multi-line declaration, or before a block of single line declarations (e.g. fields, or methods collapsed into a single line).

In most cases, we can just add a blank line to the start of the String template we use. In some cases that emit single-line declarations, we have a manual call to `appendBlankLine` before emitting multiple single line decls. For declarations with comments we also add the blank line manually, as there shouldn't be a blank line between the comment and declaration.

- I've also added the default constructor to every class we generate, and moved it before the layout decl in struct classes (makes a little bit more sense I think).
- fixed the indentation and excess trailing whitespace after the class `}` of a class.
- Fixed the way in which we add indentation to text blocks, so that we don't add trailing white space to empty lines.

<details>
<summary>Sample output (click to unfold)</summary>

For instance for this header:
```
struct Foo {
    int x;
    struct Bar {
        int y;
    } bar;
};

typedef struct Foo (*CB)(void);
```

Foo.java:
```
// Generated by jextract

import java.lang.invoke.MethodHandle;
import java.lang.invoke.MethodHandles;
import java.lang.invoke.VarHandle;
import java.nio.ByteOrder;
import java.lang.foreign.*;
import static java.lang.foreign.ValueLayout.*;

/**
 * {@snippet lang=c :
 * struct Foo {
 *     int x;
 *     struct Bar bar;
 * };
 * }
 */
public class Foo {

    Foo() {
        // Suppresses public default constructor, ensuring non-instantiability,
        // but allows generated subclasses in same package.
    }

    private static final GroupLayout $LAYOUT = MemoryLayout.structLayout(
        struct_with_fptr_h.C_INT.withName("x"),
        Foo.Bar.$LAYOUT().withName("bar")
    ).withName("Foo");

    public static final GroupLayout $LAYOUT() {
        return $LAYOUT;
    }

    private static final long x$OFFSET = 0;

    /**
     * Getter for field:
     * {@snippet lang=c :
     * int x;
     * }
     */
    public static int x$get(MemorySegment seg) {
        return seg.get(struct_with_fptr_h.C_INT, x$OFFSET);
    }

    public static int x$get(MemorySegment seg, long index) {
        return seg.get(struct_with_fptr_h.C_INT, x$OFFSET + (index * sizeof()));
    }

    /**
     * Setter for field:
     * {@snippet lang=c :
     * int x;
     * }
     */
    public static void x$set(MemorySegment seg, int x) {
        seg.set(struct_with_fptr_h.C_INT, x$OFFSET, x);
    }

    public static void x$set(MemorySegment seg, long index, int x) {
        seg.set(struct_with_fptr_h.C_INT, x$OFFSET + (index * sizeof()), x);
    }

    /**
     * {@snippet lang=c :
     * struct Bar {
     *     int y;
     * };
     * }
     */
    public static class Bar {

        Bar() {
            // Suppresses public default constructor, ensuring non-instantiability,
            // but allows generated subclasses in same package.
        }

        private static final GroupLayout $LAYOUT = MemoryLayout.structLayout(
            struct_with_fptr_h.C_INT.withName("y")
        ).withName("Bar");

        public static final GroupLayout $LAYOUT() {
            return $LAYOUT;
        }

        private static final long y$OFFSET = 0;

        /**
         * Getter for field:
         * {@snippet lang=c :
         * int y;
         * }
         */
        public static int y$get(MemorySegment seg) {
            return seg.get(struct_with_fptr_h.C_INT, y$OFFSET);
        }

        public static int y$get(MemorySegment seg, long index) {
            return seg.get(struct_with_fptr_h.C_INT, y$OFFSET + (index * sizeof()));
        }

        /**
         * Setter for field:
         * {@snippet lang=c :
         * int y;
         * }
         */
        public static void y$set(MemorySegment seg, int x) {
            seg.set(struct_with_fptr_h.C_INT, y$OFFSET, x);
        }

        public static void y$set(MemorySegment seg, long index, int x) {
            seg.set(struct_with_fptr_h.C_INT, y$OFFSET + (index * sizeof()), x);
        }

        public static long sizeof() { return $LAYOUT().byteSize(); }
        public static MemorySegment allocate(SegmentAllocator allocator) { return allocator.allocate($LAYOUT()); }

        public static MemorySegment allocateArray(long len, SegmentAllocator allocator) {
            return allocator.allocate(MemoryLayout.sequenceLayout(len, $LAYOUT()));
        }

        public static MemorySegment ofAddress(MemorySegment addr, Arena scope) {
            return addr.reinterpret($LAYOUT().byteSize(), scope, null);
        }
    }

    private static final long bar$OFFSET = 4;
    private static final long bar$SIZE = 4;

    public static MemorySegment bar$slice(MemorySegment seg) {
        return seg.asSlice(bar$OFFSET, bar$SIZE);
    }

    public static long sizeof() { return $LAYOUT().byteSize(); }
    public static MemorySegment allocate(SegmentAllocator allocator) { return allocator.allocate($LAYOUT()); }

    public static MemorySegment allocateArray(long len, SegmentAllocator allocator) {
        return allocator.allocate(MemoryLayout.sequenceLayout(len, $LAYOUT()));
    }

    public static MemorySegment ofAddress(MemorySegment addr, Arena scope) {
        return addr.reinterpret($LAYOUT().byteSize(), scope, null);
    }
}
```

CB.java:
```
// Generated by jextract

import java.lang.invoke.MethodHandle;
import java.lang.invoke.MethodHandles;
import java.lang.invoke.VarHandle;
import java.nio.ByteOrder;
import java.lang.foreign.*;
import static java.lang.foreign.ValueLayout.*;

/**
 * {@snippet lang=c :
 * struct Foo (*CB)();
 * }
 */
public interface CB {

    MemorySegment apply();

    FunctionDescriptor $DESC = FunctionDescriptor.of(
        Foo.$LAYOUT());

    MethodHandle UP$MH = struct_with_fptr_h.upcallHandle(CB.class, "apply", $DESC);

    static MemorySegment allocate(CB fi, Arena scope) {
        return Linker.nativeLinker().upcallStub(UP$MH.bindTo(fi), $DESC, scope);
    }

    MethodHandle DOWN$MH = Linker.nativeLinker().downcallHandle($DESC);

    static CB ofAddress(MemorySegment addr, Arena arena) {
        MemorySegment symbol = addr.reinterpret(arena, null);
        return () -> {
            try {
                return (MemorySegment) DOWN$MH.invokeExact(symbol, (SegmentAllocator)arena);
            } catch (Throwable ex$) {
                throw new AssertionError("should not reach here", ex$);
            }
        };
    }
}
```

struct_with_fptr_h.java:
```
// Generated by jextract

import java.lang.invoke.MethodHandle;
import java.lang.invoke.MethodHandles;
import java.lang.invoke.VarHandle;
import java.nio.ByteOrder;
import java.lang.foreign.*;
import static java.lang.foreign.ValueLayout.*;

public class struct_with_fptr_h {

    static final SymbolLookup SYMBOL_LOOKUP;
    static {
        SymbolLookup loaderLookup = SymbolLookup.loaderLookup();
        Linker linker = Linker.nativeLinker();
        SYMBOL_LOOKUP = name -> loaderLookup.find(name).or(() -> linker.defaultLookup().find(name));
    }

    struct_with_fptr_h() {
        // Suppresses public default constructor, ensuring non-instantiability,
        // but allows generated subclasses in same package.
    }

    public static final ValueLayout.OfBoolean C_BOOL = ValueLayout.JAVA_BOOLEAN;
    public static final ValueLayout.OfByte C_CHAR = ValueLayout.JAVA_BYTE;
    public static final ValueLayout.OfShort C_SHORT = ValueLayout.JAVA_SHORT;
    public static final ValueLayout.OfInt C_INT = ValueLayout.JAVA_INT;
    public static final ValueLayout.OfLong C_LONG_LONG = ValueLayout.JAVA_LONG;
    public static final ValueLayout.OfFloat C_FLOAT = ValueLayout.JAVA_FLOAT;
    public static final ValueLayout.OfDouble C_DOUBLE = ValueLayout.JAVA_DOUBLE;
    public static final AddressLayout C_POINTER = ValueLayout.ADDRESS
            .withTargetLayout(MemoryLayout.sequenceLayout(java.lang.Long.MAX_VALUE, JAVA_BYTE));
    public static final ValueLayout.OfInt C_LONG = ValueLayout.JAVA_INT;
    public static final ValueLayout.OfDouble C_LONG_DOUBLE = ValueLayout.JAVA_DOUBLE;

    static MemorySegment findOrThrow(String symbol) {
        return SYMBOL_LOOKUP.find(symbol)
            .orElseThrow(() -> new UnsatisfiedLinkError("unresolved symbol: " + symbol));
    }

    static MemoryLayout[] inferVariadicLayouts(Object[] varargs) {
        MemoryLayout[] result = new MemoryLayout[varargs.length];
        for (int i = 0; i < varargs.length; i++) {
            result[i] = variadicLayout(varargs[i].getClass());
        }
        return result;
    }

    static MethodHandle upcallHandle(Class<?> fi, String name, FunctionDescriptor fdesc) {
        try {
            return MethodHandles.lookup().findVirtual(fi, name, fdesc.toMethodType());
        } catch (ReflectiveOperationException ex) {
            throw new AssertionError(ex);
        }
    }

    static MethodHandle downcallHandleVariadic(String name, FunctionDescriptor baseDesc, MemoryLayout[] variadicLayouts) {
        FunctionDescriptor variadicDesc = baseDesc.appendArgumentLayouts(variadicLayouts);
        Linker.Option fva = Linker.Option.firstVariadicArg(baseDesc.argumentLayouts().size());
        return SYMBOL_LOOKUP.find(name)
                .map(addr -> Linker.nativeLinker().downcallHandle(addr, variadicDesc, fva)
                        .asSpreader(Object[].class, variadicLayouts.length))
                .orElse(null);
    }

    // Internals only below this point

    private static MemoryLayout variadicLayout(Class<?> c) {
        // apply default argument promotions per C spec
        // note that all primitives are boxed, since they are passed through an Object[]
        if (c == Boolean.class || c == Byte.class || c == Character.class || c == Short.class || c == Integer.class) {
            return JAVA_INT;
        } else if (c == Long.class) {
            return JAVA_LONG;
        } else if (c == Float.class || c == Double.class) {
            return JAVA_DOUBLE;
        } else if (MemorySegment.class.isAssignableFrom(c)) {
            return ADDRESS;
        }
        throw new IllegalArgumentException("Invalid type for ABI: " + c.getTypeName());
    }
}
```
</details>

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/166/head:pull/166` \
`$ git checkout pull/166`

Update a local copy of the PR: \
`$ git checkout pull/166` \
`$ git pull https://git.openjdk.org/jextract.git pull/166/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 166`

View PR using the GUI difftool: \
`$ git pr show -t 166`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/166.diff">https://git.openjdk.org/jextract/pull/166.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/166#issuecomment-1857975564)