### PR TITLE
7903616: Bad formatting of layout string for structs with nested anon structs/unions

### DIFF
--- a/src/main/java/org/openjdk/jextract/impl/ClassSourceBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/ClassSourceBuilder.java
@@ -250,9 +250,9 @@ abstract class ClassSourceBuilder {
             case Double -> alignIfNeeded(STR."\{runtimeHelperName()}.C_DOUBLE", 8, align);
             case LongDouble -> TypeImpl.IS_WINDOWS ?
                     alignIfNeeded(STR."\{runtimeHelperName()}.C_LONG_DOUBLE", 8, align) :
-                    paddingLayoutString(8);
-            case HalfFloat, Char16, WChar -> paddingLayoutString(2); // unsupported
-            case Float128, Int128 -> paddingLayoutString(16); // unsupported
+                    paddingLayoutString(8, 0);
+            case HalfFloat, Char16, WChar -> paddingLayoutString(2, 0); // unsupported
+            case Float128, Int128 -> paddingLayoutString(16, 0); // unsupported
             default -> throw new UnsupportedOperationException(primitiveType.toString());
         };
     }
@@ -263,7 +263,7 @@ abstract class ClassSourceBuilder {
                 layoutPrefix;
     }
 
-    String paddingLayoutString(long size) {
-        return STR."MemoryLayout.paddingLayout(\{size})";
+    String paddingLayoutString(long size, int indent) {
+        return STR."\{indentString(indent)}MemoryLayout.paddingLayout(\{size})";
     }
 }

--- a/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
@@ -377,9 +377,9 @@ class HeaderFileBuilder extends ClassSourceBuilder {
 
     private String constantValue(Class<?> type, Object value) {
         if (value instanceof String) {
-            return STR."Arena.ofAuto().allocateFrom(\"\{Utils.quote(Objects.toString(value))}\");";
+            return STR."Arena.ofAuto().allocateFrom(\"\{Utils.quote(Objects.toString(value))}\")";
         } else if (type == MemorySegment.class) {
-            return STR."MemorySegment.ofAddress(\{((Number)value).longValue()}L);";
+            return STR."MemorySegment.ofAddress(\{((Number)value).longValue()}L)";
         } else {
             StringBuilder buf = new StringBuilder();
             if (type == float.class) {

--- a/src/main/java/org/openjdk/jextract/impl/StructBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/StructBuilder.java
@@ -283,7 +283,7 @@ final class StructBuilder extends ClassSourceBuilder implements OutputFactory.Bu
 
     private String structOrUnionLayoutString(Type type) {
         return switch (type) {
-            case Declared d when Utils.isStructOrUnion(type) -> structOrUnionLayoutString(0, d.tree());
+            case Declared d when Utils.isStructOrUnion(type) -> structOrUnionLayoutString(0, d.tree(), 0);
             default -> throw new UnsupportedOperationException(type.toString());
         };
     }
@@ -297,7 +297,7 @@ final class StructBuilder extends ClassSourceBuilder implements OutputFactory.Bu
         }
     }
 
-    private String structOrUnionLayoutString(long base, Declaration.Scoped scoped) {
+    private String structOrUnionLayoutString(long base, Declaration.Scoped scoped, int indent) {
         List<String> memberLayouts = new ArrayList<>();
 
         boolean isStruct = scoped.kind() == Scoped.Kind.STRUCT;
@@ -320,10 +320,10 @@ final class StructBuilder extends ClassSourceBuilder implements OutputFactory.Bu
                 String memberLayout;
                 if (member instanceof Variable var) {
                     memberLayout = layoutString(var.type(), align);
-                    memberLayout = STR."\{memberLayout}.withName(\"\{member.name()}\")";
+                    memberLayout = STR."\{indentString(indent + 1)}\{memberLayout}.withName(\"\{member.name()}\")";
                 } else {
                     // anon struct
-                    memberLayout = structOrUnionLayoutString(offset, (Scoped) member);
+                    memberLayout = structOrUnionLayoutString(offset, (Scoped) member, indent + 1);
                 }
                 memberLayouts.add(memberLayout);
                 // update offset and size
@@ -344,11 +344,12 @@ final class StructBuilder extends ClassSourceBuilder implements OutputFactory.Bu
             memberLayouts.add(paddingLayoutString(trailPadding));
         }
 
-        String indentNewLine = STR."\n\{indentString(1)}";
-        String prefix = isStruct ? "MemoryLayout.structLayout(" :
-                "MemoryLayout.unionLayout(";
+        String prefix = isStruct ?
+                STR."\{indentString(indent)}MemoryLayout.structLayout(\n" :
+                STR."\{indentString(indent)}MemoryLayout.unionLayout(\n";
+        String suffix = STR."\n\{indentString(indent)})";
         String layoutString = memberLayouts.stream()
-                .collect(Collectors.joining("," + indentNewLine, prefix + indentNewLine, "\n)"));
+                .collect(Collectors.joining(",\n", prefix, suffix));
 
         // the name is only useful for clients accessing the layout, jextract doesn't care about it
         String name = scoped.name().isEmpty() ?

--- a/src/main/java/org/openjdk/jextract/impl/StructBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/StructBuilder.java
@@ -311,7 +311,7 @@ final class StructBuilder extends ClassSourceBuilder implements OutputFactory.Bu
                 long nextOffset = recordMemberOffset(member);
                 long delta = nextOffset - offset;
                 if (delta > 0) {
-                    memberLayouts.add(paddingLayoutString(delta / 8));
+                    memberLayouts.add(paddingLayoutString(delta / 8, indent + 1));
                     offset += delta;
                     if (isStruct) {
                         size += delta;
@@ -341,7 +341,7 @@ final class StructBuilder extends ClassSourceBuilder implements OutputFactory.Bu
             long trailPadding = isStruct ?
                     (expectedSize - size) / 8 :
                     expectedSize / 8;
-            memberLayouts.add(paddingLayoutString(trailPadding));
+            memberLayouts.add(paddingLayoutString(trailPadding, indent + 1));
         }
 
         String prefix = isStruct ?


### PR DESCRIPTION
This PR fixes an indentation issue when generating a struct layout string.

Example:

```c
struct Foo {
    struct {
        int x;
        union {
            int y;
            int z;
        };
    };
}; 
```

For this, jextract generates:

```java
    private static final GroupLayout $LAYOUT = MemoryLayout.structLayout(
        MemoryLayout.structLayout(
        foo_h.C_INT.withName("x"),
        MemoryLayout.unionLayout(
        foo_h.C_INT.withName("y"),
        foo_h.C_INT.withName("z")
    ).withName("$anon$7:9")
    ).withName("$anon$5:5")
    ).withName("Foo");
```

With the fix in this PR, the generated string is:

```java
    private static final GroupLayout $LAYOUT = MemoryLayout.structLayout(
        MemoryLayout.structLayout(
            foo_h.C_INT.withName("x"),
            MemoryLayout.unionLayout(
                foo_h.C_INT.withName("y"),
                foo_h.C_INT.withName("z")
            ).withName("$anon$7:9")
        ).withName("$anon$5:5")
    ).withName("Foo");
```

The fix is to correctly track required indentation when descending into a scoped declaration.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Issue
 * [CODETOOLS-7903616](https://bugs.openjdk.org/browse/CODETOOLS-7903616): Bad formatting of layout string for structs with nested anon structs/unions (**Bug** - P4)


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/170/head:pull/170` \
`$ git checkout pull/170`

Update a local copy of the PR: \
`$ git checkout pull/170` \
`$ git pull https://git.openjdk.org/jextract.git pull/170/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 170`

View PR using the GUI difftool: \
`$ git pr show -t 170`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/170.diff">https://git.openjdk.org/jextract/pull/170.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/170#issuecomment-1866582425)