### PR TITLE
Wrong libclang library name on Windows

### DIFF
--- a/src/main/java/org/openjdk/jextract/clang/libclang/Index_h.java
+++ b/src/main/java/org/openjdk/jextract/clang/libclang/Index_h.java
@@ -40,7 +40,8 @@ public class Index_h {
             = SymbolLookup.loaderLookup().or(Linker.nativeLinker().defaultLookup());
 
     static {
-        System.loadLibrary("clang");
+        String libName = System.getProperty("os.name").startsWith("Windows")? "libclang" : "clang";
+        System.loadLibrary(libName);
     }
 
     Index_h() {
@@ -8263,4 +8264,3 @@ public class Index_h {
         return CXResult_VisitBreak;
     }
 }
-


### PR DESCRIPTION
This snuck in when we recently refreshed the libclang bindings.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/172/head:pull/172` \
`$ git checkout pull/172`

Update a local copy of the PR: \
`$ git checkout pull/172` \
`$ git pull https://git.openjdk.org/jextract.git pull/172/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 172`

View PR using the GUI difftool: \
`$ git pr show -t 172`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/172.diff">https://git.openjdk.org/jextract/pull/172.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/172#issuecomment-1887322085)