### PR TITLE
7903599: jextract includes extraneous man pages

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -130,6 +130,7 @@ task createJextractImage(type: Exec) {
          "--add-modules=org.openjdk.jextract,jdk.compiler,jdk.zipfs",
          "--output=${jextract_app_dir}",
          "--launcher=jextract=org.openjdk.jextract/org.openjdk.jextract.JextractTool",
+         "--strip-debug", "--no-man-pages", "--no-header-files",
          "--add-options",
          "${quote_jlink_opts}"
     ]


### PR DESCRIPTION
A simple fix which drops the man pages from the generated jlink image. I've also added some other options to strip debug information, and header files, both of which are not needed for the regular non-test runtime image.

The native commands (e.g. `java.exe`) are still needed because we invoke that in the jextract launcher script, so we can't drop those.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Issue
 * [CODETOOLS-7903599](https://bugs.openjdk.org/browse/CODETOOLS-7903599): jextract includes extraneous man pages (**Bug** - P4)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/173/head:pull/173` \
`$ git checkout pull/173`

Update a local copy of the PR: \
`$ git checkout pull/173` \
`$ git pull https://git.openjdk.org/jextract.git pull/173/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 173`

View PR using the GUI difftool: \
`$ git pr show -t 173`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/173.diff">https://git.openjdk.org/jextract/pull/173.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/173#issuecomment-1887652313)