### PR TITLE
7903584: Revisit struct accessors

### DIFF
--- a/samples/libclang/ASTPrinter.java
+++ b/samples/libclang/ASTPrinter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/samples/libclang/ASTPrinter.java
+++ b/samples/libclang/ASTPrinter.java
@@ -63,7 +63,7 @@ public class ASTPrinter {
                 var kindName = asJavaString(clang_getCursorKindSpelling(arena, kind));
                 System.out.printf("%s %s %s", " ".repeat(level[0]), kindName, name);
                 var type = clang_getCursorType(arena, cursor);
-                if (CXType.kind$get(type) != CXType_Invalid()) {
+                if (CXType.kind(type) != CXType_Invalid()) {
                     var typeName = asJavaString(clang_getTypeSpelling(arena, type));
                     System.out.printf(" <%s>", typeName);
                 }

--- a/samples/libcurl/compile_windows.ps1
+++ b/samples/libcurl/compile_windows.ps1
@@ -9,7 +9,7 @@ jextract `
   --dump-includes 'includes_all.conf' `
   "$curlpath\include\curl\curl.h"
   
-Select-String -Path 'includes_all.conf' -Pattern 'curl' | %{ $_.Line } | Out-File -FilePath 'includes_filtered.conf' -Encoding ascii
+Select-String -Path 'includes_all.conf' -Pattern '(curl|sockaddr )' | %{ $_.Line } | Out-File -FilePath 'includes_filtered.conf' -Encoding ascii
 
 jextract `
   -t org.jextract `

--- a/samples/libffmpeg/LibffmpegMain.java
+++ b/samples/libffmpeg/LibffmpegMain.java
@@ -105,10 +105,10 @@ public class LibffmpegMain {
                 int videoStream = -1;
                 // AVFrameContext formatCtx;
                 // formatCtx.nb_streams
-                int nb_streams = AVFormatContext.nb_streams$get(pFormatCtx);
+                int nb_streams = AVFormatContext.nb_streams(pFormatCtx);
                 System.out.println("number of streams: " + nb_streams);
                 // formatCtx.streams
-                var pStreams = AVFormatContext.streams$get(pFormatCtx);
+                var pStreams = AVFormatContext.streams(pFormatCtx);
 
                 // AVCodecContext* pVideoCodecCtx;
                 var pVideoCodecCtx = NULL;
@@ -118,12 +118,12 @@ public class LibffmpegMain {
                     // AVStream* pStream;
                     var pStream = pStreams.getAtIndex(C_POINTER, i);
                     // AVCodecContext* pCodecCtx;
-                    pCodecCtx = AVStream.codec$get(pStream);
-                    if (AVCodecContext.codec_type$get(pCodecCtx) == AVMEDIA_TYPE_VIDEO()) {
+                    pCodecCtx = AVStream.codec(pStream);
+                    if (AVCodecContext.codec_type(pCodecCtx) == AVMEDIA_TYPE_VIDEO()) {
                         videoStream = i;
                         pVideoCodecCtx = pCodecCtx;
                         // Find the decoder for the video stream
-                        pCodec = avcodec_find_decoder(AVCodecContext.codec_id$get(pCodecCtx));
+                        pCodec = avcodec_find_decoder(AVCodecContext.codec_id(pCodecCtx));
                         break;
                     }
                 }
@@ -160,8 +160,8 @@ public class LibffmpegMain {
                 pFrameRGB = av_frame_alloc();
 
                 // Determine required buffer size and allocate buffer
-                int width = AVCodecContext.width$get(pCodecCtx);
-                int height = AVCodecContext.height$get(pCodecCtx);
+                int width = AVCodecContext.width(pCodecCtx);
+                int height = AVCodecContext.height(pCodecCtx);
                 int numBytes = avpicture_get_size(AV_PIX_FMT_RGB24(), width, height);
                 buffer = av_malloc(numBytes * C_CHAR.byteSize());
 
@@ -182,7 +182,7 @@ public class LibffmpegMain {
                 avpicture_fill(pFrameRGB, buffer, AV_PIX_FMT_RGB24(), width, height);
 
                 // initialize SWS context for software scaling
-                int pix_fmt = AVCodecContext.pix_fmt$get(pCodecCtx);
+                int pix_fmt = AVCodecContext.pix_fmt(pCodecCtx);
                 var sws_ctx = sws_getContext(width, height, pix_fmt, width, height,
                         AV_PIX_FMT_RGB24(), SWS_BILINEAR(), NULL, NULL, NULL);
 
@@ -195,7 +195,7 @@ public class LibffmpegMain {
                 while (av_read_frame(pFormatCtx, packet) >= 0) {
                     // Is this a packet from the video stream?
                     // packet.stream_index == videoStream
-                    if (AVPacket.stream_index$get(packet) == videoStream) {
+                    if (AVPacket.stream_index(packet) == videoStream) {
                         // Decode video frame
                         avcodec_decode_video2(pCodecCtx, pFrame, pFrameFinished, packet);
 

--- a/samples/libffmpeg/LibffmpegMain.java
+++ b/samples/libffmpeg/LibffmpegMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/samples/time/PanamaTime.java
+++ b/samples/time/PanamaTime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/samples/time/PanamaTime.java
+++ b/samples/time/PanamaTime.java
@@ -40,7 +40,7 @@ public class PanamaTime {
             var now = arena.allocateFrom(C_LONG, System.currentTimeMillis() / 1000);
             MemorySegment time = tm.allocate(arena);
             localtime_r(now, time);
-            System.err.printf("Time = %d:%02d\n", tm.tm_hour$get(time), tm.tm_min$get(time));
+            System.err.printf("Time = %d:%02d\n", tm.tm_hour(time), tm.tm_min(time));
         }
     }
 }

--- a/src/main/java/org/openjdk/jextract/impl/DeclarationImpl.java
+++ b/src/main/java/org/openjdk/jextract/impl/DeclarationImpl.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ *  Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  *  This code is free software; you can redistribute it and/or modify it

--- a/src/main/java/org/openjdk/jextract/impl/DeclarationImpl.java
+++ b/src/main/java/org/openjdk/jextract/impl/DeclarationImpl.java
@@ -404,11 +404,6 @@ public abstract class DeclarationImpl implements Declaration {
             declaration.addAttribute(new JavaFunctionalInterfaceName(fiName));
         }
 
-        public static Optional<String> get(Declaration declaration) {
-            return declaration.getAttribute(JavaFunctionalInterfaceName.class)
-                    .map(JavaFunctionalInterfaceName::fiName);
-        }
-
         public static String getOrThrow(Declaration declaration) {
             return declaration.getAttribute(JavaFunctionalInterfaceName.class)
                     .map(JavaFunctionalInterfaceName::fiName).get();

--- a/src/main/java/org/openjdk/jextract/impl/FunctionalInterfaceBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/FunctionalInterfaceBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/main/java/org/openjdk/jextract/impl/FunctionalInterfaceBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/FunctionalInterfaceBuilder.java
@@ -27,7 +27,6 @@ package org.openjdk.jextract.impl;
 
 import org.openjdk.jextract.Declaration;
 import org.openjdk.jextract.Type;
-import org.openjdk.jextract.impl.DeclarationImpl.DeclarationString;
 
 import java.lang.invoke.MethodType;
 import java.util.List;

--- a/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
@@ -61,7 +61,6 @@ class HeaderFileBuilder extends ClassSourceBuilder {
     }
 
     public void addVar(Declaration.Variable varTree) {
-        Optional<String> fiName = JavaFunctionalInterfaceName.get(varTree);
         String nativeName = varTree.name();
         String javaName = JavaName.getOrThrow(varTree);
         String layoutVar = emitVarLayout(varTree.type(), javaName);
@@ -71,7 +70,6 @@ class HeaderFileBuilder extends ClassSourceBuilder {
             String segmentConstant = emitGlobalSegment(layoutVar, javaName, nativeName, null);
             emitGlobalGetter(segmentConstant, layoutVar, javaName, varTree, "Getter for variable:");
             emitGlobalSetter(segmentConstant, layoutVar, javaName, varTree, "Setter for variable:");
-            fiName.ifPresent(s -> emitFunctionalInterfaceGetter(s, javaName));
         } else {
             throw new IllegalArgumentException("Tree type not handled: " + varTree.type());
         }
@@ -209,14 +207,6 @@ class HeaderFileBuilder extends ClassSourceBuilder {
                 """);
         }
         decrAlign();
-    }
-
-    private void emitFunctionalInterfaceGetter(String fiName, String javaName) {
-        appendIndentedLines(STR."""
-            public static \{fiName} \{javaName}(Arena scope) {
-                return \{fiName}.ofAddress(\{javaName}(), scope);
-            }
-            """);
     }
 
     void emitPrimitiveTypedef(Declaration.Typedef typedefTree, Type.Primitive primType, String name) {

--- a/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
@@ -213,8 +213,8 @@ class HeaderFileBuilder extends ClassSourceBuilder {
 
     private void emitFunctionalInterfaceGetter(String fiName, String javaName) {
         appendIndentedLines(STR."""
-            public static \{fiName} \{javaName}() {
-                return \{fiName}.ofAddress(\{javaName}$get(), Arena.global());
+            public static \{fiName} \{javaName}(Arena scope) {
+                return \{fiName}.ofAddress(\{javaName}(), scope);
             }
             """);
     }
@@ -309,7 +309,7 @@ class HeaderFileBuilder extends ClassSourceBuilder {
         emitDocComment(decl, docHeader);
         Class<?> type = Utils.carrierFor(decl.type());
         appendLines(STR."""
-            public static \{type.getSimpleName()} \{javaName}$get() {
+            public static \{type.getSimpleName()} \{javaName}() {
                 return \{segmentConstant}.get(\{layoutVar}, 0L);
             }
             """);
@@ -322,7 +322,7 @@ class HeaderFileBuilder extends ClassSourceBuilder {
         emitDocComment(decl, docHeader);
         Class<?> type = Utils.carrierFor(decl.type());
         appendLines(STR."""
-            public static void \{javaName}$set(\{type.getSimpleName()} x) {
+            public static void \{javaName}(\{type.getSimpleName()} x) {
                 \{segmentConstant}.set(\{layoutVar}, 0L, x);
             }
             """);

--- a/src/main/java/org/openjdk/jextract/impl/StructBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/StructBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/main/java/org/openjdk/jextract/impl/StructBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/StructBuilder.java
@@ -88,6 +88,7 @@ final class StructBuilder extends ClassSourceBuilder implements OutputFactory.Bu
 
     void end() {
         if (!inAnonymousNested()) {
+            emitAt();
             appendBlankLine();
             emitSizeof();
             emitAllocatorAllocate();
@@ -141,9 +142,7 @@ final class StructBuilder extends ClassSourceBuilder implements OutputFactory.Bu
             emitSegmentGetter(javaName, offsetField, sizeField);
         } else if (Utils.isPointer(varTree.type()) || Utils.isPrimitive(varTree.type())) {
             emitFieldGetter(javaName, varTree, offsetField);
-            emitIndexedFieldGetter(javaName, varTree.type(), offsetField);
             emitFieldSetter(javaName, varTree, offsetField);
-            emitIndexedFieldSetter(javaName, varTree.type(), offsetField);
             fiName.ifPresent(s -> emitFunctionalInterfaceGetter(s, javaName));
         } else {
             throw new IllegalArgumentException(STR."Type not supported: \{varTree.type()}");
@@ -196,6 +195,15 @@ final class StructBuilder extends ClassSourceBuilder implements OutputFactory.Bu
 
             public static MemorySegment \{javaName}$slice(MemorySegment \{seg}) {
                 return \{seg}.asSlice(\{offsetField}, \{sizeField});
+            }
+            """);
+    }
+
+    private void emitAt() {
+        appendIndentedLines(STR."""
+
+            public static MemorySegment $at(MemorySegment ptr, long index) {
+                return ptr.asSlice($LAYOUT().byteSize() * index);
             }
             """);
     }

--- a/src/main/java/org/openjdk/jextract/impl/StructBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/StructBuilder.java
@@ -193,7 +193,7 @@ final class StructBuilder extends ClassSourceBuilder implements OutputFactory.Bu
         String seg = safeParameterName("seg");
         appendIndentedLines(STR."""
 
-            public static MemorySegment \{javaName}Slice(MemorySegment \{seg}) {
+            public static MemorySegment \{javaName}$slice(MemorySegment \{seg}) {
                 return \{seg}.asSlice(\{offsetField}, \{sizeField});
             }
             """);

--- a/src/main/java/org/openjdk/jextract/impl/StructBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/StructBuilder.java
@@ -41,7 +41,6 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
@@ -88,7 +87,7 @@ final class StructBuilder extends ClassSourceBuilder implements OutputFactory.Bu
 
     void end() {
         if (!inAnonymousNested()) {
-            emitAt();
+            asSlice();
             appendBlankLine();
             emitSizeof();
             emitAllocatorAllocate();
@@ -188,10 +187,10 @@ final class StructBuilder extends ClassSourceBuilder implements OutputFactory.Bu
             """);
     }
 
-    private void emitAt() {
+    private void asSlice() {
         appendIndentedLines(STR."""
 
-            public static MemorySegment $at(MemorySegment ptr, long index) {
+            public static MemorySegment asSlice(MemorySegment ptr, long index) {
                 return ptr.asSlice($LAYOUT().byteSize() * index);
             }
             """);

--- a/src/main/java/org/openjdk/jextract/impl/StructBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/StructBuilder.java
@@ -159,7 +159,7 @@ final class StructBuilder extends ClassSourceBuilder implements OutputFactory.Bu
         appendIndentedLines(STR."""
 
             public static \{fiName} \{javaName}(MemorySegment segment, Arena scope) {
-                return \{fiName}.ofAddress(\{javaName}$get(segment), scope);
+                return \{fiName}.ofAddress(\{javaName}(segment), scope);
             }
             """);
     }
@@ -170,7 +170,7 @@ final class StructBuilder extends ClassSourceBuilder implements OutputFactory.Bu
         appendBlankLine();
         emitFieldDocComment(varTree, "Getter for field:");
         appendIndentedLines(STR."""
-            public static \{type.getSimpleName()} \{javaName}$get(MemorySegment \{seg}) {
+            public static \{type.getSimpleName()} \{javaName}(MemorySegment \{seg}) {
                 return \{seg}.get(\{layoutString(varTree.type())}, \{offsetField});
             }
             """);
@@ -183,7 +183,7 @@ final class StructBuilder extends ClassSourceBuilder implements OutputFactory.Bu
         appendBlankLine();
         emitFieldDocComment(varTree, "Setter for field:");
         appendIndentedLines(STR."""
-            public static void \{javaName}$set(MemorySegment \{seg}, \{type.getSimpleName()} \{x}) {
+            public static void \{javaName}(MemorySegment \{seg}, \{type.getSimpleName()} \{x}) {
                 \{seg}.set(\{layoutString(varTree.type())}, \{offsetField}, \{x});
             }
             """);
@@ -193,7 +193,7 @@ final class StructBuilder extends ClassSourceBuilder implements OutputFactory.Bu
         String seg = safeParameterName("seg");
         appendIndentedLines(STR."""
 
-            public static MemorySegment \{javaName}$slice(MemorySegment \{seg}) {
+            public static MemorySegment \{javaName}Slice(MemorySegment \{seg}) {
                 return \{seg}.asSlice(\{offsetField}, \{sizeField});
             }
             """);
@@ -234,31 +234,6 @@ final class StructBuilder extends ClassSourceBuilder implements OutputFactory.Bu
 
             public static MemorySegment ofAddress(MemorySegment addr, Arena scope) {
                 return addr.reinterpret($LAYOUT().byteSize(), scope, null);
-            }
-            """);
-    }
-
-    private void emitIndexedFieldGetter(String javaName, Type varType, String offsetField) {
-        String index = safeParameterName("index");
-        String seg = safeParameterName("seg");
-        Class<?> type = Utils.carrierFor(varType);
-        appendIndentedLines(STR."""
-
-            public static \{type.getSimpleName()} \{javaName}$get(MemorySegment \{seg}, long \{index}) {
-                return \{seg}.get(\{layoutString(varType)}, \{offsetField} + (\{index} * sizeof()));
-            }
-            """);
-    }
-
-    private void emitIndexedFieldSetter(String javaName, Type varType, String offsetField) {
-        String index = safeParameterName("index");
-        String seg = safeParameterName("seg");
-        String x = safeParameterName("x");
-        Class<?> type = Utils.carrierFor(varType);
-        appendIndentedLines(STR."""
-
-            public static void \{javaName}$set(MemorySegment \{seg}, long \{index}, \{type.getSimpleName()} \{x}) {
-                \{seg}.set(\{layoutString(varType)}, \{offsetField} + (\{index} * sizeof()), \{x});
             }
             """);
     }

--- a/src/main/java/org/openjdk/jextract/impl/StructBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/StructBuilder.java
@@ -87,7 +87,7 @@ final class StructBuilder extends ClassSourceBuilder implements OutputFactory.Bu
 
     void end() {
         if (!inAnonymousNested()) {
-            asSlice();
+            emitAsSlice();
             appendBlankLine();
             emitSizeof();
             emitAllocatorAllocate();
@@ -187,7 +187,7 @@ final class StructBuilder extends ClassSourceBuilder implements OutputFactory.Bu
             """);
     }
 
-    private void asSlice() {
+    private void emitAsSlice() {
         appendIndentedLines(STR."""
 
             public static MemorySegment asSlice(MemorySegment ptr, long index) {

--- a/src/main/java/org/openjdk/jextract/impl/StructBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/StructBuilder.java
@@ -133,7 +133,6 @@ final class StructBuilder extends ClassSourceBuilder implements OutputFactory.Bu
 
     @Override
     public void addVar(Declaration.Variable varTree) {
-        Optional<String> fiName = JavaFunctionalInterfaceName.get(varTree);
         String javaName = JavaName.getOrThrow(varTree);
         appendBlankLine();
         String offsetField = emitOffsetFieldDecl(varTree);
@@ -143,7 +142,6 @@ final class StructBuilder extends ClassSourceBuilder implements OutputFactory.Bu
         } else if (Utils.isPointer(varTree.type()) || Utils.isPrimitive(varTree.type())) {
             emitFieldGetter(javaName, varTree, offsetField);
             emitFieldSetter(javaName, varTree, offsetField);
-            fiName.ifPresent(s -> emitFunctionalInterfaceGetter(s, javaName));
         } else {
             throw new IllegalArgumentException(STR."Type not supported: \{varTree.type()}");
         }
@@ -153,15 +151,6 @@ final class StructBuilder extends ClassSourceBuilder implements OutputFactory.Bu
         incrAlign();
         emitDocComment(varTree, header);
         decrAlign();
-    }
-
-    private void emitFunctionalInterfaceGetter(String fiName, String javaName) {
-        appendIndentedLines(STR."""
-
-            public static \{fiName} \{javaName}(MemorySegment segment, Arena scope) {
-                return \{fiName}.ofAddress(\{javaName}(segment), scope);
-            }
-            """);
     }
 
     private void emitFieldGetter(String javaName, Declaration.Variable varTree, String offsetField) {

--- a/src/main/java/org/openjdk/jextract/impl/StructBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/StructBuilder.java
@@ -181,7 +181,7 @@ final class StructBuilder extends ClassSourceBuilder implements OutputFactory.Bu
         String seg = safeParameterName("seg");
         appendIndentedLines(STR."""
 
-            public static MemorySegment \{javaName}$slice(MemorySegment \{seg}) {
+            public static MemorySegment \{javaName}(MemorySegment \{seg}) {
                 return \{seg}.asSlice(\{offsetField}, \{sizeField});
             }
             """);

--- a/test/jtreg/generator/allocCallback/TestAllocCallback.java
+++ b/test/jtreg/generator/allocCallback/TestAllocCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jtreg/generator/allocCallback/TestAllocCallback.java
+++ b/test/jtreg/generator/allocCallback/TestAllocCallback.java
@@ -55,8 +55,8 @@ public class TestAllocCallback {
             var barA = Foo.a(foo, arena).apply();
             var barB = Foo.b(foo, arena).apply(100);
 
-            assertEquals(Bar.a$get(barA), 5);
-            assertEquals(Bar.a$get(barB), 100);
+            assertEquals(Bar.a(barA), 5);
+            assertEquals(Bar.a(barB), 100);
         }
     }
 }

--- a/test/jtreg/generator/allocCallback/TestAllocCallback.java
+++ b/test/jtreg/generator/allocCallback/TestAllocCallback.java
@@ -52,8 +52,8 @@ public class TestAllocCallback {
         try (Arena arena = Arena.ofConfined()) {
             var foo = alloc_callback_h.foo$SEGMENT();
 
-            var barA = Foo.a(foo, arena).apply();
-            var barB = Foo.b(foo, arena).apply(100);
+            var barA = Foo.a.ofAddress(Foo.a(foo), arena).apply();
+            var barB = Foo.b.ofAddress(Foo.b(foo), arena).apply(100);
 
             assertEquals(Bar.a(barA), 5);
             assertEquals(Bar.a(barB), 100);

--- a/test/jtreg/generator/funcPointerInvokers/TestFuncPointerInvokers.java
+++ b/test/jtreg/generator/funcPointerInvokers/TestFuncPointerInvokers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jtreg/generator/funcPointerInvokers/TestFuncPointerInvokers.java
+++ b/test/jtreg/generator/funcPointerInvokers/TestFuncPointerInvokers.java
@@ -52,7 +52,7 @@ public class TestFuncPointerInvokers {
         try (Arena arena = Arena.ofConfined()) {
             AtomicInteger val = new AtomicInteger(-1);
             MemorySegment bar = Bar.allocate(arena);
-            Bar.foo$set(bar, Foo.allocate((i) -> val.set(i), arena));
+            Bar.foo(bar, Foo.allocate((i) -> val.set(i), arena));
             Bar.foo(bar, arena).apply(42);
             assertEquals(val.get(), 42);
         }
@@ -63,8 +63,8 @@ public class TestFuncPointerInvokers {
         try (Arena arena = Arena.ofConfined()) {
             AtomicInteger val = new AtomicInteger(-1);
             MemorySegment bar = Bar.allocate(arena);
-            Bar.foo$set(bar, Foo.allocate((i) -> val.set(i), arena));
-            Foo.ofAddress(Bar.foo$get(bar), arena).apply(42);
+            Bar.foo(bar, Foo.allocate((i) -> val.set(i), arena));
+            Foo.ofAddress(Bar.foo(bar), arena).apply(42);
             assertEquals(val.get(), 42);
         }
     }
@@ -94,7 +94,7 @@ public class TestFuncPointerInvokers {
         try (Arena arena = Arena.ofConfined()) {
             AtomicInteger val = new AtomicInteger(-1);
             MemorySegment baz = Baz.allocate(arena);
-            Baz.fp$set(baz, Baz.fp.allocate((i) -> val.set(i), arena));
+            Baz.fp(baz, Baz.fp.allocate((i) -> val.set(i), arena));
             Baz.fp(baz, arena).apply(42);
             assertEquals(val.get(), 42);
         }
@@ -105,8 +105,8 @@ public class TestFuncPointerInvokers {
         try (Arena arena = Arena.ofConfined()) {
             AtomicInteger val = new AtomicInteger(-1);
             MemorySegment baz = Baz.allocate(arena);
-            Baz.fp$set(baz, Baz.fp.allocate((i) -> val.set(i), arena));
-            Baz.fp.ofAddress(Baz.fp$get(baz), arena).apply(42);
+            Baz.fp(baz, Baz.fp.allocate((i) -> val.set(i), arena));
+            Baz.fp.ofAddress(Baz.fp(baz), arena).apply(42);
             assertEquals(val.get(), 42);
         }
     }

--- a/test/jtreg/generator/funcPointerInvokers/TestFuncPointerInvokers.java
+++ b/test/jtreg/generator/funcPointerInvokers/TestFuncPointerInvokers.java
@@ -73,8 +73,8 @@ public class TestFuncPointerInvokers {
     public void testGlobalTypedef() {
         try (Arena arena = Arena.ofConfined()) {
             AtomicInteger val = new AtomicInteger(-1);
-            f$set(Foo.allocate((i) -> val.set(i), arena));
-            f().apply(42);
+            f(Foo.allocate((i) -> val.set(i), arena));
+            f(arena).apply(42);
             assertEquals(val.get(), 42);
         }
     }
@@ -83,8 +83,8 @@ public class TestFuncPointerInvokers {
     public void testGlobalFITypedef() {
         try (Arena arena = Arena.ofConfined()) {
             AtomicInteger val = new AtomicInteger(-1);
-            f$set(Foo.allocate((i) -> val.set(i), arena));
-            Foo.ofAddress(f$get(), arena).apply(42);
+            f(Foo.allocate((i) -> val.set(i), arena));
+            Foo.ofAddress(f(), arena).apply(42);
             assertEquals(val.get(), 42);
         }
     }
@@ -115,8 +115,8 @@ public class TestFuncPointerInvokers {
     public void testGlobalFunctionPointer() {
         try (Arena arena = Arena.ofConfined()) {
             AtomicInteger val = new AtomicInteger(-1);
-            fp$set(fp.allocate((i) -> val.set(i), arena));
-            fp().apply(42);
+            fp(fp.allocate((i) -> val.set(i), arena));
+            fp(arena).apply(42);
             assertEquals(val.get(), 42);
         }
     }
@@ -125,8 +125,8 @@ public class TestFuncPointerInvokers {
     public void testGlobalFIFunctionPointer() {
         try (Arena arena = Arena.ofConfined()) {
             AtomicInteger val = new AtomicInteger(-1);
-            fp$set(fp.allocate((i) -> val.set(i), arena));
-            fp.ofAddress(fp$get(), arena).apply(42);
+            fp(fp.allocate((i) -> val.set(i), arena));
+            fp.ofAddress(fp(), arena).apply(42);
             assertEquals(val.get(), 42);
         }
     }
@@ -134,8 +134,8 @@ public class TestFuncPointerInvokers {
     @Test
     public void testGlobalFIFunctionPointerAddress() {
         try (Arena arena = Arena.ofConfined()) {
-            fp_addr$set(fp_addr.allocate((addr) -> MemorySegment.ofAddress(addr.address() + 1), arena));
-            assertEquals(fp_addr.ofAddress(fp_addr$get(), arena).apply(MemorySegment.ofAddress(42)), MemorySegment.ofAddress(43));
+            fp_addr(fp_addr.allocate((addr) -> MemorySegment.ofAddress(addr.address() + 1), arena));
+            assertEquals(fp_addr.ofAddress(fp_addr(), arena).apply(MemorySegment.ofAddress(42)), MemorySegment.ofAddress(43));
         }
     }
 }

--- a/test/jtreg/generator/funcPointerInvokers/TestFuncPointerInvokers.java
+++ b/test/jtreg/generator/funcPointerInvokers/TestFuncPointerInvokers.java
@@ -47,16 +47,6 @@ import test.jextract.funcpointers.*;
  * @run testng/othervm --enable-native-access=ALL-UNNAMED TestFuncPointerInvokers
  */
 public class TestFuncPointerInvokers {
-    @Test
-    public void testStructFieldTypedef() {
-        try (Arena arena = Arena.ofConfined()) {
-            AtomicInteger val = new AtomicInteger(-1);
-            MemorySegment bar = Bar.allocate(arena);
-            Bar.foo(bar, Foo.allocate((i) -> val.set(i), arena));
-            Bar.foo(bar, arena).apply(42);
-            assertEquals(val.get(), 42);
-        }
-    }
 
     @Test
     public void testStructFieldFITypedef() {
@@ -65,16 +55,6 @@ public class TestFuncPointerInvokers {
             MemorySegment bar = Bar.allocate(arena);
             Bar.foo(bar, Foo.allocate((i) -> val.set(i), arena));
             Foo.ofAddress(Bar.foo(bar), arena).apply(42);
-            assertEquals(val.get(), 42);
-        }
-    }
-
-    @Test
-    public void testGlobalTypedef() {
-        try (Arena arena = Arena.ofConfined()) {
-            AtomicInteger val = new AtomicInteger(-1);
-            f(Foo.allocate((i) -> val.set(i), arena));
-            f(arena).apply(42);
             assertEquals(val.get(), 42);
         }
     }
@@ -90,33 +70,12 @@ public class TestFuncPointerInvokers {
     }
 
     @Test
-    public void testStructFieldFunctionPointer() {
-        try (Arena arena = Arena.ofConfined()) {
-            AtomicInteger val = new AtomicInteger(-1);
-            MemorySegment baz = Baz.allocate(arena);
-            Baz.fp(baz, Baz.fp.allocate((i) -> val.set(i), arena));
-            Baz.fp(baz, arena).apply(42);
-            assertEquals(val.get(), 42);
-        }
-    }
-
-    @Test
     public void testStructFieldFIFunctionPointer() {
         try (Arena arena = Arena.ofConfined()) {
             AtomicInteger val = new AtomicInteger(-1);
             MemorySegment baz = Baz.allocate(arena);
             Baz.fp(baz, Baz.fp.allocate((i) -> val.set(i), arena));
             Baz.fp.ofAddress(Baz.fp(baz), arena).apply(42);
-            assertEquals(val.get(), 42);
-        }
-    }
-
-    @Test
-    public void testGlobalFunctionPointer() {
-        try (Arena arena = Arena.ofConfined()) {
-            AtomicInteger val = new AtomicInteger(-1);
-            fp(fp.allocate((i) -> val.set(i), arena));
-            fp(arena).apply(42);
             assertEquals(val.get(), 42);
         }
     }

--- a/test/jtreg/generator/test8244938/Test8244938.java
+++ b/test/jtreg/generator/test8244938/Test8244938.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jtreg/generator/test8244938/Test8244938.java
+++ b/test/jtreg/generator/test8244938/Test8244938.java
@@ -54,7 +54,7 @@ public class Test8244938 {
              var seg = func(arena);
              assertEquals(seg.byteSize(), Point.sizeof());
              assertEquals(Point.k(seg), 44);
-             var point2dSeg = Point.point2dSlice(seg);
+             var point2dSeg = Point.point2d$slice(seg);
              assertEquals(Point2D.i(point2dSeg), 567);
              assertEquals(Point2D.j(point2dSeg), 33);
          }

--- a/test/jtreg/generator/test8244938/Test8244938.java
+++ b/test/jtreg/generator/test8244938/Test8244938.java
@@ -53,10 +53,10 @@ public class Test8244938 {
          try (Arena arena = Arena.ofConfined()) {
              var seg = func(arena);
              assertEquals(seg.byteSize(), Point.sizeof());
-             assertEquals(Point.k$get(seg), 44);
-             var point2dSeg = Point.point2d$slice(seg);
-             assertEquals(Point2D.i$get(point2dSeg), 567);
-             assertEquals(Point2D.j$get(point2dSeg), 33);
+             assertEquals(Point.k(seg), 44);
+             var point2dSeg = Point.point2dSlice(seg);
+             assertEquals(Point2D.i(point2dSeg), 567);
+             assertEquals(Point2D.j(point2dSeg), 33);
          }
     }
 }

--- a/test/jtreg/generator/test8244938/Test8244938.java
+++ b/test/jtreg/generator/test8244938/Test8244938.java
@@ -54,7 +54,7 @@ public class Test8244938 {
              var seg = func(arena);
              assertEquals(seg.byteSize(), Point.sizeof());
              assertEquals(Point.k(seg), 44);
-             var point2dSeg = Point.point2d$slice(seg);
+             var point2dSeg = Point.point2d(seg);
              assertEquals(Point2D.i(point2dSeg), 567);
              assertEquals(Point2D.j(point2dSeg), 33);
          }

--- a/test/jtreg/generator/test8245003/Test8245003.java
+++ b/test/jtreg/generator/test8245003/Test8245003.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jtreg/generator/test8245003/Test8245003.java
+++ b/test/jtreg/generator/test8245003/Test8245003.java
@@ -52,16 +52,16 @@ public class Test8245003 {
     public void testStructAccessor() {
         var seg = special_pt$SEGMENT();
         assertEquals(seg.byteSize(), Point.sizeof());
-        assertEquals(Point.x$get(seg), 56);
-        assertEquals(Point.y$get(seg), 75);
+        assertEquals(Point.x(seg), 56);
+        assertEquals(Point.y(seg), 75);
 
         seg = special_pt3d$SEGMENT();
         assertEquals(seg.byteSize(), Point3D.sizeof());
-        assertEquals(Point3D.z$get(seg), 35);
-        var pointSeg = Point3D.p$slice(seg);
+        assertEquals(Point3D.z(seg), 35);
+        var pointSeg = Point3D.pSlice(seg);
         assertEquals(pointSeg.byteSize(), Point.sizeof());
-        assertEquals(Point.x$get(pointSeg), 43);
-        assertEquals(Point.y$get(pointSeg), 45);
+        assertEquals(Point.x(pointSeg), 43);
+        assertEquals(Point.y(pointSeg), 45);
     }
 
     @Test
@@ -78,8 +78,8 @@ public class Test8245003 {
 
         seg = foo$SEGMENT();
         assertEquals(seg.byteSize(), Foo.sizeof());
-        assertEquals(Foo.count$get(seg), 37);
-        var greeting = Foo.greeting$slice(seg);
+        assertEquals(Foo.count(seg), 37);
+        var greeting = Foo.greetingSlice(seg);
         byte[] barr = greeting.toArray(C_CHAR);
         assertEquals(new String(barr), "hello");
     }

--- a/test/jtreg/generator/test8245003/Test8245003.java
+++ b/test/jtreg/generator/test8245003/Test8245003.java
@@ -58,7 +58,7 @@ public class Test8245003 {
         seg = special_pt3d$SEGMENT();
         assertEquals(seg.byteSize(), Point3D.sizeof());
         assertEquals(Point3D.z(seg), 35);
-        var pointSeg = Point3D.pSlice(seg);
+        var pointSeg = Point3D.p$slice(seg);
         assertEquals(pointSeg.byteSize(), Point.sizeof());
         assertEquals(Point.x(pointSeg), 43);
         assertEquals(Point.y(pointSeg), 45);
@@ -79,7 +79,7 @@ public class Test8245003 {
         seg = foo$SEGMENT();
         assertEquals(seg.byteSize(), Foo.sizeof());
         assertEquals(Foo.count(seg), 37);
-        var greeting = Foo.greetingSlice(seg);
+        var greeting = Foo.greeting$slice(seg);
         byte[] barr = greeting.toArray(C_CHAR);
         assertEquals(new String(barr), "hello");
     }

--- a/test/jtreg/generator/test8245003/Test8245003.java
+++ b/test/jtreg/generator/test8245003/Test8245003.java
@@ -58,7 +58,7 @@ public class Test8245003 {
         seg = special_pt3d$SEGMENT();
         assertEquals(seg.byteSize(), Point3D.sizeof());
         assertEquals(Point3D.z(seg), 35);
-        var pointSeg = Point3D.p$slice(seg);
+        var pointSeg = Point3D.p(seg);
         assertEquals(pointSeg.byteSize(), Point.sizeof());
         assertEquals(Point.x(pointSeg), 43);
         assertEquals(Point.y(pointSeg), 45);
@@ -79,7 +79,7 @@ public class Test8245003 {
         seg = foo$SEGMENT();
         assertEquals(seg.byteSize(), Foo.sizeof());
         assertEquals(Foo.count(seg), 37);
-        var greeting = Foo.greeting$slice(seg);
+        var greeting = Foo.greeting(seg);
         byte[] barr = greeting.toArray(C_CHAR);
         assertEquals(new String(barr), "hello");
     }

--- a/test/jtreg/generator/test8246400/LibTest8246400Test.java
+++ b/test/jtreg/generator/test8246400/LibTest8246400Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jtreg/generator/test8246400/LibTest8246400Test.java
+++ b/test/jtreg/generator/test8246400/LibTest8246400Test.java
@@ -53,21 +53,21 @@ public class LibTest8246400Test {
         MemorySegment sum = null;
         try (Arena arena = Arena.ofConfined()) {
             var v1 = Vector.allocate(arena);
-            Vector.x$set(v1, 1.0);
-            Vector.y$set(v1, 0.0);
+            Vector.x(v1, 1.0);
+            Vector.y(v1, 0.0);
 
             var v2 = Vector.allocate(arena);
-            Vector.x$set(v2, 0.0);
-            Vector.y$set(v2, 1.0);
+            Vector.x(v2, 0.0);
+            Vector.y(v2, 1.0);
 
             sum = add(arena, v1, v2);
 
-            assertEquals(Vector.x$get(sum), 1.0, 0.1);
-            assertEquals(Vector.y$get(sum), 1.0, 0.1);
+            assertEquals(Vector.x(sum), 1.0, 0.1);
+            assertEquals(Vector.y(sum), 1.0, 0.1);
 
             MemorySegment callback = cosine_similarity$dot.allocate((a, b) -> {
-                return (Vector.x$get(a) * Vector.x$get(b)) +
-                    (Vector.y$get(a) * Vector.y$get(b));
+                return (Vector.x(a) * Vector.x(b)) +
+                    (Vector.y(a) * Vector.y(b));
             }, arena);
 
             var value = cosine_similarity(v1, v2, callback);

--- a/test/jtreg/generator/test8252465/LibTest8252465Test.java
+++ b/test/jtreg/generator/test8252465/LibTest8252465Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jtreg/generator/test8252465/LibTest8252465Test.java
+++ b/test/jtreg/generator/test8252465/LibTest8252465Test.java
@@ -52,11 +52,11 @@ public class LibTest8252465Test {
     public void test() {
         try (var arena = Arena.ofConfined()) {
             var foo = Foo.allocate(arena);
-            Foo.x$set(foo, 3.14f);
-            assertEquals(Foo.x$get(foo), 3.14f, 0.001f);
+            Foo.x(foo, 3.14f);
+            assertEquals(Foo.x(foo), 3.14f, 0.001f);
             var bar = Bar.allocate(arena);
-            Bar.x$set(bar, -42);
-            assertEquals(Bar.x$get(bar), -42);
+            Bar.x(bar, -42);
+            assertEquals(Bar.x(bar), -42);
         }
     }
 }

--- a/test/jtreg/generator/test8253102/LibTest8253102Test.java
+++ b/test/jtreg/generator/test8253102/LibTest8253102Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jtreg/generator/test8253102/LibTest8253102Test.java
+++ b/test/jtreg/generator/test8253102/LibTest8253102Test.java
@@ -54,8 +54,8 @@ public class LibTest8253102Test {
         try (Arena arena = Arena.ofConfined()) {
             MemorySegment addr = make(14, 99);
             MemorySegment seg = Point.ofAddress(addr, arena);
-            assertEquals(Point.x$get(seg), 14);
-            assertEquals(Point.y$get(seg), 99);
+            assertEquals(Point.x(seg), 14);
+            assertEquals(Point.y(seg), 99);
             freePoint(addr);
         }
     }

--- a/test/jtreg/generator/test8254983/LibTest8254983Test.java
+++ b/test/jtreg/generator/test8254983/LibTest8254983Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jtreg/generator/test8254983/LibTest8254983Test.java
+++ b/test/jtreg/generator/test8254983/LibTest8254983Test.java
@@ -53,8 +53,8 @@ public class LibTest8254983Test {
         try (Arena arena = Arena.ofConfined()) {
             assertEquals(((GroupLayout)Foo._struct.$LAYOUT()).memberLayouts().size(), 1);
             MemorySegment str = Foo._struct.allocate(arena);
-            Foo._struct.x$set(str, 42);
-            assertEquals(Foo._struct.x$get(str), 42);
+            Foo._struct.x(str, 42);
+            assertEquals(Foo._struct.x(str), 42);
         }
     }
 
@@ -63,8 +63,8 @@ public class LibTest8254983Test {
         assertEquals(((GroupLayout)Foo._union._struct.$LAYOUT()).memberLayouts().size(), 2);
         try (Arena arena = Arena.ofConfined()) {
             MemorySegment str = Foo._union._struct.allocate(arena);
-            Foo._union._struct.x$set(str, 42);
-            assertEquals(Foo._union._struct.x$get(str), 42);
+            Foo._union._struct.x(str, 42);
+            assertEquals(Foo._union._struct.x(str), 42);
         }
     }
 }

--- a/test/jtreg/generator/test8257892/LibUnsupportedTest.java
+++ b/test/jtreg/generator/test8257892/LibUnsupportedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jtreg/generator/test8257892/LibUnsupportedTest.java
+++ b/test/jtreg/generator/test8257892/LibUnsupportedTest.java
@@ -61,10 +61,10 @@ public class LibUnsupportedTest {
     public void testAllocateFoo() {
         try (Arena arena = Arena.ofConfined()) {
             var seg = Foo.allocate(arena);
-            Foo.i$set(seg, 32);
-            Foo.c$set(seg, (byte)'z');
-            assertEquals(Foo.i$get(seg), 32);
-            assertEquals(Foo.c$get(seg), (byte)'z');
+            Foo.i(seg, 32);
+            Foo.c(seg, (byte)'z');
+            assertEquals(Foo.i(seg), 32);
+            assertEquals(Foo.c(seg), (byte)'z');
         }
     }
 
@@ -72,10 +72,10 @@ public class LibUnsupportedTest {
     public void testGetFoo() {
         try (Arena arena = Arena.ofConfined()) {
             var seg = Foo.ofAddress(getFoo(), arena);
-            Foo.i$set(seg, 42);
-            Foo.c$set(seg, (byte)'j');
-            assertEquals(Foo.i$get(seg), 42);
-            assertEquals(Foo.c$get(seg), (byte)'j');
+            Foo.i(seg, 42);
+            Foo.c(seg, (byte)'j');
+            assertEquals(Foo.i(seg), 42);
+            assertEquals(Foo.c(seg), (byte)'j');
         }
     }
 

--- a/test/jtreg/generator/test8258605/LibTest8258605Test.java
+++ b/test/jtreg/generator/test8258605/LibTest8258605Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jtreg/generator/test8258605/LibTest8258605Test.java
+++ b/test/jtreg/generator/test8258605/LibTest8258605Test.java
@@ -68,7 +68,7 @@ public class LibTest8258605Test {
              // get struct Foo instance
              var foo = getFoo(arena);
              // make sure that foo.bar is not NULL
-             assertFalse(Foo.bar$get(foo).equals(NULL));
+             assertFalse(Foo.bar(foo).equals(NULL));
 
              f2(foo, CB.allocate(i -> {
                  assertTrue(i == 42);

--- a/test/jtreg/generator/test8261511/Test8261511.java
+++ b/test/jtreg/generator/test8261511/Test8261511.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jtreg/generator/test8261511/Test8261511.java
+++ b/test/jtreg/generator/test8261511/Test8261511.java
@@ -50,7 +50,7 @@ public class Test8261511 {
     @Test
     public void test() {
         try (Arena arena = Arena.ofConfined()) {
-            var funcPtr = Foo.sum$get(get_foo(arena));
+            var funcPtr = Foo.sum(get_foo(arena));
             var sumIface = Foo.sum.ofAddress(funcPtr, arena);
             assertEquals(sumIface.apply(15,20), 35);
             assertEquals(sum(1.2, 4.5), 5.7, 0.001);

--- a/test/jtreg/generator/testGlobalRedefinition/TestGlobalRedefinition.java
+++ b/test/jtreg/generator/testGlobalRedefinition/TestGlobalRedefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jtreg/generator/testGlobalRedefinition/TestGlobalRedefinition.java
+++ b/test/jtreg/generator/testGlobalRedefinition/TestGlobalRedefinition.java
@@ -46,10 +46,10 @@ import static test.jextract.redef.redef_h.*;
 public class TestGlobalRedefinition {
     @Test
     public void test() throws Throwable {
-        Method mGet = redef_h.class.getMethod("x$get");
+        Method mGet = redef_h.class.getMethod("x");
         assertEquals(mGet.getReturnType(), int.class);
 
-        Method mSet = redef_h.class.getMethod("x$set", int.class);
+        Method mSet = redef_h.class.getMethod("x", int.class);
         assertEquals(mSet.getParameterTypes()[0], int.class);
     }
 }

--- a/test/jtreg/generator/testLinkageErrors/TestLinkageErrors.java
+++ b/test/jtreg/generator/testLinkageErrors/TestLinkageErrors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jtreg/generator/testLinkageErrors/TestLinkageErrors.java
+++ b/test/jtreg/generator/testLinkageErrors/TestLinkageErrors.java
@@ -63,8 +63,8 @@ public class TestLinkageErrors {
     public void nullChecksTest() {
         assertThrowsULE(() -> func(), "func");
         assertThrowsULE(() -> func$MH(), "func");
-        assertThrowsULE(() -> x$get(), "x");
-        assertThrowsULE(() -> x$set(1), "x");
+        assertThrowsULE(() -> x(), "x");
+        assertThrowsULE(() -> x(1), "x");
         assertThrowsULE(() -> x$SEGMENT(), "x");
         assertThrowsULE(() -> y$SEGMENT(), "y");
         assertThrowsULE(() -> pt$SEGMENT(), "pt");

--- a/test/jtreg/generator/testStruct/LibStructTest.java
+++ b/test/jtreg/generator/testStruct/LibStructTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jtreg/generator/testStruct/LibStructTest.java
+++ b/test/jtreg/generator/testStruct/LibStructTest.java
@@ -55,8 +55,8 @@ public class LibStructTest {
     public void testMakePoint() {
         try (Arena arena = Arena.ofConfined()) {
             var seg = makePoint(arena, 42, -39);
-            assertEquals(Point.x$get(seg), 42);
-            assertEquals(Point.y$get(seg), -39);
+            assertEquals(Point.x(seg), 42);
+            assertEquals(Point.y(seg), -39);
         }
     }
 
@@ -64,10 +64,10 @@ public class LibStructTest {
     public void testAllocate() {
         try (Arena arena = Arena.ofConfined()) {
             var seg = Point.allocate(arena);
-            Point.x$set(seg, 56);
-            Point.y$set(seg, 65);
-            assertEquals(Point.x$get(seg), 56);
-            assertEquals(Point.y$get(seg), 65);
+            Point.x(seg, 56);
+            Point.y(seg, 65);
+            assertEquals(Point.x(seg), 56);
+            assertEquals(Point.y(seg), 65);
         }
     }
 
@@ -77,13 +77,13 @@ public class LibStructTest {
             var seg = Point.allocateArray(3, arena);
             for (int i = 0; i < 3; i++) {
                 MemorySegment point = Point.$at(seg, i);
-                Point.x$set(point, 56 + i);
-                Point.y$set(point, 65 + i);
+                Point.x(point, 56 + i);
+                Point.y(point, 65 + i);
             }
             for (int i = 0; i < 3; i++) {
                 MemorySegment point = Point.$at(seg, i);
-                assertEquals(Point.x$get(point), 56 + i);
-                assertEquals(Point.y$get(point), 65 + i);
+                assertEquals(Point.x(point), 56 + i);
+                assertEquals(Point.y(point), 65 + i);
             }
         }
     }

--- a/test/jtreg/generator/testStruct/LibStructTest.java
+++ b/test/jtreg/generator/testStruct/LibStructTest.java
@@ -25,6 +25,8 @@ import java.lang.foreign.Arena;
 import java.lang.foreign.GroupLayout;
 import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemoryLayout.PathElement;
+import java.lang.foreign.MemorySegment;
+
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
@@ -74,12 +76,14 @@ public class LibStructTest {
         try (Arena arena = Arena.ofConfined()) {
             var seg = Point.allocateArray(3, arena);
             for (int i = 0; i < 3; i++) {
-                Point.x$set(seg, i, 56 + i);
-                Point.y$set(seg, i, 65 + i);
+                MemorySegment point = Point.$at(seg, i);
+                Point.x$set(point, 56 + i);
+                Point.y$set(point, 65 + i);
             }
             for (int i = 0; i < 3; i++) {
-                assertEquals(Point.x$get(seg, i), 56 + i);
-                assertEquals(Point.y$get(seg, i), 65 + i);
+                MemorySegment point = Point.$at(seg, i);
+                assertEquals(Point.x$get(point), 56 + i);
+                assertEquals(Point.y$get(point), 65 + i);
             }
         }
     }

--- a/test/jtreg/generator/testStruct/LibStructTest.java
+++ b/test/jtreg/generator/testStruct/LibStructTest.java
@@ -76,12 +76,12 @@ public class LibStructTest {
         try (Arena arena = Arena.ofConfined()) {
             var seg = Point.allocateArray(3, arena);
             for (int i = 0; i < 3; i++) {
-                MemorySegment point = Point.$at(seg, i);
+                MemorySegment point = Point.asSlice(seg, i);
                 Point.x(point, 56 + i);
                 Point.y(point, 65 + i);
             }
             for (int i = 0; i < 3; i++) {
-                MemorySegment point = Point.$at(seg, i);
+                MemorySegment point = Point.asSlice(seg, i);
                 assertEquals(Point.x(point), 56 + i);
                 assertEquals(Point.y(point), 65 + i);
             }

--- a/test/testng/org/openjdk/jextract/test/toolprovider/RepeatedDeclsTest.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/RepeatedDeclsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/testng/org/openjdk/jextract/test/toolprovider/RepeatedDeclsTest.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/RepeatedDeclsTest.java
@@ -64,10 +64,10 @@ public class RepeatedDeclsTest extends JextractToolRunner {
             assertNotNull(findMethod(cls, "distance", MemorySegment.class));
 
             // check a getter method for "i"
-            assertNotNull(findMethod(cls, "i$get"));
+            assertNotNull(findMethod(cls, "i"));
 
             // check a setter method for "i"
-            assertNotNull(findMethod(cls, "i$set", int.class));
+            assertNotNull(findMethod(cls, "i", int.class));
 
             // make sure that enum constants are generated fine
             checkIntGetter(cls, "R", 0);

--- a/test/testng/org/openjdk/jextract/test/toolprovider/Test8248415.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/Test8248415.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/testng/org/openjdk/jextract/test/toolprovider/Test8248415.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/Test8248415.java
@@ -40,13 +40,9 @@ public class Test8248415 extends JextractToolRunner {
         try(TestUtils.Loader loader = TestUtils.classLoader(outputPath)) {
             Class<?> nodeClass = loader.loadClass("Node");
 
-            // Check if getters for pointer fields were generated
             checkMethod(nodeClass, "next$get", MemorySegment.class, MemorySegment.class);
-            checkMethod(nodeClass, "next$get", MemorySegment.class, MemorySegment.class, long.class);
-
-            // Check if setters for pointer fields were generated
             checkMethod(nodeClass, "next$set", void.class, MemorySegment.class, MemorySegment.class);
-            checkMethod(nodeClass, "next$set", void.class, MemorySegment.class, long.class, MemorySegment.class);
+            checkMethod(nodeClass, "$at", MemorySegment.class, MemorySegment.class, long.class);
         } finally {
             TestUtils.deleteDir(outputPath);
         }

--- a/test/testng/org/openjdk/jextract/test/toolprovider/Test8248415.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/Test8248415.java
@@ -42,7 +42,7 @@ public class Test8248415 extends JextractToolRunner {
 
             checkMethod(nodeClass, "next", MemorySegment.class, MemorySegment.class);
             checkMethod(nodeClass, "next", void.class, MemorySegment.class, MemorySegment.class);
-            checkMethod(nodeClass, "$at", MemorySegment.class, MemorySegment.class, long.class);
+            checkMethod(nodeClass, "asSlice", MemorySegment.class, MemorySegment.class, long.class);
         } finally {
             TestUtils.deleteDir(outputPath);
         }

--- a/test/testng/org/openjdk/jextract/test/toolprovider/Test8248415.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/Test8248415.java
@@ -40,8 +40,8 @@ public class Test8248415 extends JextractToolRunner {
         try(TestUtils.Loader loader = TestUtils.classLoader(outputPath)) {
             Class<?> nodeClass = loader.loadClass("Node");
 
-            checkMethod(nodeClass, "next$get", MemorySegment.class, MemorySegment.class);
-            checkMethod(nodeClass, "next$set", void.class, MemorySegment.class, MemorySegment.class);
+            checkMethod(nodeClass, "next", MemorySegment.class, MemorySegment.class);
+            checkMethod(nodeClass, "next", void.class, MemorySegment.class, MemorySegment.class);
             checkMethod(nodeClass, "$at", MemorySegment.class, MemorySegment.class, long.class);
         } finally {
             TestUtils.deleteDir(outputPath);

--- a/test/testng/org/openjdk/jextract/test/toolprovider/Test8251943.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/Test8251943.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/testng/org/openjdk/jextract/test/toolprovider/Test8251943.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/Test8251943.java
@@ -47,7 +47,7 @@ public class Test8251943 extends JextractToolRunner {
             Class<?> fooClass = loader.loadClass("Foo");
             assertNotNull(findMethod(fooClass, "bar", MemorySegment.class));
             assertNull(findMethod(fooClass, "names", MemorySegment.class));
-            assertNotNull(findMethod(fooClass, "namesSlice", MemorySegment.class));
+            assertNotNull(findMethod(fooClass, "names$slice", MemorySegment.class));
         } finally {
             TestUtils.deleteDir(outputPath);
         }

--- a/test/testng/org/openjdk/jextract/test/toolprovider/Test8251943.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/Test8251943.java
@@ -46,8 +46,7 @@ public class Test8251943 extends JextractToolRunner {
 
             Class<?> fooClass = loader.loadClass("Foo");
             assertNotNull(findMethod(fooClass, "bar", MemorySegment.class));
-            assertNull(findMethod(fooClass, "names", MemorySegment.class));
-            assertNotNull(findMethod(fooClass, "names$slice", MemorySegment.class));
+            assertNotNull(findMethod(fooClass, "names", MemorySegment.class));
         } finally {
             TestUtils.deleteDir(outputPath);
         }

--- a/test/testng/org/openjdk/jextract/test/toolprovider/Test8251943.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/Test8251943.java
@@ -45,9 +45,9 @@ public class Test8251943 extends JextractToolRunner {
             assertNotNull(findMethod(headerClass, "tzname$SEGMENT"));
 
             Class<?> fooClass = loader.loadClass("Foo");
-            assertNotNull(findMethod(fooClass, "bar$get", MemorySegment.class));
-            assertNull(findMethod(fooClass, "names$get", MemorySegment.class));
-            assertNotNull(findMethod(fooClass, "names$slice", MemorySegment.class));
+            assertNotNull(findMethod(fooClass, "bar", MemorySegment.class));
+            assertNull(findMethod(fooClass, "names", MemorySegment.class));
+            assertNotNull(findMethod(fooClass, "namesSlice", MemorySegment.class));
         } finally {
             TestUtils.deleteDir(outputPath);
         }

--- a/test/testng/org/openjdk/jextract/test/toolprovider/Test8260705.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/Test8260705.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/testng/org/openjdk/jextract/test/toolprovider/Test8260705.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/Test8260705.java
@@ -44,14 +44,14 @@ public class Test8260705 extends JextractToolRunner {
             Class<?> FooClass = loader.loadClass("Foo");
             checkMethod(FooClass, "c", byte.class, MemorySegment.class);
             checkMethod(FooClass, "c", void.class, MemorySegment.class, byte.class);
-            checkMethod(FooClass, "$at", MemorySegment.class, MemorySegment.class, long.class);
+            checkMethod(FooClass, "asSlice", MemorySegment.class, MemorySegment.class, long.class);
 
             Class<?> Foo2Class = loader.loadClass("Foo2");
             checkMethod(Foo2Class, "z", int.class, MemorySegment.class);
             checkMethod(Foo2Class, "z", void.class, MemorySegment.class, int.class);
             checkMethod(Foo2Class, "w", int.class, MemorySegment.class);
             checkMethod(Foo2Class, "w", void.class, MemorySegment.class, int.class);
-            checkMethod(Foo2Class, "$at", MemorySegment.class, MemorySegment.class, long.class);
+            checkMethod(Foo2Class, "asSlice", MemorySegment.class, MemorySegment.class, long.class);
 
             assertNotNull(loader.loadClass("Foo3"));
 

--- a/test/testng/org/openjdk/jextract/test/toolprovider/Test8260705.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/Test8260705.java
@@ -42,15 +42,15 @@ public class Test8260705 extends JextractToolRunner {
         run("--output", outputPath.toString(), headerFile.toString()).checkSuccess();
         try(TestUtils.Loader loader = TestUtils.classLoader(outputPath)) {
             Class<?> FooClass = loader.loadClass("Foo");
-            checkMethod(FooClass, "c$get", byte.class, MemorySegment.class);
-            checkMethod(FooClass, "c$set", void.class, MemorySegment.class, byte.class);
+            checkMethod(FooClass, "c", byte.class, MemorySegment.class);
+            checkMethod(FooClass, "c", void.class, MemorySegment.class, byte.class);
             checkMethod(FooClass, "$at", MemorySegment.class, MemorySegment.class, long.class);
 
             Class<?> Foo2Class = loader.loadClass("Foo2");
-            checkMethod(Foo2Class, "z$get", int.class, MemorySegment.class);
-            checkMethod(Foo2Class, "z$set", void.class, MemorySegment.class, int.class);
-            checkMethod(Foo2Class, "w$get", int.class, MemorySegment.class);
-            checkMethod(Foo2Class, "w$set", void.class, MemorySegment.class, int.class);
+            checkMethod(Foo2Class, "z", int.class, MemorySegment.class);
+            checkMethod(Foo2Class, "z", void.class, MemorySegment.class, int.class);
+            checkMethod(Foo2Class, "w", int.class, MemorySegment.class);
+            checkMethod(Foo2Class, "w", void.class, MemorySegment.class, int.class);
             checkMethod(Foo2Class, "$at", MemorySegment.class, MemorySegment.class, long.class);
 
             assertNotNull(loader.loadClass("Foo3"));

--- a/test/testng/org/openjdk/jextract/test/toolprovider/Test8260705.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/Test8260705.java
@@ -43,19 +43,15 @@ public class Test8260705 extends JextractToolRunner {
         try(TestUtils.Loader loader = TestUtils.classLoader(outputPath)) {
             Class<?> FooClass = loader.loadClass("Foo");
             checkMethod(FooClass, "c$get", byte.class, MemorySegment.class);
-            checkMethod(FooClass, "c$get", byte.class, MemorySegment.class, long.class);
             checkMethod(FooClass, "c$set", void.class, MemorySegment.class, byte.class);
-            checkMethod(FooClass, "c$set", void.class, MemorySegment.class, long.class, byte.class);
+            checkMethod(FooClass, "$at", MemorySegment.class, MemorySegment.class, long.class);
 
             Class<?> Foo2Class = loader.loadClass("Foo2");
             checkMethod(Foo2Class, "z$get", int.class, MemorySegment.class);
-            checkMethod(Foo2Class, "z$get", int.class, MemorySegment.class, long.class);
             checkMethod(Foo2Class, "z$set", void.class, MemorySegment.class, int.class);
-            checkMethod(Foo2Class, "z$set", void.class, MemorySegment.class, long.class, int.class);
             checkMethod(Foo2Class, "w$get", int.class, MemorySegment.class);
-            checkMethod(Foo2Class, "w$get", int.class, MemorySegment.class, long.class);
             checkMethod(Foo2Class, "w$set", void.class, MemorySegment.class, int.class);
-            checkMethod(Foo2Class, "w$set", void.class, MemorySegment.class, long.class, int.class);
+            checkMethod(Foo2Class, "$at", MemorySegment.class, MemorySegment.class, long.class);
 
             assertNotNull(loader.loadClass("Foo3"));
 
@@ -79,4 +75,3 @@ public class Test8260705 extends JextractToolRunner {
         }
     }
 }
-

--- a/test/testng/org/openjdk/jextract/test/toolprovider/Test8260717.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/Test8260717.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/testng/org/openjdk/jextract/test/toolprovider/Test8260717.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/Test8260717.java
@@ -39,15 +39,12 @@ public class Test8260717 extends JextractToolRunner {
         try(TestUtils.Loader loader = TestUtils.classLoader(outputPath)) {
             Class<?> FooClass = loader.loadClass("foo_t");
             checkMethod(FooClass, "s$get", short.class, MemorySegment.class);
-            checkMethod(FooClass, "s$get", short.class, MemorySegment.class, long.class);
             checkMethod(FooClass, "s$set", void.class, MemorySegment.class, short.class);
-            checkMethod(FooClass, "s$set", void.class, MemorySegment.class, long.class, short.class);
 
             checkMethod(FooClass, "ptr$get", MemorySegment.class, MemorySegment.class);
-            checkMethod(FooClass, "ptr$get", MemorySegment.class, MemorySegment.class, long.class);
             checkMethod(FooClass, "ptr$set", void.class, MemorySegment.class, MemorySegment.class);
-            checkMethod(FooClass, "ptr$set", void.class, MemorySegment.class, long.class, MemorySegment.class);
 
+            checkMethod(FooClass, "$at", MemorySegment.class, MemorySegment.class, long.class);
         } finally {
             TestUtils.deleteDir(outputPath);
         }

--- a/test/testng/org/openjdk/jextract/test/toolprovider/Test8260717.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/Test8260717.java
@@ -44,7 +44,7 @@ public class Test8260717 extends JextractToolRunner {
             checkMethod(FooClass, "ptr", MemorySegment.class, MemorySegment.class);
             checkMethod(FooClass, "ptr", void.class, MemorySegment.class, MemorySegment.class);
 
-            checkMethod(FooClass, "$at", MemorySegment.class, MemorySegment.class, long.class);
+            checkMethod(FooClass, "asSlice", MemorySegment.class, MemorySegment.class, long.class);
         } finally {
             TestUtils.deleteDir(outputPath);
         }

--- a/test/testng/org/openjdk/jextract/test/toolprovider/Test8260717.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/Test8260717.java
@@ -38,11 +38,11 @@ public class Test8260717 extends JextractToolRunner {
         run("--output", outputPath.toString(), headerFile.toString()).checkSuccess();
         try(TestUtils.Loader loader = TestUtils.classLoader(outputPath)) {
             Class<?> FooClass = loader.loadClass("foo_t");
-            checkMethod(FooClass, "s$get", short.class, MemorySegment.class);
-            checkMethod(FooClass, "s$set", void.class, MemorySegment.class, short.class);
+            checkMethod(FooClass, "s", short.class, MemorySegment.class);
+            checkMethod(FooClass, "s", void.class, MemorySegment.class, short.class);
 
-            checkMethod(FooClass, "ptr$get", MemorySegment.class, MemorySegment.class);
-            checkMethod(FooClass, "ptr$set", void.class, MemorySegment.class, MemorySegment.class);
+            checkMethod(FooClass, "ptr", MemorySegment.class, MemorySegment.class);
+            checkMethod(FooClass, "ptr", void.class, MemorySegment.class, MemorySegment.class);
 
             checkMethod(FooClass, "$at", MemorySegment.class, MemorySegment.class, long.class);
         } finally {

--- a/test/testng/org/openjdk/jextract/test/toolprovider/Test8260929.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/Test8260929.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/testng/org/openjdk/jextract/test/toolprovider/Test8260929.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/Test8260929.java
@@ -44,14 +44,12 @@ public class Test8260929 extends JextractToolRunner {
             assertNotNull(rab2Class);
 
             checkMethod(rab2Class, "y$get", int.class, MemorySegment.class);
-            checkMethod(rab2Class, "y$get", int.class, MemorySegment.class, long.class);
             checkMethod(rab2Class, "y$set", void.class, MemorySegment.class, int.class);
-            checkMethod(rab2Class, "y$set", void.class, MemorySegment.class, long.class, int.class);
 
             checkMethod(rab2Class, "x$get", short.class, MemorySegment.class);
-            checkMethod(rab2Class, "x$get", short.class, MemorySegment.class, long.class);
             checkMethod(rab2Class, "x$set", void.class, MemorySegment.class, short.class);
-            checkMethod(rab2Class, "x$set", void.class, MemorySegment.class, long.class, short.class);
+
+            checkMethod(rab2Class, "$at", MemorySegment.class, MemorySegment.class, long.class);
         } finally {
             TestUtils.deleteDir(outputPath);
         }

--- a/test/testng/org/openjdk/jextract/test/toolprovider/Test8260929.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/Test8260929.java
@@ -43,11 +43,11 @@ public class Test8260929 extends JextractToolRunner {
             Class<?> rab2Class = loader.loadClass("rab2");
             assertNotNull(rab2Class);
 
-            checkMethod(rab2Class, "y$get", int.class, MemorySegment.class);
-            checkMethod(rab2Class, "y$set", void.class, MemorySegment.class, int.class);
+            checkMethod(rab2Class, "y", int.class, MemorySegment.class);
+            checkMethod(rab2Class, "y", void.class, MemorySegment.class, int.class);
 
-            checkMethod(rab2Class, "x$get", short.class, MemorySegment.class);
-            checkMethod(rab2Class, "x$set", void.class, MemorySegment.class, short.class);
+            checkMethod(rab2Class, "x", short.class, MemorySegment.class);
+            checkMethod(rab2Class, "x", void.class, MemorySegment.class, short.class);
 
             checkMethod(rab2Class, "$at", MemorySegment.class, MemorySegment.class, long.class);
         } finally {

--- a/test/testng/org/openjdk/jextract/test/toolprovider/Test8260929.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/Test8260929.java
@@ -49,7 +49,7 @@ public class Test8260929 extends JextractToolRunner {
             checkMethod(rab2Class, "x", short.class, MemorySegment.class);
             checkMethod(rab2Class, "x", void.class, MemorySegment.class, short.class);
 
-            checkMethod(rab2Class, "$at", MemorySegment.class, MemorySegment.class, long.class);
+            checkMethod(rab2Class, "asSlice", MemorySegment.class, MemorySegment.class, long.class);
         } finally {
             TestUtils.deleteDir(outputPath);
         }

--- a/test/testng/org/openjdk/jextract/test/toolprovider/Test8261578.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/Test8261578.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/testng/org/openjdk/jextract/test/toolprovider/Test8261578.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/Test8261578.java
@@ -41,7 +41,7 @@ public class Test8261578 extends JextractToolRunner {
             Class<?> ndpi_class = loader.loadClass("ndpi_flow_tcp_struct");
             assertNotNull(ndpi_class);
 
-            checkMethod(ndpi_class, "gnutella_msg_id$slice", MemorySegment.class, MemorySegment.class);
+            checkMethod(ndpi_class, "gnutella_msg_id", MemorySegment.class, MemorySegment.class);
         } finally {
             TestUtils.deleteDir(outputPath);
         }
@@ -56,7 +56,7 @@ public class Test8261578 extends JextractToolRunner {
             Class<?> foo_class = loader.loadClass("foo");
             assertNotNull(foo_class);
 
-            checkMethod(foo_class, "clear_color$slice", MemorySegment.class, MemorySegment.class);
+            checkMethod(foo_class, "clear_color", MemorySegment.class, MemorySegment.class);
             checkMethod(foo_class, "clear_z", int.class, MemorySegment.class);
             checkMethod(foo_class, "clear_z", void.class, MemorySegment.class, int.class);
             checkMethod(foo_class, "clear_s", byte.class, MemorySegment.class);

--- a/test/testng/org/openjdk/jextract/test/toolprovider/Test8261578.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/Test8261578.java
@@ -41,7 +41,7 @@ public class Test8261578 extends JextractToolRunner {
             Class<?> ndpi_class = loader.loadClass("ndpi_flow_tcp_struct");
             assertNotNull(ndpi_class);
 
-            checkMethod(ndpi_class, "gnutella_msg_id$slice", MemorySegment.class, MemorySegment.class);
+            checkMethod(ndpi_class, "gnutella_msg_idSlice", MemorySegment.class, MemorySegment.class);
         } finally {
             TestUtils.deleteDir(outputPath);
         }
@@ -56,11 +56,11 @@ public class Test8261578 extends JextractToolRunner {
             Class<?> foo_class = loader.loadClass("foo");
             assertNotNull(foo_class);
 
-            checkMethod(foo_class, "clear_color$slice", MemorySegment.class, MemorySegment.class);
-            checkMethod(foo_class, "clear_z$get", int.class, MemorySegment.class);
-            checkMethod(foo_class, "clear_z$set", void.class, MemorySegment.class, int.class);
-            checkMethod(foo_class, "clear_s$get", byte.class, MemorySegment.class);
-            checkMethod(foo_class, "clear_s$set", void.class, MemorySegment.class, byte.class);
+            checkMethod(foo_class, "clear_colorSlice", MemorySegment.class, MemorySegment.class);
+            checkMethod(foo_class, "clear_z", int.class, MemorySegment.class);
+            checkMethod(foo_class, "clear_z", void.class, MemorySegment.class, int.class);
+            checkMethod(foo_class, "clear_s", byte.class, MemorySegment.class);
+            checkMethod(foo_class, "clear_s", void.class, MemorySegment.class, byte.class);
         } finally {
             TestUtils.deleteDir(outputPath);
         }
@@ -75,8 +75,8 @@ public class Test8261578 extends JextractToolRunner {
             Class<?> plugin_class = loader.loadClass("PluginCodec_H323AudioG7231AnnexC");
             assertNotNull(plugin_class);
 
-            checkMethod(plugin_class, "maxAl_sduAudioFrames$get", byte.class, MemorySegment.class);
-            checkMethod(plugin_class, "maxAl_sduAudioFrames$set", void.class, MemorySegment.class, byte.class);
+            checkMethod(plugin_class, "maxAl_sduAudioFrames", byte.class, MemorySegment.class);
+            checkMethod(plugin_class, "maxAl_sduAudioFrames", void.class, MemorySegment.class, byte.class);
         } finally {
             TestUtils.deleteDir(outputPath);
         }

--- a/test/testng/org/openjdk/jextract/test/toolprovider/Test8261578.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/Test8261578.java
@@ -41,7 +41,7 @@ public class Test8261578 extends JextractToolRunner {
             Class<?> ndpi_class = loader.loadClass("ndpi_flow_tcp_struct");
             assertNotNull(ndpi_class);
 
-            checkMethod(ndpi_class, "gnutella_msg_idSlice", MemorySegment.class, MemorySegment.class);
+            checkMethod(ndpi_class, "gnutella_msg_id$slice", MemorySegment.class, MemorySegment.class);
         } finally {
             TestUtils.deleteDir(outputPath);
         }
@@ -56,7 +56,7 @@ public class Test8261578 extends JextractToolRunner {
             Class<?> foo_class = loader.loadClass("foo");
             assertNotNull(foo_class);
 
-            checkMethod(foo_class, "clear_colorSlice", MemorySegment.class, MemorySegment.class);
+            checkMethod(foo_class, "clear_color$slice", MemorySegment.class, MemorySegment.class);
             checkMethod(foo_class, "clear_z", int.class, MemorySegment.class);
             checkMethod(foo_class, "clear_z", void.class, MemorySegment.class, int.class);
             checkMethod(foo_class, "clear_s", byte.class, MemorySegment.class);

--- a/test/testng/org/openjdk/jextract/test/toolprovider/TestClassGeneration.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/TestClassGeneration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/testng/org/openjdk/jextract/test/toolprovider/TestClassGeneration.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/TestClassGeneration.java
@@ -191,8 +191,8 @@ public class TestClassGeneration extends JextractToolRunner {
             assertEquals(offsetField.getType(), long.class);
             assertEquals(offsetField.get(null), structLayout.byteOffset(PathElement.groupElement(memberName)));
 
-            Method getter = checkMethod(structCls, memberName + "$get", expectedType, MemorySegment.class);
-            Method setter = checkMethod(structCls, memberName + "$set", void.class, MemorySegment.class, expectedType);
+            Method getter = checkMethod(structCls, memberName + "", expectedType, MemorySegment.class);
+            Method setter = checkMethod(structCls, memberName + "", void.class, MemorySegment.class, expectedType);
             MemorySegment addr = struct;
             setter.invoke(null, addr, testValue);
             assertEquals(getter.invoke(null, addr), testValue);

--- a/test/testng/org/openjdk/jextract/test/toolprovider/TestClassGeneration.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/TestClassGeneration.java
@@ -170,11 +170,10 @@ public class TestClassGeneration extends JextractToolRunner {
         Method addr_getter = checkMethod(cls, name + "$SEGMENT", MemorySegment.class);
         MemorySegment segment = (MemorySegment)addr_getter.invoke(null);
 
-        Method getter = checkMethod(cls, name + "$get", expectedType);
+        Method getter = checkMethod(cls, name, expectedType);
         assertEquals(getter.invoke(segment), expectedValue);
 
-        checkMethod(cls, name + "$get", expectedType);
-        checkMethod(cls, name + "$set", void.class, expectedType);
+        checkMethod(cls, name, void.class, expectedType);
     }
 
     @Test(dataProvider = "structMembers")
@@ -191,8 +190,8 @@ public class TestClassGeneration extends JextractToolRunner {
             assertEquals(offsetField.getType(), long.class);
             assertEquals(offsetField.get(null), structLayout.byteOffset(PathElement.groupElement(memberName)));
 
-            Method getter = checkMethod(structCls, memberName + "", expectedType, MemorySegment.class);
-            Method setter = checkMethod(structCls, memberName + "", void.class, MemorySegment.class, expectedType);
+            Method getter = checkMethod(structCls, memberName, expectedType, MemorySegment.class);
+            Method setter = checkMethod(structCls, memberName, void.class, MemorySegment.class, expectedType);
             MemorySegment addr = struct;
             setter.invoke(null, addr, testValue);
             assertEquals(getter.invoke(null, addr), testValue);

--- a/test/testng/org/openjdk/jextract/test/toolprovider/TestFilters.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/TestFilters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/testng/org/openjdk/jextract/test/toolprovider/TestFilters.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/TestFilters.java
@@ -106,7 +106,7 @@ public class TestFilters extends JextractToolRunner {
         Object get(Class<?> headerClass) {
             return switch (this) {
                 case FUNCTION, MACRO_CONSTANT, ENUM_CONSTANT -> findMethod(headerClass, symbolName);
-                case VAR -> findMethod(headerClass, symbolName + "$get");
+                case VAR -> findMethod(headerClass, symbolName);
                 case TYPEDEF -> findField(headerClass, symbolName);
                 case STRUCT, UNION -> {
                     try {

--- a/test/testng/org/openjdk/jextract/test/toolprovider/TestNested.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/TestNested.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/testng/org/openjdk/jextract/test/toolprovider/TestNested.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/TestNested.java
@@ -153,7 +153,7 @@ public class TestNested extends JextractToolRunner {
                                        MemoryLayout fieldLayout) {
         try {
             if (type == MemorySegment.class) {
-                Method slicer = cls.getMethod(fieldName + "$slice", MemorySegment.class);
+                Method slicer = cls.getMethod(fieldName + "Slice", MemorySegment.class);
                 assertEquals(slicer.getReturnType(), MemorySegment.class);
                 try (Arena arena = Arena.ofConfined()) {
                     MemorySegment struct = arena.allocate(layout);
@@ -161,9 +161,9 @@ public class TestNested extends JextractToolRunner {
                     assertEquals(slice.byteSize(), fieldLayout.byteSize());
                 }
             } else {
-                Method getter = cls.getMethod(fieldName + "$get", MemorySegment.class);
+                Method getter = cls.getMethod(fieldName + "", MemorySegment.class);
                 assertEquals(getter.getReturnType(), type);
-                Method setter = cls.getMethod(fieldName + "$set", MemorySegment.class, type);
+                Method setter = cls.getMethod(fieldName + "", MemorySegment.class, type);
                 assertEquals(setter.getReturnType(), void.class);
 
                 Object zero = MethodHandles.zero(type).invoke();

--- a/test/testng/org/openjdk/jextract/test/toolprovider/TestNested.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/TestNested.java
@@ -153,7 +153,7 @@ public class TestNested extends JextractToolRunner {
                                        MemoryLayout fieldLayout) {
         try {
             if (type == MemorySegment.class) {
-                Method slicer = cls.getMethod(fieldName + "$slice", MemorySegment.class);
+                Method slicer = cls.getMethod(fieldName, MemorySegment.class);
                 assertEquals(slicer.getReturnType(), MemorySegment.class);
                 try (Arena arena = Arena.ofConfined()) {
                     MemorySegment struct = arena.allocate(layout);

--- a/test/testng/org/openjdk/jextract/test/toolprovider/TestNested.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/TestNested.java
@@ -153,7 +153,7 @@ public class TestNested extends JextractToolRunner {
                                        MemoryLayout fieldLayout) {
         try {
             if (type == MemorySegment.class) {
-                Method slicer = cls.getMethod(fieldName + "Slice", MemorySegment.class);
+                Method slicer = cls.getMethod(fieldName + "$slice", MemorySegment.class);
                 assertEquals(slicer.getReturnType(), MemorySegment.class);
                 try (Arena arena = Arena.ofConfined()) {
                     MemorySegment struct = arena.allocate(layout);
@@ -161,9 +161,9 @@ public class TestNested extends JextractToolRunner {
                     assertEquals(slice.byteSize(), fieldLayout.byteSize());
                 }
             } else {
-                Method getter = cls.getMethod(fieldName + "", MemorySegment.class);
+                Method getter = cls.getMethod(fieldName, MemorySegment.class);
                 assertEquals(getter.getReturnType(), type);
-                Method setter = cls.getMethod(fieldName + "", MemorySegment.class, type);
+                Method setter = cls.getMethod(fieldName, MemorySegment.class, type);
                 assertEquals(setter.getReturnType(), void.class);
 
                 Object zero = MethodHandles.zero(type).invoke();


### PR DESCRIPTION
Drop the `$get` and `$set` from the getter/setter names.

To ensure that we don't run into any clashes with the indexed accessors on structs (e.g. because a `long` field setter would clash with the indexed getter), we replace the indexed accessors with a 'asSlice' method which can be used to slice a given pointer using an index. This turns the following access pattern:

    MemorySegment arr = ...
    int x = Foo.x$get(arr, 10); // old 

Into this:

    MemorySegment arr = ...
    MemorySegment theFoo = Foo.asSlice(arr, 10);
    int x = Foo.x(theFoo); // new 

This then allows us to drop the indexed accessors altogether, thus avoiding a name clash.

---

This patch also drops the getters (both fro globals and struct fields) which return instances of a functional interface. There is an issue that the new getter name will clash with the FI instance getter (which was already using the nice name), but when discussing this with Maurizio we realized that returning wrappers, like these FI instances, is not really in the spirit of the current 'all-static' approach that jextract takes. So, this patch drops the FI instance getters. For now, the samples will manually wrap the address in an FI instance, until we address: https://bugs.openjdk.org/browse/CODETOOLS-7903628

Note: I did not test the LibffmpegMain and PanamaTime changes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Issues
 * [CODETOOLS-7903584](https://bugs.openjdk.org/browse/CODETOOLS-7903584): Revisit struct accessors (**Enhancement** - P3)
 * [CODETOOLS-7903417](https://bugs.openjdk.org/browse/CODETOOLS-7903417): Struct array slice accessor (**Enhancement** - P4)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**) ⚠️ Review applies to [d527b3f7](https://git.openjdk.org/jextract/pull/175/files/d527b3f7b04fe4577487e4ae1240bff3cdbef2fe)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/175/head:pull/175` \
`$ git checkout pull/175`

Update a local copy of the PR: \
`$ git checkout pull/175` \
`$ git pull https://git.openjdk.org/jextract.git pull/175/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 175`

View PR using the GUI difftool: \
`$ git pr show -t 175`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/175.diff">https://git.openjdk.org/jextract/pull/175.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/175#issuecomment-1892374674)