### PR TITLE
7903630: jextract emits duplicate symbols for macro clashing with enum constants

### DIFF
--- a/src/main/java/org/openjdk/jextract/impl/DuplicateFilter.java
+++ b/src/main/java/org/openjdk/jextract/impl/DuplicateFilter.java
@@ -112,6 +112,7 @@ final class DuplicateFilter implements Declaration.Visitor<Void, Void> {
     @java.lang.Override
     public Void visitScoped(Declaration.Scoped d, Void aVoid) {
         if (Utils.isEnum(d)) {
+            // enum constants might clash with macro constants with same name
             d.members().forEach(m -> m.accept(this, null));
         }
         return null;

--- a/src/main/java/org/openjdk/jextract/impl/DuplicateFilter.java
+++ b/src/main/java/org/openjdk/jextract/impl/DuplicateFilter.java
@@ -109,6 +109,14 @@ final class DuplicateFilter implements Declaration.Visitor<Void, Void> {
         return null;
     }
 
+    @java.lang.Override
+    public Void visitScoped(Declaration.Scoped d, Void aVoid) {
+        if (Utils.isEnum(d)) {
+            d.members().forEach(m -> m.accept(this, null));
+        }
+        return null;
+    }
+
     @Override
     public Void visitDeclaration(Declaration decl, Void ignored) {
         return null;

--- a/test/testng/org/openjdk/jextract/test/toolprovider/ConstantsTest.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/ConstantsTest.java
@@ -94,6 +94,7 @@ public class ConstantsTest extends JextractToolRunner {
                 { "BOOL_VALUE", boolean.class, equalsTo(true) },
                 { "SUB", int.class, equalsTo( 7 ) },
                 { "SEVEN", int.class, equalsTo(7) },
+                { "EIGHT", int.class, equalsTo(8) },
                 // pointer type values
                 { "STR", MemorySegment.class, equalsToJavaStr("Hello") },
                 { "QUOTE", MemorySegment.class, equalsToJavaStr("QUOTE") },

--- a/test/testng/org/openjdk/jextract/test/toolprovider/ConstantsTest.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/ConstantsTest.java
@@ -93,6 +93,7 @@ public class ConstantsTest extends JextractToolRunner {
                 { "MULTICHAR_VALUE", int.class, equalsTo(26728) },  //integer char constants have type int
                 { "BOOL_VALUE", boolean.class, equalsTo(true) },
                 { "SUB", int.class, equalsTo( 7 ) },
+                { "SEVEN", int.class, equalsTo(7) },
                 // pointer type values
                 { "STR", MemorySegment.class, equalsToJavaStr("Hello") },
                 { "QUOTE", MemorySegment.class, equalsToJavaStr("QUOTE") },

--- a/test/testng/org/openjdk/jextract/test/toolprovider/constants.h
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/constants.h
@@ -66,3 +66,8 @@
 #define F_PTR (void*) 0xFFFFFFFFFFFFFFFFLL; // all 1s
 
 #define ARRAY { 0, 1, 2, 3, 4, 5 }
+
+enum AnEnum {
+    SEVEN = 7,
+    #define SEVEN SEVEN
+};

--- a/test/testng/org/openjdk/jextract/test/toolprovider/constants.h
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/constants.h
@@ -70,4 +70,5 @@
 enum AnEnum {
     SEVEN = 7,
     #define SEVEN SEVEN
+    #define EIGHT SEVEN + 1
 };


### PR DESCRIPTION
The removal of `EnumConstantLifter` caused certain name conflicts to go undetected by `DuplicateFilter`. More specifically, if a macro constant has same name as that of an enum constant, given the enum constant is no longer lifted to toplevel, `DuplicateFilter` will not see the clash. The fix is to tweak `DuplicateFilter` to recurse into enums.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Issue
 * [CODETOOLS-7903630](https://bugs.openjdk.org/browse/CODETOOLS-7903630): jextract emits duplicate symbols for macro clashing with enum constants (**Bug** - P4)


### Reviewers
 * [Athijegannathan Sundararajan](https://openjdk.org/census#sundar) (@sundararajana - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/177/head:pull/177` \
`$ git checkout pull/177`

Update a local copy of the PR: \
`$ git checkout pull/177` \
`$ git pull https://git.openjdk.org/jextract.git pull/177/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 177`

View PR using the GUI difftool: \
`$ git pr show -t 177`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/177.diff">https://git.openjdk.org/jextract/pull/177.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/177#issuecomment-1893607745)