### PR TITLE
7903626: Add struct helper method to reintrepret an array of structs

### DIFF
--- a/src/main/java/org/openjdk/jextract/impl/SourceFileBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/SourceFileBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/main/java/org/openjdk/jextract/impl/SourceFileBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/SourceFileBuilder.java
@@ -75,6 +75,7 @@ final class SourceFileBuilder {
             import java.lang.foreign.*;
             import java.nio.ByteOrder;
             import java.util.*;
+            import java.util.function.*;
             import java.util.stream.*;
 
             import static java.lang.foreign.ValueLayout.*;

--- a/src/main/java/org/openjdk/jextract/impl/StructBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/StructBuilder.java
@@ -221,7 +221,7 @@ final class StructBuilder extends ClassSourceBuilder implements OutputFactory.Bu
         appendIndentedLines("""
 
             public static MemorySegment reinterpret(MemorySegment addr, Arena scope, Consumer<MemorySegment> cleanup) {
-                return addr.reinterpret($LAYOUT().byteSize(), scope, cleanup);
+                return reinterpret(addr, 1, scope, cleanup);
             }
 
             public static MemorySegment reinterpret(MemorySegment addr, long elementCount, Arena scope, Consumer<MemorySegment> cleanup) {

--- a/src/main/java/org/openjdk/jextract/impl/StructBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/StructBuilder.java
@@ -92,7 +92,7 @@ final class StructBuilder extends ClassSourceBuilder implements OutputFactory.Bu
             emitSizeof();
             emitAllocatorAllocate();
             emitAllocatorAllocateArray();
-            emitOfAddressScoped();
+            emitReinterpret();
             classEnd();
             if (isNested()) {
                 // we are nested. Decrease align
@@ -217,11 +217,15 @@ final class StructBuilder extends ClassSourceBuilder implements OutputFactory.Bu
             """);
     }
 
-    private void emitOfAddressScoped() {
+    private void emitReinterpret() {
         appendIndentedLines("""
 
-            public static MemorySegment ofAddress(MemorySegment addr, Arena scope) {
-                return addr.reinterpret($LAYOUT().byteSize(), scope, null);
+            public static MemorySegment reinterpret(MemorySegment addr, Arena scope, Consumer<MemorySegment> cleanup) {
+                return addr.reinterpret($LAYOUT().byteSize(), scope, cleanup);
+            }
+
+            public static MemorySegment reinterpret(MemorySegment addr, long elementCount, Arena scope, Consumer<MemorySegment> cleanup) {
+                return addr.reinterpret($LAYOUT().byteSize() * elementCount, scope, cleanup);
             }
             """);
     }

--- a/test/TEST.groups
+++ b/test/TEST.groups
@@ -11,7 +11,7 @@ native_tests = \
     jtreg/generator/test8249757/LibTest8249757Test.java \
     jtreg/generator/test8252016/Test8252016.java \
     jtreg/generator/test8252121/Test8252121.java \
-    jtreg/generator/test8253102/LibTest8253102Test.java \
+    jtreg/generator/reinterpret/TestReinterpret.java \
     jtreg/generator/test8257892/LibUnsupportedTest.java \
     jtreg/generator/test8258605/LibTest8258605Test.java \
     jtreg/generator/test8261511/Test8261511.java \

--- a/test/jtreg/generator/reinterpret/TestReinterpret.java
+++ b/test/jtreg/generator/reinterpret/TestReinterpret.java
@@ -27,36 +27,49 @@ import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
-import static test.jextract.test8253102.test8253102_h.*;
-import test.jextract.test8253102.*;
+import static test.jextract.reinterpret.reinterpret_h.*;
+import test.jextract.reinterpret.*;
 
 /*
  * @test id=classes
- * @bug 8253102
- * @summary jextract should emit address to segment utility method on struct classes
+ * @bug 8253102 7903626
+ * @summary jextract should emit reinterpret utility method on struct classes
  * @library /lib
- * @run main/othervm JtregJextract -l Test8253102 -t test.jextract.test8253102 test8253102.h
- * @build LibTest8253102Test
- * @run testng/othervm --enable-native-access=ALL-UNNAMED LibTest8253102Test
+ * @run main/othervm JtregJextract -l Reinterpret -t test.jextract.reinterpret reinterpret.h
+ * @build TestReinterpret
+ * @run testng/othervm --enable-native-access=ALL-UNNAMED TestReinterpret
  */
 /*
  * @test id=sources
- * @bug 8253102
- * @summary jextract should emit address to segment utility method on struct classes
+ * @bug 8253102 7903626
+ * @summary jextract should emit reinterpret utility method on struct classes
  * @library /lib
- * @run main/othervm JtregJextractSources -l Test8253102 -t test.jextract.test8253102 test8253102.h
- * @build LibTest8253102Test
- * @run testng/othervm --enable-native-access=ALL-UNNAMED LibTest8253102Test
+ * @run main/othervm JtregJextractSources -l Reinterpret -t test.jextract.reinterpret reinterpret.h
+ * @build TestReinterpret
+ * @run testng/othervm --enable-native-access=ALL-UNNAMED TestReinterpret
  */
-public class LibTest8253102Test {
+public class TestReinterpret {
     @Test
-    public void test() {
+    public void testSingleStruct() {
         try (Arena arena = Arena.ofConfined()) {
             MemorySegment addr = make(14, 99);
-            MemorySegment seg = Point.ofAddress(addr, arena);
+            MemorySegment seg = Point.reinterpret(addr, arena, reinterpret_h::freePoint);
             assertEquals(Point.x(seg), 14);
             assertEquals(Point.y(seg), 99);
-            freePoint(addr);
+        }
+    }
+
+    @Test
+    public void testStructArray() {
+        try (Arena arena = Arena.ofConfined()) {
+            int elementCount = 10;
+            MemorySegment addr = makeArray(elementCount);
+            MemorySegment array = Point.reinterpret(addr, elementCount, arena, reinterpret_h::freePoint);
+            for (int i = 0; i < elementCount; i++) {
+                MemorySegment point = Point.asSlice(array, i);
+                assertEquals(Point.x(point), i);
+                assertEquals(Point.y(point), i + 1);
+            }
         }
     }
 }

--- a/test/jtreg/generator/reinterpret/libReinterpret.c
+++ b/test/jtreg/generator/reinterpret/libReinterpret.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jtreg/generator/reinterpret/libReinterpret.c
+++ b/test/jtreg/generator/reinterpret/libReinterpret.c
@@ -21,7 +21,7 @@
  * questions.
  */
 
-#include "test8253102.h"
+#include "reinterpret.h"
 #include <stdlib.h>
 
 EXPORT Point* make(int x, int y) {
@@ -32,4 +32,13 @@ EXPORT Point* make(int x, int y) {
 
 EXPORT void freePoint(struct Point* ptr) {
     free(ptr);
+}
+
+EXPORT Point* makeArray(int count) {
+    Point* p = (Point*)calloc(count, sizeof(Point));
+    for (int i = 0; i < count; i++) {
+        p[i].x = i;
+        p[i].y = i + 1;
+    }
+    return p;
 }

--- a/test/jtreg/generator/reinterpret/reinterpret.h
+++ b/test/jtreg/generator/reinterpret/reinterpret.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jtreg/generator/reinterpret/reinterpret.h
+++ b/test/jtreg/generator/reinterpret/reinterpret.h
@@ -40,6 +40,8 @@ EXPORT Point* make(int x, int y);
 
 EXPORT void freePoint(struct Point*);
 
+EXPORT Point* makeArray(int count);
+
 #ifdef __cplusplus
 }
 #endif // __cplusplus

--- a/test/jtreg/generator/test8257892/LibUnsupportedTest.java
+++ b/test/jtreg/generator/test8257892/LibUnsupportedTest.java
@@ -71,7 +71,7 @@ public class LibUnsupportedTest {
     @Test
     public void testGetFoo() {
         try (Arena arena = Arena.ofConfined()) {
-            var seg = Foo.ofAddress(getFoo(), arena);
+            var seg = Foo.reinterpret(getFoo(), arena, null);
             Foo.i(seg, 42);
             Foo.c(seg, (byte)'j');
             assertEquals(Foo.i(seg), 42);


### PR DESCRIPTION
This patch renames the existing `ofAddress` method we generate in struct classes to `reinterpret` to reflect the latest naming changes in the FFM API. It also adds another overload that takes an element count, for reinterpreting arrays. Finally, this patch adds the missing cleanup parameter that the underlying reinterpret method accepts.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Issue
 * [CODETOOLS-7903626](https://bugs.openjdk.org/browse/CODETOOLS-7903626): Add struct helper method to reintrepret an array of structs (**Enhancement** - P3)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**) ⚠️ Review applies to [196c3b4b](https://git.openjdk.org/jextract/pull/178/files/196c3b4b2e1fa29867315b78b20a17d99f66c36d)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/178/head:pull/178` \
`$ git checkout pull/178`

Update a local copy of the PR: \
`$ git checkout pull/178` \
`$ git pull https://git.openjdk.org/jextract.git pull/178/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 178`

View PR using the GUI difftool: \
`$ git pr show -t 178`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/178.diff">https://git.openjdk.org/jextract/pull/178.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/178#issuecomment-1893943042)