### PR TITLE
7903631: Improve names for getter/setters

### DIFF
--- a/test/jtreg/generator/nestedStructAccess/TestNestedStructAccess.java
+++ b/test/jtreg/generator/nestedStructAccess/TestNestedStructAccess.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import test.jextract.nestedaccess.*;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.testng.annotations.Test;
+import static org.testng.Assert.assertEquals;
+
+/*
+ * @test id=classes
+  * @library /lib
+ * @run main/othervm JtregJextract -l Func -t test.jextract.nestedaccess nestedStructAccess.h
+ * @build TestNestedStructAccess
+ * @run testng/othervm --enable-native-access=ALL-UNNAMED TestNestedStructAccess
+ */
+/*
+ * @test id=sources
+  * @library /lib
+ * @run main/othervm JtregJextractSources -l Func -t test.jextract.nestedaccess nestedStructAccess.h
+ * @build TestNestedStructAccess
+ * @run testng/othervm --enable-native-access=ALL-UNNAMED TestNestedStructAccess
+ */
+public class TestNestedStructAccess {
+
+    @Test
+    public void testNestedStructAccess() {
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment start = allocatePoint(1, 2, arena);
+            MemorySegment end = allocatePoint(3, 4, arena);
+            MemorySegment line = allocateLine(start, end, arena);
+            checkPointEquals(Line.start(line), start);
+            checkPointEquals(Line.end(line), end);
+        }
+    }
+
+    static MemorySegment allocatePoint(int x, int y, Arena arena) {
+        MemorySegment point = Point.allocate(arena);
+        Point.x(point, x);
+        Point.y(point, y);
+        return point;
+    }
+
+    static MemorySegment allocateLine(MemorySegment start, MemorySegment end, Arena arena) {
+        MemorySegment line = Line.allocate(arena);
+        Line.start(line, start);
+        Line.end(line, end);
+        return line;
+    }
+
+    static void checkPointEquals(MemorySegment found, MemorySegment expected) {
+        assertEquals(Point.x(found), Point.x(expected));
+        assertEquals(Point.y(found), Point.y(expected));
+    }
+}

--- a/test/jtreg/generator/nestedStructAccess/nestedStructAccess.h
+++ b/test/jtreg/generator/nestedStructAccess/nestedStructAccess.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+struct Point {
+    int x;
+    int y;
+};
+
+struct Line {
+   struct Point start;
+   struct Point end;
+};


### PR DESCRIPTION
This patch improves the parameter names for getter/setter methods generated inside a struct.

As I was writing this I realized that:

* we were not using `safeParameterName` consistently. So I've sprinkled that to cover all generated methods;
* we were not generating a setter for fields whose type was a by-value struct. A new setter is now added (which uses `MemorySegment::copy`). A test has also been added.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Issue
 * [CODETOOLS-7903631](https://bugs.openjdk.org/browse/CODETOOLS-7903631): Improve names for getter/setters (**Bug** - P3)


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/179/head:pull/179` \
`$ git checkout pull/179`

Update a local copy of the PR: \
`$ git checkout pull/179` \
`$ git pull https://git.openjdk.org/jextract.git pull/179/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 179`

View PR using the GUI difftool: \
`$ git pr show -t 179`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/179.diff">https://git.openjdk.org/jextract/pull/179.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/179#issuecomment-1893961796)