### PR TITLE
7903628: Replace ofAddress method in FI classes with a static invoke method

### DIFF
--- a/test/jtreg/generator/allocCallback/TestAllocCallback.java
+++ b/test/jtreg/generator/allocCallback/TestAllocCallback.java
@@ -52,8 +52,8 @@ public class TestAllocCallback {
         try (Arena arena = Arena.ofConfined()) {
             var foo = alloc_callback_h.foo$SEGMENT();
 
-            var barA = Foo.a.ofAddress(Foo.a(foo), arena).apply();
-            var barB = Foo.b.ofAddress(Foo.b(foo), arena).apply(100);
+            var barA = Foo.a.invoke(Foo.a(foo), arena);
+            var barB = Foo.b.invoke(Foo.b(foo), arena, 100);
 
             assertEquals(Bar.a(barA), 5);
             assertEquals(Bar.a(barB), 100);

--- a/test/jtreg/generator/funcPointerInvokers/TestFuncPointerInvokers.java
+++ b/test/jtreg/generator/funcPointerInvokers/TestFuncPointerInvokers.java
@@ -54,7 +54,7 @@ public class TestFuncPointerInvokers {
             AtomicInteger val = new AtomicInteger(-1);
             MemorySegment bar = Bar.allocate(arena);
             Bar.foo(bar, Foo.allocate((i) -> val.set(i), arena));
-            Foo.ofAddress(Bar.foo(bar), arena).apply(42);
+            Foo.invoke(Bar.foo(bar), 42);
             assertEquals(val.get(), 42);
         }
     }
@@ -64,7 +64,7 @@ public class TestFuncPointerInvokers {
         try (Arena arena = Arena.ofConfined()) {
             AtomicInteger val = new AtomicInteger(-1);
             f(Foo.allocate((i) -> val.set(i), arena));
-            Foo.ofAddress(f(), arena).apply(42);
+            Foo.invoke(f(), 42);
             assertEquals(val.get(), 42);
         }
     }
@@ -75,7 +75,7 @@ public class TestFuncPointerInvokers {
             AtomicInteger val = new AtomicInteger(-1);
             MemorySegment baz = Baz.allocate(arena);
             Baz.fp(baz, Baz.fp.allocate((i) -> val.set(i), arena));
-            Baz.fp.ofAddress(Baz.fp(baz), arena).apply(42);
+            Baz.fp.invoke(Baz.fp(baz), 42);
             assertEquals(val.get(), 42);
         }
     }
@@ -85,7 +85,7 @@ public class TestFuncPointerInvokers {
         try (Arena arena = Arena.ofConfined()) {
             AtomicInteger val = new AtomicInteger(-1);
             fp(fp.allocate((i) -> val.set(i), arena));
-            fp.ofAddress(fp(), arena).apply(42);
+            fp.invoke(fp(), 42);
             assertEquals(val.get(), 42);
         }
     }
@@ -94,7 +94,7 @@ public class TestFuncPointerInvokers {
     public void testGlobalFIFunctionPointerAddress() {
         try (Arena arena = Arena.ofConfined()) {
             fp_addr(fp_addr.allocate((addr) -> MemorySegment.ofAddress(addr.address() + 1), arena));
-            assertEquals(fp_addr.ofAddress(fp_addr(), arena).apply(MemorySegment.ofAddress(42)), MemorySegment.ofAddress(43));
+            assertEquals(fp_addr.invoke(fp_addr(), MemorySegment.ofAddress(42)), MemorySegment.ofAddress(43));
         }
     }
 }

--- a/test/jtreg/generator/test8261511/Test8261511.java
+++ b/test/jtreg/generator/test8261511/Test8261511.java
@@ -51,8 +51,7 @@ public class Test8261511 {
     public void test() {
         try (Arena arena = Arena.ofConfined()) {
             var funcPtr = Foo.sum(get_foo(arena));
-            var sumIface = Foo.sum.ofAddress(funcPtr, arena);
-            assertEquals(sumIface.apply(15,20), 35);
+            assertEquals(Foo.sum.invoke(funcPtr, 15, 20), 35);
             assertEquals(sum(1.2, 4.5), 5.7, 0.001);
         }
     }


### PR DESCRIPTION
This patch replaces the factory method in the generated function pointer interfaces with a static invoke method. This avoids clients having to wrap a function pointer in an instance of the interface in order to invoke it, and instead allows invoking function pointers more directly. This aligns with the general jextract strategy of being 'all static' which avoids object allocation overheads.

The new approach also simplifies the handling of function pointers that accept an allocator (because they return a struct by-value), as now we no longer how to infer the allocator, but the client can pass it explicitly when invoking the function pointer.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Issue
 * [CODETOOLS-7903628](https://bugs.openjdk.org/browse/CODETOOLS-7903628): Replace ofAddress method in FI classes with a static invoke method (**Enhancement** - P3)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/180/head:pull/180` \
`$ git checkout pull/180`

Update a local copy of the PR: \
`$ git checkout pull/180` \
`$ git pull https://git.openjdk.org/jextract.git pull/180/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 180`

View PR using the GUI difftool: \
`$ git pr show -t 180`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/180.diff">https://git.openjdk.org/jextract/pull/180.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/180#issuecomment-1894039562)