### PR TITLE
7903632: struct accessor info is not derived from toplevel layout decl

### DIFF
--- a/src/main/java/org/openjdk/jextract/impl/SourceFileBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/SourceFileBuilder.java
@@ -78,6 +78,7 @@ final class SourceFileBuilder {
             import java.util.stream.*;
 
             import static java.lang.foreign.ValueLayout.*;
+            import static java.lang.foreign.MemoryLayout.PathElement.*;
             """);
     }
 


### PR DESCRIPTION
This PR dials back the code generation updates a little when it comes to struct getter/setter, so that both their layouts and offsets is now derived from the toplevel struct layout - using layout paths, as before.

This allows clients to e.g. tweak layouts in a single place (the topelevel struct layout declaration) to adjust things such as endianness.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Issue
 * [CODETOOLS-7903632](https://bugs.openjdk.org/browse/CODETOOLS-7903632): struct accessor info is not derived from toplevel layout decl (**Bug** - P3)


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - Committer) ⚠️ Review applies to [326be9ca](https://git.openjdk.org/jextract/pull/181/files/326be9ca77bcbf710e19c40b84287a89483c6029)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/181/head:pull/181` \
`$ git checkout pull/181`

Update a local copy of the PR: \
`$ git checkout pull/181` \
`$ git pull https://git.openjdk.org/jextract.git pull/181/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 181`

View PR using the GUI difftool: \
`$ git pr show -t 181`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/181.diff">https://git.openjdk.org/jextract/pull/181.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/181#issuecomment-1894071956)