### PR TITLE
Minor tweaks in jextract codegen

### DIFF
--- a/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
@@ -155,8 +155,8 @@ class HeaderFileBuilder extends ClassSourceBuilder {
                 STR."\"\{nativeName}\", \{paramList}";
         incrAlign();
         if (!isVarArg) {
-            emitDocComment(decl);
             appendLines(STR."""
+
                 \{MEMBER_MODS} MethodHandle \{getterName}() {
                     class Holder {
                         static final FunctionDescriptor DESC = \{functionDescriptorString(2, decl.type())};
@@ -167,7 +167,10 @@ class HeaderFileBuilder extends ClassSourceBuilder {
                     }
                     return Holder.MH;
                 }
-
+                """);
+                appendBlankLine();
+                emitDocComment(decl);
+                appendLines(STR."""
                 public static \{retType} \{javaName}(\{paramExprs(declType, finalParamNames, isVarArg)}) {
                     var mh$ = \{getterName}();
                     try {

--- a/src/main/java/org/openjdk/jextract/impl/StructBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/StructBuilder.java
@@ -263,12 +263,12 @@ final class StructBuilder extends ClassSourceBuilder implements OutputFactory.Bu
     private void emitReinterpret() {
         appendIndentedLines("""
 
-            public static MemorySegment reinterpret(MemorySegment addr, Arena scope, Consumer<MemorySegment> cleanup) {
-                return reinterpret(addr, 1, scope, cleanup);
+            public static MemorySegment reinterpret(MemorySegment addr, Arena arena, Consumer<MemorySegment> cleanup) {
+                return reinterpret(addr, 1, arena, cleanup);
             }
 
-            public static MemorySegment reinterpret(MemorySegment addr, long elementCount, Arena scope, Consumer<MemorySegment> cleanup) {
-                return addr.reinterpret($LAYOUT().byteSize() * elementCount, scope, cleanup);
+            public static MemorySegment reinterpret(MemorySegment addr, long elementCount, Arena arena, Consumer<MemorySegment> cleanup) {
+                return addr.reinterpret($LAYOUT().byteSize() * elementCount, arena, cleanup);
             }
             """);
     }


### PR DESCRIPTION
When running some examples, I noted that:

* jextract is not adding javadoc to the function wrappers in the header class (instead the javadoc is added to the MH getter)
* the new `reinterpret` method still use the parameter name `scope` instead of `arena`
