### PR TITLE
fixed libffmpeg samples for "$slice" removal in struct field accessors

### DIFF
--- a/samples/libffmpeg/LibffmpegMain.java
+++ b/samples/libffmpeg/LibffmpegMain.java
@@ -203,9 +203,9 @@ public class LibffmpegMain {
                         // Did we get a video frame?
                         if (frameFinished != 0) {
                             // Convert the image from its native format to RGB
-                            sws_scale(sws_ctx, AVFrame.data$slice(pFrame),
-                                    AVFrame.linesize$slice(pFrame), 0, height,
-                                    AVFrame.data$slice(pFrameRGB), AVFrame.linesize$slice(pFrameRGB));
+                            sws_scale(sws_ctx, AVFrame.data(pFrame),
+                                    AVFrame.linesize(pFrame), 0, height,
+                                    AVFrame.data(pFrameRGB), AVFrame.linesize(pFrameRGB));
 
                             // Save the frame to disk
                             if (++i <= NUM_FRAMES_TO_CAPTURE) {
@@ -266,11 +266,11 @@ public class LibffmpegMain {
         try (var os = Files.newOutputStream(path)) {
             System.out.println("writing " + path.toString());
             os.write(header.getBytes());
-            var data = AVFrame.data$slice(frameRGB);
+            var data = AVFrame.data(frameRGB);
             // frameRGB.data[0]
             var pdata = data.get(C_POINTER, 0);
             // frameRGB.linespace[0]
-            var linesize = AVFrame.linesize$slice(frameRGB).get(C_INT, 0);
+            var linesize = AVFrame.linesize(frameRGB).get(C_INT, 0);
             // Write pixel data
             for (int y = 0; y < height; y++) {
                 // frameRGB.data[0] + y*frameRGB.linesize[0] is the pointer. And 3*width size of data


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/184/head:pull/184` \
`$ git checkout pull/184`

Update a local copy of the PR: \
`$ git checkout pull/184` \
`$ git pull https://git.openjdk.org/jextract.git pull/184/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 184`

View PR using the GUI difftool: \
`$ git pr show -t 184`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/184.diff">https://git.openjdk.org/jextract/pull/184.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/184#issuecomment-1895828423)