### PR TITLE
Mac AArch64 build support in make (jdk22)

### DIFF
--- a/make/Build.gmk
+++ b/make/Build.gmk
@@ -47,7 +47,7 @@ $(foreach file,$(NATIVE_TEST_SOURCES),$(eval $(call BuildNativeLibrary,$(file),$
 $(BUILD_CLASSES_DIR):
 	$(MKDIR) -p $(BUILD_CLASSES_DIR)/org/openjdk/jextract/impl
 	$(FIXPATH) $(PANAMA_JAVA_HOME)/bin/javac \
-	    --release=19 \
+	    --release=22 \
 	    --enable-preview \
 	    -d "$(BUILD_CLASSES_DIR)" \
 	    src/main/java/module-info.java \
@@ -71,7 +71,7 @@ $(BUILD_MODULES_DIR): $(BUILD_CLASSES_DIR)
 	# create jextract jmod file
 	$(FIXPATH) $(PANAMA_JAVA_HOME)/bin/jmod \
 	    create \
-	    --module-version=19 \
+	    --module-version=22 \
 	    --class-path=$(BUILD_CLASSES_DIR) \
 	    --libs=$(JEXTRACT_JMOD_LIBS_DIR) \
 	    --conf=$(JEXTRACT_JMOD_CONF_DIR) \

--- a/make/Common.gmk
+++ b/make/Common.gmk
@@ -73,6 +73,9 @@ UNAME_M := $(shell uname -m)
 ifeq ($(UNAME_M),x86_64)
   DEVKIT_VS_CPU_VAR_NAME := x86_64
   PLATFORM_CPU := x64
+else ifeq ($(UNAME_M),arm64)
+  DEVKIT_VS_CPU_VAR_NAME := aarch64
+  PLATFORM_CPU := aarch64
 else
   $(error "Unknown CPU: $(UNAME_M)")
 endif

--- a/make/RunTestsPrebuilt.gmk
+++ b/make/RunTestsPrebuilt.gmk
@@ -66,7 +66,7 @@ define SetupRunJtregTest
 	    -workDir:$$($1_TEST_SUPPORT_DIR) \
 	    -avm \
 	    -conc:$$(JTREG_CONCURRENCY) \
-	    -verbose:summary \
+	    -verbose:summary,fail,error \
 	    -nativepath:$$(JEXTRACT_NATIVE_TEST_DIR) \
 	    -vmoption:--enable-native-access=ALL-UNNAMED,org.openjdk.jextract \
 	    $2 \


### PR DESCRIPTION
- Add support for mac aarch64
- Build updates for jdk22
- Verbose error ouput for tests in make build (this is useful for testing locally, but I could drop this as well)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/185/head:pull/185` \
`$ git checkout pull/185`

Update a local copy of the PR: \
`$ git checkout pull/185` \
`$ git pull https://git.openjdk.org/jextract.git pull/185/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 185`

View PR using the GUI difftool: \
`$ git pr show -t 185`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/185.diff">https://git.openjdk.org/jextract/pull/185.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/185#issuecomment-1896453215)