### PR TITLE
Make method handle accessor private

### DIFF
--- a/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
@@ -161,7 +161,7 @@ class HeaderFileBuilder extends ClassSourceBuilder {
                 appendBlankLine();
                 emitDocComment(decl);
                 appendLines(STR."""
-                \{"public static"} \{retType} \{javaName}(\{paramExprs(declType, finalParamNames, isVarArg)}) {
+                public static \{retType} \{javaName}(\{paramExprs(declType, finalParamNames, isVarArg)}) {
                     var mh$ = \{getterName}();
                     try {
                         if (TRACE_DOWNCALLS) {

--- a/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
@@ -159,7 +159,7 @@ class HeaderFileBuilder extends ClassSourceBuilder {
         if (!isVarArg) {
             appendLines(STR."""
 
-                \{MEMBER_MODS} MethodHandle \{getterName}() {
+                private static MethodHandle \{getterName}() {
                     class Holder {
                         static final FunctionDescriptor DESC = \{functionDescriptorString(2, decl.type())};
 
@@ -173,7 +173,7 @@ class HeaderFileBuilder extends ClassSourceBuilder {
                 appendBlankLine();
                 emitDocComment(decl);
                 appendLines(STR."""
-                public static \{retType} \{javaName}(\{paramExprs(declType, finalParamNames, isVarArg)}) {
+                \{MEMBER_MODS} \{retType} \{javaName}(\{paramExprs(declType, finalParamNames, isVarArg)}) {
                     var mh$ = \{getterName}();
                     try {
                         if (TRACE_DOWNCALLS) {
@@ -327,7 +327,7 @@ class HeaderFileBuilder extends ClassSourceBuilder {
         emitDocComment(decl, docHeader);
         Class<?> type = Utils.carrierFor(decl.type());
         appendLines(STR."""
-            public static \{type.getSimpleName()} \{javaName}() {
+            \{MEMBER_MODS} \{type.getSimpleName()} \{javaName}() {
                 return \{segmentConstant}.get(\{layoutVar}, 0L);
             }
             """);
@@ -341,7 +341,7 @@ class HeaderFileBuilder extends ClassSourceBuilder {
         emitDocComment(decl, docHeader);
         Class<?> type = Utils.carrierFor(decl.type());
         appendLines(STR."""
-            public static void \{javaName}(\{type.getSimpleName()} x) {
+            \{MEMBER_MODS} void \{javaName}(\{type.getSimpleName()} x) {
                 \{segmentConstant}.set(\{layoutVar}, 0L, x);
             }
             """);
@@ -354,7 +354,7 @@ class HeaderFileBuilder extends ClassSourceBuilder {
         incrAlign();
         emitDocComment(varTree, docHeader);
         appendLines(STR."""
-            public static MemorySegment \{javaName}() {
+            \{MEMBER_MODS} MemorySegment \{javaName}() {
                 return \{segmentConstant};
             }
             """);
@@ -367,7 +367,7 @@ class HeaderFileBuilder extends ClassSourceBuilder {
         incrAlign();
         emitDocComment(varTree, docHeader);
         appendLines(STR."""
-            public static void \{javaName}(MemorySegment varValue) {
+            \{MEMBER_MODS} void \{javaName}(MemorySegment varValue) {
                 MemorySegment.copy(varValue, 0L, \{segmentConstant}, 0L, \{layoutVar}.byteSize());
             }
             """);

--- a/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
@@ -25,30 +25,20 @@
 package org.openjdk.jextract.impl;
 
 import java.io.File;
-import java.lang.foreign.FunctionDescriptor;
-import java.lang.foreign.Linker;
 import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.SegmentAllocator;
-import java.lang.foreign.SymbolLookup;
 import java.lang.invoke.MethodHandle;
 
 import org.openjdk.jextract.Declaration;
 import org.openjdk.jextract.Type;
-import org.openjdk.jextract.impl.DeclarationImpl.JavaFunctionalInterfaceName;
 import org.openjdk.jextract.impl.DeclarationImpl.JavaName;
 
-import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
-import java.lang.invoke.VarHandle;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.StringJoiner;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * A helper class to generate header interface class in source form.
@@ -56,8 +46,6 @@ import java.util.stream.Stream;
  * method is called to get overall generated source string.
  */
 class HeaderFileBuilder extends ClassSourceBuilder {
-
-    static final String MEMBER_MODS = "public static";
 
     HeaderFileBuilder(SourceFileBuilder builder, String className, String superName, String runtimeHelperName) {
         super(builder, "public", Kind.CLASS, className, superName, null, runtimeHelperName);
@@ -173,7 +161,7 @@ class HeaderFileBuilder extends ClassSourceBuilder {
                 appendBlankLine();
                 emitDocComment(decl);
                 appendLines(STR."""
-                \{MEMBER_MODS} \{retType} \{javaName}(\{paramExprs(declType, finalParamNames, isVarArg)}) {
+                \{"public static"} \{retType} \{javaName}(\{paramExprs(declType, finalParamNames, isVarArg)}) {
                     var mh$ = \{getterName}();
                     try {
                         if (TRACE_DOWNCALLS) {
@@ -327,7 +315,7 @@ class HeaderFileBuilder extends ClassSourceBuilder {
         emitDocComment(decl, docHeader);
         Class<?> type = Utils.carrierFor(decl.type());
         appendLines(STR."""
-            \{MEMBER_MODS} \{type.getSimpleName()} \{javaName}() {
+            public static \{type.getSimpleName()} \{javaName}() {
                 return \{segmentConstant}.get(\{layoutVar}, 0L);
             }
             """);
@@ -341,7 +329,7 @@ class HeaderFileBuilder extends ClassSourceBuilder {
         emitDocComment(decl, docHeader);
         Class<?> type = Utils.carrierFor(decl.type());
         appendLines(STR."""
-            \{MEMBER_MODS} void \{javaName}(\{type.getSimpleName()} x) {
+            public static void \{javaName}(\{type.getSimpleName()} x) {
                 \{segmentConstant}.set(\{layoutVar}, 0L, x);
             }
             """);
@@ -354,7 +342,7 @@ class HeaderFileBuilder extends ClassSourceBuilder {
         incrAlign();
         emitDocComment(varTree, docHeader);
         appendLines(STR."""
-            \{MEMBER_MODS} MemorySegment \{javaName}() {
+            public static MemorySegment \{javaName}() {
                 return \{segmentConstant};
             }
             """);
@@ -367,7 +355,7 @@ class HeaderFileBuilder extends ClassSourceBuilder {
         incrAlign();
         emitDocComment(varTree, docHeader);
         appendLines(STR."""
-            \{MEMBER_MODS} void \{javaName}(MemorySegment varValue) {
+            public static void \{javaName}(MemorySegment varValue) {
                 MemorySegment.copy(varValue, 0L, \{segmentConstant}, 0L, \{layoutVar}.byteSize());
             }
             """);
@@ -411,7 +399,7 @@ class HeaderFileBuilder extends ClassSourceBuilder {
             """);
         emitDocComment(declaration);
         appendLines(STR."""
-            \{MEMBER_MODS} \{javaType.getSimpleName()} \{constantName}() {
+            public static \{javaType.getSimpleName()} \{constantName}() {
                 return \{constantName};
             }
             """);


### PR DESCRIPTION
In my previous PR, I forgot to also make the method handle accessor (for native downcalls) `private`.

This was discovered when manually eyeballing at jextracted code for windows.h.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - Committer) ⚠️ Review applies to [a7f001ca](https://git.openjdk.org/jextract/pull/188/files/a7f001ca6cd108b7151f8e1e32bd71478b05c77b)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/188/head:pull/188` \
`$ git checkout pull/188`

Update a local copy of the PR: \
`$ git checkout pull/188` \
`$ git pull https://git.openjdk.org/jextract.git pull/188/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 188`

View PR using the GUI difftool: \
`$ git pr show -t 188`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/188.diff">https://git.openjdk.org/jextract/pull/188.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/188#issuecomment-1900766058)