### PR TITLE
7903637: Use holder classes for string constants

### DIFF
--- a/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
@@ -394,16 +394,28 @@ class HeaderFileBuilder extends ClassSourceBuilder {
 
     private void emitConstant(Class<?> javaType, String constantName, Object value, Declaration declaration) {
         incrAlign();
-        appendLines(STR."""
-            private static final \{javaType.getSimpleName()} \{constantName} = \{constantValue(javaType, value)};
-
-            """);
-        emitDocComment(declaration);
-        appendLines(STR."""
-            public static \{javaType.getSimpleName()} \{constantName}() {
-                return \{constantName};
-            }
-            """);
+        boolean useHolderClass = value instanceof String;
+        if (useHolderClass) {
+            emitDocComment(declaration);
+            appendLines(STR."""
+                public static \{javaType.getSimpleName()} \{constantName}() {
+                    class Holder {
+                        static final \{javaType.getSimpleName()} \{constantName} = \{constantValue(javaType, value)};
+                    }
+                    return Holder.\{constantName};
+                }
+                """);
+        } else {
+            appendLines(STR."""
+                private static final \{javaType.getSimpleName()} \{constantName} = \{constantValue(javaType, value)};
+                """);
+            emitDocComment(declaration);
+            appendLines(STR."""
+                public static \{javaType.getSimpleName()} \{constantName}() {
+                    return \{constantName};
+                }
+                """);
+        }
         decrAlign();
     }
 

--- a/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
@@ -450,9 +450,11 @@ class HeaderFileBuilder extends ClassSourceBuilder {
             } else if (type == boolean.class) {
                 boolean booleanValue = ((Number)value).byteValue() != 0;
                 buf.append(booleanValue);
-            } else {
+            } else if (value instanceof Number n) {
                 buf.append("(" + type.getName() + ")");
-                buf.append(value + "L");
+                buf.append(n.longValue() + "L");
+            } else {
+                throw new IllegalArgumentException(STR."Unhandled type: \{type}, or value: \{value}");
             }
             return buf.toString();
         }

--- a/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
@@ -394,13 +394,13 @@ class HeaderFileBuilder extends ClassSourceBuilder {
 
     private void emitConstant(Class<?> javaType, String constantName, Object value, Declaration declaration) {
         incrAlign();
-        boolean useHolderClass = value instanceof String;
-        if (useHolderClass) {
+        if (value instanceof String) {
             emitDocComment(declaration);
             appendLines(STR."""
                 public static \{javaType.getSimpleName()} \{constantName}() {
                     class Holder {
-                        static final \{javaType.getSimpleName()} \{constantName} = \{constantValue(javaType, value)};
+                        static final \{javaType.getSimpleName()} \{constantName}
+                            = \{runtimeHelperName()}.LIBRARY_ARENA.allocateFrom("\{Utils.quote(Objects.toString(value))}");
                     }
                     return Holder.\{constantName};
                 }
@@ -420,9 +420,7 @@ class HeaderFileBuilder extends ClassSourceBuilder {
     }
 
     private String constantValue(Class<?> type, Object value) {
-        if (value instanceof String) {
-            return STR."\{runtimeHelperName()}.LIBRARY_ARENA.allocateFrom(\"\{Utils.quote(Objects.toString(value))}\")";
-        } else if (type == MemorySegment.class) {
+        if (type == MemorySegment.class) {
             return STR."MemorySegment.ofAddress(\{((Number)value).longValue()}L)";
         } else {
             StringBuilder buf = new StringBuilder();

--- a/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
@@ -250,6 +250,7 @@ class HeaderFileBuilder extends ClassSourceBuilder {
     void emitRuntimeHelperMethods() {
         appendIndentedLines("""
 
+            static final Arena LIBRARY_ARENA = Arena.ofAuto();
             static final boolean TRACE_DOWNCALLS = Boolean.getBoolean("jextract.trace.downcalls");
 
             static void traceDowncall(String name, Object... args) {
@@ -408,7 +409,7 @@ class HeaderFileBuilder extends ClassSourceBuilder {
 
     private String constantValue(Class<?> type, Object value) {
         if (value instanceof String) {
-            return STR."Arena.ofAuto().allocateFrom(\"\{Utils.quote(Objects.toString(value))}\")";
+            return STR."\{runtimeHelperName()}.LIBRARY_ARENA.allocateFrom(\"\{Utils.quote(Objects.toString(value))}\")";
         } else if (type == MemorySegment.class) {
             return STR."MemorySegment.ofAddress(\{((Number)value).longValue()}L)";
         } else {


### PR DESCRIPTION
Use holder class idiom for string constants (See JBS issue for motivation).

The code in `emitConstant` is a bit copy-pasty. We need to strike a balance between giving a clear picture of the generated code by using a single string template as much as possible, and reducing duplication by splitting the templates up and weaving in more control flow.

I went with the repeated, but clearer approach here of having 2 separate templates. Let me know if you'd like me to change that.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Issue
 * [CODETOOLS-7903637](https://bugs.openjdk.org/browse/CODETOOLS-7903637): Use holder classes for string constants (**Enhancement** - P4)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**) ⚠️ Review applies to [51d3e11a](https://git.openjdk.org/jextract/pull/191/files/51d3e11ac344a8842a5039c1a37b226dfead62db)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/191/head:pull/191` \
`$ git checkout pull/191`

Update a local copy of the PR: \
`$ git checkout pull/191` \
`$ git pull https://git.openjdk.org/jextract.git pull/191/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 191`

View PR using the GUI difftool: \
`$ git pr show -t 191`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/191.diff">https://git.openjdk.org/jextract/pull/191.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/191#issuecomment-1904587361)