### PR TITLE
7903629: Emit allocateFrom method for struct classes

### DIFF
--- a/test/jtreg/generator/testStruct/LibStructTest.java
+++ b/test/jtreg/generator/testStruct/LibStructTest.java
@@ -78,6 +78,31 @@ public class LibStructTest {
         }
     }
 
+    @Test
+    public void testAllocateFrom() {
+        try (Arena arena = Arena.ofConfined()) {
+            var point = Point.allocateFrom(arena, 1, 2);
+            assertEquals(Point.x(point), 1);
+            assertEquals(Point.y(point), 2);
+        }
+    }
+
+    @Test
+    public void testInit() {
+        try (Arena arena = Arena.ofConfined()) {
+            var seg = Point.allocateArray(3, arena);
+            for (int i = 0; i < 3; i++) {
+                MemorySegment point = Point.asSlice(seg, i);
+                Point.init(point, 56 + i, 65 + i);
+            }
+            for (int i = 0; i < 3; i++) {
+                MemorySegment point = Point.asSlice(seg, i);
+                assertEquals(Point.x(point), 56 + i);
+                assertEquals(Point.y(point), 65 + i);
+            }
+        }
+    }
+
     private static void checkField(GroupLayout group, String fieldName, MemoryLayout expected) {
         assertEquals(group.select(PathElement.groupElement(fieldName)), expected.withName(fieldName));
     }


### PR DESCRIPTION
Adds an `allocateFrom` method to struct classes, which can be used like a constructor to allocate and initialize a struct in one call.

I realized that, while this works well for initializing single structs, it doesn't work for arrays of structs. So, I've also added an `init` method which can be used to initialize a given struct. This allows a client to first allocate an array, and then initialize each element in a single shot (see test case). (we can then also just call `init` from `allocateFrom`s implementation).

Open question: I'm currently not emitting the new methods if the struct doesn't have any fields, since they are really not needed in that case. But, maybe `allocateFrom` and `init` should also be emitted for empty struct for the sake of consistency?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Issue
 * [CODETOOLS-7903629](https://bugs.openjdk.org/browse/CODETOOLS-7903629): Emit allocateFrom method for struct classes (**Enhancement** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/192/head:pull/192` \
`$ git checkout pull/192`

Update a local copy of the PR: \
`$ git checkout pull/192` \
`$ git pull https://git.openjdk.org/jextract.git pull/192/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 192`

View PR using the GUI difftool: \
`$ git pr show -t 192`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/192.diff">https://git.openjdk.org/jextract/pull/192.diff</a>

</details>
