### PR TITLE
7903639: Add javadoc to all jextract generated API points

### DIFF
--- a/src/main/java/org/openjdk/jextract/impl/ClassSourceBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/ClassSourceBuilder.java
@@ -144,8 +144,7 @@ abstract class ClassSourceBuilder {
         appendIndentedLines(STR."""
 
             \{className}() {
-                // Suppresses public default constructor, ensuring non-instantiability,
-                // but allows generated subclasses in same package.
+                // Should not be called directly
             }
             """);
     }

--- a/src/main/java/org/openjdk/jextract/impl/FunctionalInterfaceBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/FunctionalInterfaceBuilder.java
@@ -80,7 +80,7 @@ final class FunctionalInterfaceBuilder extends ClassSourceBuilder {
             private static final MethodHandle UP$MH = \{runtimeHelperName()}.upcallHandle(\{className()}.Function.class, "apply", $DESC);
 
             /**
-             * Allocates a new upcall segment, whose implementation is defined by {@code fi}.
+             * Allocates a new upcall stub, whose implementation is defined by {@code fi}.
              * The lifetime of the returned segment is managed by {@code arena}
              */
             public static MemorySegment allocate(\{className()}.Function fi, Arena arena) {
@@ -99,7 +99,7 @@ final class FunctionalInterfaceBuilder extends ClassSourceBuilder {
             private static final MethodHandle DOWN$MH = Linker.nativeLinker().downcallHandle($DESC);
 
             /**
-             * Invoke the upcall segment {@code funcPtr}, with given parameters
+             * Invoke the upcall stub {@code funcPtr}, with given parameters
              */
             public static \{methodType.returnType().getSimpleName()} invoke(MemorySegment funcPtr\{allocParam}\{paramStr}) {
                 try {

--- a/src/main/java/org/openjdk/jextract/impl/StructBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/StructBuilder.java
@@ -88,7 +88,6 @@ final class StructBuilder extends ClassSourceBuilder implements OutputFactory.Bu
     void end() {
         if (!inAnonymousNested()) {
             emitAsSlice();
-            appendBlankLine();
             emitSizeof();
             emitAllocatorAllocate();
             emitAllocatorAllocateArray();
@@ -227,6 +226,10 @@ final class StructBuilder extends ClassSourceBuilder implements OutputFactory.Bu
         String arrayParam = safeParameterName("array");
         appendIndentedLines(STR."""
 
+            /**
+             * Obtains a slice of {@code arrayParam} which selects the array element at {@code index}.
+             * The returned segment has address {@code arrayParam.address() + index * layout().byteSize}
+             */
             public static MemorySegment asSlice(MemorySegment \{arrayParam}, long index) {
                 return \{arrayParam}.asSlice(layout().byteSize() * index);
             }
@@ -234,7 +237,11 @@ final class StructBuilder extends ClassSourceBuilder implements OutputFactory.Bu
     }
 
     private void emitSizeof() {
-        appendIndentedLines("""
+        appendIndentedLines(STR."""
+
+            /**
+             * The size (in bytes) of this \{kindName()}
+             */
             public static long sizeof() { return layout().byteSize(); }
             """);
     }
@@ -243,6 +250,9 @@ final class StructBuilder extends ClassSourceBuilder implements OutputFactory.Bu
         String allocatorParam = safeParameterName("allocator");
         appendIndentedLines(STR."""
 
+            /**
+             * Allocate a segment of size {@code layout().byteSize()} using {@code \{allocatorParam}}
+             */
             public static MemorySegment allocate(SegmentAllocator \{allocatorParam}) {
                 return \{allocatorParam}.allocate(layout());
             }
@@ -254,6 +264,10 @@ final class StructBuilder extends ClassSourceBuilder implements OutputFactory.Bu
         String elementCountParam = safeParameterName("elementCount");
         appendIndentedLines(STR."""
 
+            /**
+             * Allocate an array of size {@code \{elementCountParam}} using {@code \{allocatorParam}}.
+             * The returned segment has size {@code \{elementCountParam} * layout().byteSize()}.
+             */
             public static MemorySegment allocateArray(long \{elementCountParam}, SegmentAllocator \{allocatorParam}) {
                 return \{allocatorParam}.allocate(MemoryLayout.sequenceLayout(\{elementCountParam}, layout()));
             }
@@ -263,10 +277,18 @@ final class StructBuilder extends ClassSourceBuilder implements OutputFactory.Bu
     private void emitReinterpret() {
         appendIndentedLines("""
 
+            /**
+             * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction) (if any).
+             * The returned segment has size {@code layout().byteSize()}
+             */
             public static MemorySegment reinterpret(MemorySegment addr, Arena arena, Consumer<MemorySegment> cleanup) {
                 return reinterpret(addr, 1, arena, cleanup);
             }
 
+            /**
+             * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction) (if any).
+             * The returned segment has size {@code elementCount * layout().byteSize()}
+             */
             public static MemorySegment reinterpret(MemorySegment addr, long elementCount, Arena arena, Consumer<MemorySegment> cleanup) {
                 return addr.reinterpret(layout().byteSize() * elementCount, arena, cleanup);
             }
@@ -278,6 +300,9 @@ final class StructBuilder extends ClassSourceBuilder implements OutputFactory.Bu
 
             private static final GroupLayout $LAYOUT = \{structOrUnionLayoutString(structType)};
 
+            /**
+             * The layout of this \{kindName()}
+             */
             public static final GroupLayout layout() {
                 return $LAYOUT;
             }

--- a/src/main/java/org/openjdk/jextract/impl/StructBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/StructBuilder.java
@@ -228,7 +228,7 @@ final class StructBuilder extends ClassSourceBuilder implements OutputFactory.Bu
 
             /**
              * Obtains a slice of {@code arrayParam} which selects the array element at {@code index}.
-             * The returned segment has address {@code arrayParam.address() + index * layout().byteSize}
+             * The returned segment has address {@code arrayParam.address() + index * layout().byteSize()}
              */
             public static MemorySegment asSlice(MemorySegment \{arrayParam}, long index) {
                 return \{arrayParam}.asSlice(layout().byteSize() * index);

--- a/test/testng/org/openjdk/jextract/test/toolprovider/docComments/TestDocComments.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/docComments/TestDocComments.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Pattern;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
 
 public class TestDocComments extends JextractToolRunner {
     // Regular expression for javadoc comment text
@@ -103,7 +104,7 @@ public class TestDocComments extends JextractToolRunner {
     @Test
     public void testFunctionPointer() throws IOException {
         var comments = getDocComments("funcptrs.h", "funcptr.java");
-        assertEquals(comments, List.of(
+        assertContains(comments, List.of(
             "void (*funcptr)(int *, int)"
         ));
     }
@@ -111,7 +112,7 @@ public class TestDocComments extends JextractToolRunner {
     @Test
     public void testFunctionPointer2() throws IOException {
         var comments = getDocComments("funcptrs.h", "signal$func.java");
-        assertEquals(comments, List.of(
+        assertContains(comments, List.of(
             "void (*func)(int)"
         ));
     }
@@ -119,7 +120,7 @@ public class TestDocComments extends JextractToolRunner {
     @Test
     public void testFunctionPointer3() throws IOException {
         var comments = getDocComments("funcptrs.h", "signal$return.java");
-        assertEquals(comments, List.of(
+        assertContains(comments, List.of(
             "void (*signal(int sig, void (*func)(int)))(int)"
         ));
     }
@@ -127,7 +128,7 @@ public class TestDocComments extends JextractToolRunner {
     @Test
     public void testFunctionPointer4() throws IOException {
         var comments = getDocComments("funcptrs.h", "funcptrs_h.java");
-        assertEquals(comments, List.of(
+        assertContains(comments, List.of(
             "Getter for variable: void (*funcptr)(int *, int)",
             "Setter for variable: void (*funcptr)(int *, int)",
             "void (*signal(int sig, void (*func)(int)))(int)"
@@ -148,7 +149,7 @@ public class TestDocComments extends JextractToolRunner {
     @Test
     public void testStruct() throws IOException {
         var comments = getDocComments("structs.h", "Point.java");
-        assertEquals(comments, List.of(
+        assertContains(comments, List.of(
             "struct Point { int x; int y; }",
             "Getter for field: int x",
             "Setter for field: int x",
@@ -159,7 +160,7 @@ public class TestDocComments extends JextractToolRunner {
     @Test
     public void testStruct2() throws IOException {
         var comments = getDocComments("structs.h", "Point3D.java");
-        assertEquals(comments, List.of(
+        assertContains(comments, List.of(
             "struct Point3D { int x; int y; int z; }",
             "Getter for field: int x",
             "Setter for field: int x",
@@ -172,7 +173,7 @@ public class TestDocComments extends JextractToolRunner {
     @Test
     public void testNestedAnon() throws IOException {
         var comments = getDocComments("structs.h", "NestedAnon.java");
-        assertEquals(comments, List.of(
+        assertContains(comments, List.of(
             "struct NestedAnon { struct { int l; long long h; } u; }",
             "struct { int l; long long h; }",
             "Getter for field: int l",
@@ -227,5 +228,13 @@ public class TestDocComments extends JextractToolRunner {
                 .trim());
         }
         return strings;
+    }
+
+    static void assertContains(List<String> found, List<String> expected) {
+        for (String e : expected) {
+            if (!found.contains(e)) {
+                fail(String.format("\"%s\" not found in: ", e, found));
+            }
+        }
     }
 }


### PR DESCRIPTION
This PR adds simple javadoc text to all the helper functions generated by jextract:
* struct allocation methods
* struct slicing methods
* struct reinterpret methods
* function pointer allocation method
* function pointer invoke method

Following some offline discussions, I've decided to keep the comments very dry and simple (to avoid copying reams and reams of text into multiple classes). Also, the javadoc does not contain any `@param` or `@return` tag.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Issue
 * [CODETOOLS-7903639](https://bugs.openjdk.org/browse/CODETOOLS-7903639): Add javadoc to all jextract generated API points (**Enhancement** - P4)


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/193/head:pull/193` \
`$ git checkout pull/193`

Update a local copy of the PR: \
`$ git checkout pull/193` \
`$ git pull https://git.openjdk.org/jextract.git pull/193/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 193`

View PR using the GUI difftool: \
`$ git pr show -t 193`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/193.diff">https://git.openjdk.org/jextract/pull/193.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/193#issuecomment-1906622729)