### PR TITLE
7903642: Code generation for variadic function emits redundant casts

### DIFF
--- a/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
@@ -191,7 +191,7 @@ class HeaderFileBuilder extends ClassSourceBuilder {
                 }
 
                 """);
-            emitDocComment(decl);
+            emitDocComment(decl, "Variadic invoker factory for:");
             appendLines(STR."""
                 public static \{javaName} \{javaName}(MemoryLayout... layouts) {
                     FunctionDescriptor baseDesc$ = \{functionDescriptorString(2, decl.type())};

--- a/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
@@ -134,10 +134,9 @@ class HeaderFileBuilder extends ClassSourceBuilder {
         }
 
         String retType = declType.returnType().getSimpleName();
-        String returnExpr = "";
-        if (!declType.returnType().equals(void.class)) {
-            returnExpr = STR."return (\{retType}) ";
-        }
+        boolean isVoid = declType.returnType().equals(void.class);
+        String returnNoCast = isVoid ? "" : STR."return ";
+        String returnWithCast = isVoid ? "" : STR."\{returnNoCast}(\{retType})";
         String getterName = mangleName(javaName, MethodHandle.class);
         String paramList = String.join(", ", finalParamNames);
         String traceArgList = paramList.isEmpty() ?
@@ -167,7 +166,7 @@ class HeaderFileBuilder extends ClassSourceBuilder {
                         if (TRACE_DOWNCALLS) {
                             traceDowncall(\{traceArgList});
                         }
-                        \{returnExpr}mh$.invokeExact(\{paramList});
+                        \{returnWithCast}mh$.invokeExact(\{paramList});
                     } catch (Throwable ex$) {
                        throw new AssertionError("should not reach here", ex$);
                     }
@@ -187,7 +186,7 @@ class HeaderFileBuilder extends ClassSourceBuilder {
                      */
                     static \{retType} invoke(\{paramExprs}) {
                         MemoryLayout[] inferredLayouts$ = \{runtimeHelperName()}.inferVariadicLayouts(\{varargsParam});
-                        \{returnExpr.isEmpty() ? "" : "return "}\{javaName}(inferredLayouts$).apply(\{String.join(", ", finalParamNames)});
+                        \{returnNoCast}\{javaName}(inferredLayouts$).apply(\{String.join(", ", finalParamNames)});
                     }
                 }
 
@@ -202,7 +201,7 @@ class HeaderFileBuilder extends ClassSourceBuilder {
                             if (TRACE_DOWNCALLS) {
                                 traceDowncall(\{traceArgList});
                             }
-                            \{returnExpr}mh$.invokeExact(\{paramList});
+                            \{returnWithCast}mh$.invokeExact(\{paramList});
                         } catch(IllegalArgumentException ex$)  {
                             throw ex$; // rethrow IAE from passing wrong number/type of args
                         } catch (Throwable ex$) {

--- a/test/jtreg/generator/testPrintf/TestPrintf.java
+++ b/test/jtreg/generator/testPrintf/TestPrintf.java
@@ -46,7 +46,7 @@ public class TestPrintf {
     public void testsPrintf(String fmt, Object[] args, String expected, MemoryLayout[] unused) {
         try (Arena arena = Arena.ofConfined()) {
             MemorySegment s = arena.allocate(1024);
-            my_sprintf(s, arena.allocateFrom(fmt), args.length, args);
+            my_sprintf.invoke(s, arena.allocateFrom(fmt), args.length, args);
             String str = s.getString(0);
             assertEquals(str, expected);
         }
@@ -56,8 +56,8 @@ public class TestPrintf {
     public void testsPrintfInvoker(String fmt, Object[] args, String expected, MemoryLayout[] layouts) {
         try (Arena arena = Arena.ofConfined()) {
             MemorySegment s = arena.allocate(1024);
-            my_sprintf$makeInvoker(layouts)
-                .my_sprintf(s, arena.allocateFrom(fmt), args.length, args);
+            my_sprintf(layouts)
+                    .apply(s, arena.allocateFrom(fmt), args.length, args);
             String str = s.getString(0);
             assertEquals(str, expected);
         }
@@ -67,15 +67,15 @@ public class TestPrintf {
     public void testsPrintfInvokerWrongArgs(String fmt, MemoryLayout[] layouts, Object[] args) {
         try (Arena arena = Arena.ofConfined()) {
             MemorySegment s = arena.allocate(1024);
-            my_sprintf$makeInvoker(layouts)
-                .my_sprintf(s, arena.allocateFrom(fmt), args.length, args); // should throw
+            my_sprintf(layouts)
+                    .apply(s, arena.allocateFrom(fmt), args.length, args); // should throw
         }
     }
 
     // linker does not except unpromoted layouts
     @Test(dataProvider = "illegalLinkCases", expectedExceptions = IllegalArgumentException.class)
     public void testsPrintfInvokerWrongArgs(MemoryLayout[] layouts) {
-        my_sprintf$makeInvoker(layouts); // should throw
+        my_sprintf(layouts); // should throw
     }
 
     // data providers:

--- a/test/testng/org/openjdk/jextract/test/toolprovider/JextractToolProviderTest.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/JextractToolProviderTest.java
@@ -111,17 +111,22 @@ public class JextractToolProviderTest extends JextractToolRunner {
         runAndCompile(helloOutput, helloH.toString());
         try(TestUtils.Loader loader = TestUtils.classLoader(helloOutput)) {
             Class<?> cls = loader.loadClass("hello_h");
-            // check a method for "void func(int)"
-            assertNotNull(findMethod(cls, "func", int.class));
-            // check a method for "int printf(MemorySegment, Object[])"
-            assertNotNull(findMethod(cls, "printf", MemorySegment.class, Object[].class));
-            // check an interface for printf$invoker
-            assertNotNull(findNestedClass(cls, "printf$invoker"));
-            // check a method for "printf$makeInvoker printf$makeInvoker(MemoryLayout...)"
-            assertNotNull(findMethod(cls, "printf$makeInvoker", MemoryLayout[].class));
+            checkHeaderMembers(cls);
         } finally {
             TestUtils.deleteDir(helloOutput);
         }
+    }
+
+    private static void checkHeaderMembers(Class<?> header) {
+        // check a method for "void func(int)"
+        assertNotNull(findMethod(header, "func", int.class));
+        // check a method for "printf(MemoryLayout...)"
+        assertNotNull(findMethod(header, "printf", MemoryLayout[].class));
+        // check an interface for printf$invoker
+        Class<?> invokerCls = findNestedClass(header, "printf");
+        assertNotNull(invokerCls);
+        // check a method for "int printf(MemorySegment, Object[])"
+        assertNotNull(findMethod(invokerCls, "invoke", MemorySegment.class, Object[].class));
     }
 
     @Test
@@ -144,14 +149,7 @@ public class JextractToolProviderTest extends JextractToolRunner {
         runAndCompile(helloOutput, targetPkgOption, "com.acme", helloH.toString());
         try(TestUtils.Loader loader = TestUtils.classLoader(helloOutput)) {
             Class<?> cls = loader.loadClass("com.acme.hello_h");
-            // check a method for "void func(int)"
-            assertNotNull(findMethod(cls, "func", int.class));
-            // check a method for "int printf(MemorySegment, Object[])"
-            assertNotNull(findMethod(cls, "printf", MemorySegment.class, Object[].class));
-            // check an interface for printf$invoker
-            assertNotNull(findNestedClass(cls, "printf$invoker"));
-            // check a method for "printf$makeInvoker printf$makeInvoker(MemoryLayout...)"
-            assertNotNull(findMethod(cls, "printf$makeInvoker", MemoryLayout[].class));
+            checkHeaderMembers(cls);
         } finally {
             TestUtils.deleteDir(helloOutput);
         }
@@ -174,14 +172,7 @@ public class JextractToolProviderTest extends JextractToolRunner {
         runAndCompile(helloOutput, "--header-class-name", "MyHello", "-t", "com.acme", helloH.toString());
         try(TestUtils.Loader loader = TestUtils.classLoader(helloOutput)) {
             Class<?> cls = loader.loadClass("com.acme.MyHello");
-            // check a method for "void func(int)"
-            assertNotNull(findMethod(cls, "func", int.class));
-            // check a method for "int printf(MemorySegment, Object[])"
-            assertNotNull(findMethod(cls, "printf", MemorySegment.class, Object[].class));
-            // check an interface for printf$invoker
-            assertNotNull(findNestedClass(cls, "printf$invoker"));
-            // check a method for "printf$makeInvoker printf$makeInvoker(MemoryLayout...)"
-            assertNotNull(findMethod(cls, "printf$makeInvoker", MemoryLayout[].class));
+            checkHeaderMembers(cls);
         } finally {
             TestUtils.deleteDir(helloOutput);
         }

--- a/test/testng/org/openjdk/jextract/test/toolprovider/docComments/TestDocComments.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/docComments/TestDocComments.java
@@ -97,8 +97,7 @@ public class TestDocComments extends JextractToolRunner {
         assertContains(comments, List.of(
             "int func(int *fp)",
             "double distance(struct Point p)",
-            "int printf(char *fmt, ...)",
-            "int printf(char *fmt, ...)"));
+            "Variadic invoker factory for: int printf(char *fmt, ...)"));
     }
 
     @Test

--- a/test/testng/org/openjdk/jextract/test/toolprovider/docComments/TestDocComments.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/docComments/TestDocComments.java
@@ -94,7 +94,7 @@ public class TestDocComments extends JextractToolRunner {
     @Test
     public void testFunctions() throws IOException {
         var comments = getDocComments("functions.h", "functions_h.java");
-        assertEquals(comments, List.of(
+        assertContains(comments, List.of(
             "int func(int *fp)",
             "double distance(struct Point p)",
             "int printf(char *fmt, ...)",


### PR DESCRIPTION
This PR slightly changes the code generation scheme for variadic calls.

Given a variadic function like this:

```c
int foo(int count, ...);
```

We now generate the following:

```java
    /**
     * Variadic invoker interface for:
     * {@snippet lang=c :
     * int foo(int count, ...)
     * }
     */
    public interface foo {
        int apply(int count, Object... x1);

        /**
         * Invoke the variadic function with the given parameters. Layouts for variadic arguments are inferred.
         */
        static int invoke(int count, Object... x1) {
            MemoryLayout[] inferredLayouts$ = foo_h.inferVariadicLayouts(x1);
            return foo(inferredLayouts$).apply(count, x1);
        }
    }

    /**
     * {@snippet lang=c :
     * int foo(int count, ...)
     * }
     */
    public static foo foo(MemoryLayout... layouts) {
        FunctionDescriptor baseDesc$ = FunctionDescriptor.of(
                foo_h.C_INT,
                foo_h.C_INT
            );
        var mh$ = foo_h.downcallHandleVariadic("foo", baseDesc$, layouts);
        return (int count, Object... x1) -> {
            try {
                if (TRACE_DOWNCALLS) {
                    traceDowncall("foo", count, x1);
                }
                return (int) mh$.invokeExact(count, x1);
            } catch(IllegalArgumentException ex$)  {
                throw ex$; // rethrow IAE from passing wrong number/type of args
            } catch (Throwable ex$) {
               throw new AssertionError("should not reach here", ex$);
            }
        };
    }
```

Main changes:

* the invoker interface now has the same name as the variadic function (as opposed to `foo$invoker`)
* the header class only has one static method, with same name as variadic function (`foo`); this is a factory for the invoker class with same name
* the handy Java varargs method that takes objects and infers layout is now moved inside the invoker class (see static `invoke` method)
* the main invoker method name has been changed to `apply`
* a bug has been fixed where a redundant case was emitted in the static `invoke` method

Example of invoker form (see changes to `TestPrintf`):

```java
my_sprintf(layouts).apply(s, arena.allocateFrom(fmt), args.length, args);
```

Example of static invoke:

```java
my_sprintf.invoke(s, arena.allocateFrom(fmt), args.length, args);
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Issue
 * [CODETOOLS-7903642](https://bugs.openjdk.org/browse/CODETOOLS-7903642): Code generation for variadic function emits redundant casts (**Bug** - P3)


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - Committer) ⚠️ Review applies to [a48fb46a](https://git.openjdk.org/jextract/pull/194/files/a48fb46a3ccce2133c12d3e09c2b0d8259105a8b)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/194/head:pull/194` \
`$ git checkout pull/194`

Update a local copy of the PR: \
`$ git checkout pull/194` \
`$ git pull https://git.openjdk.org/jextract.git pull/194/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 194`

View PR using the GUI difftool: \
`$ git pr show -t 194`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/194.diff">https://git.openjdk.org/jextract/pull/194.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/194#issuecomment-1909942027)