### PR TITLE
7903644: typedef of anonymous struct generates a redundant class

### DIFF
--- a/src/main/java/org/openjdk/jextract/impl/NameMangler.java
+++ b/src/main/java/org/openjdk/jextract/impl/NameMangler.java
@@ -172,7 +172,7 @@ public final class NameMangler implements Declaration.Visitor<Void, Declaration>
                 if (parent instanceof Typedef typedef && typedef.type() instanceof Declared declared &&
                         declared.tree().name().isEmpty()) {
                     // typedef struct { ... } Foo;
-                    // steal the name from the parent typedef
+                    // steal the name from the parent typedef (which has already been mangled)
                     name = JavaName.getOrThrow(parent);
                 } else {
                     name = oldScope.uniqueNestedClassName(scoped.name().isEmpty() ?

--- a/src/main/java/org/openjdk/jextract/impl/OutputFactory.java
+++ b/src/main/java/org/openjdk/jextract/impl/OutputFactory.java
@@ -145,6 +145,7 @@ public class OutputFactory implements Declaration.Visitor<Void, Declaration> {
 
         Declaration.Scoped structOrUnionDecl = Utils.structOrUnionDecl(type);
         if (structOrUnionDecl != null && !structOrUnionDecl.name().isEmpty()) {
+            // do not generate a typedef class if this is a typedef of an anonymous struct (see NameMangler)
             toplevelBuilder.addTypedef(tree, JavaName.getFullNameOrThrow(structOrUnionDecl));
         } else if (type instanceof Type.Primitive) {
             toplevelBuilder.addTypedef(tree, null);

--- a/src/main/java/org/openjdk/jextract/impl/OutputFactory.java
+++ b/src/main/java/org/openjdk/jextract/impl/OutputFactory.java
@@ -144,7 +144,7 @@ public class OutputFactory implements Declaration.Visitor<Void, Declaration> {
         Utils.forEachNested(tree, s -> s.accept(this, null));
 
         Declaration.Scoped structOrUnionDecl = Utils.structOrUnionDecl(type);
-        if (structOrUnionDecl != null) {
+        if (structOrUnionDecl != null && !structOrUnionDecl.name().isEmpty()) {
             toplevelBuilder.addTypedef(tree, JavaName.getFullNameOrThrow(structOrUnionDecl));
         } else if (type instanceof Type.Primitive) {
             toplevelBuilder.addTypedef(tree, null);

--- a/src/main/java/org/openjdk/jextract/impl/Utils.java
+++ b/src/main/java/org/openjdk/jextract/impl/Utils.java
@@ -183,14 +183,6 @@ class Utils {
         return null;
     }
 
-    static Scoped getAnonymousStructTypedef(Declaration declaration) {
-        return switch (declaration) {
-            case Typedef typedef when typedef.type() instanceof Declared declared &&
-                    isStructOrUnion(declared) && declared.tree().name().isEmpty() -> declared.tree();
-            case null, default -> null;
-        };
-    }
-
     /**
      * Is a character printable ASCII?
      */

--- a/src/main/java/org/openjdk/jextract/impl/Utils.java
+++ b/src/main/java/org/openjdk/jextract/impl/Utils.java
@@ -28,8 +28,11 @@ package org.openjdk.jextract.impl;
 
 import org.openjdk.jextract.Declaration;
 import org.openjdk.jextract.Declaration.Constant;
+import org.openjdk.jextract.Declaration.Scoped;
+import org.openjdk.jextract.Declaration.Typedef;
 import org.openjdk.jextract.JavaSourceFile;
 import org.openjdk.jextract.Type;
+import org.openjdk.jextract.Type.Declared;
 import org.openjdk.jextract.Type.Delegated;
 import org.openjdk.jextract.Type.Delegated.Kind;
 import org.openjdk.jextract.Type.Function;
@@ -178,6 +181,14 @@ class Utils {
             }
         }
         return null;
+    }
+
+    static Scoped getAnonymousStructTypedef(Declaration declaration) {
+        return switch (declaration) {
+            case Typedef typedef when typedef.type() instanceof Declared declared &&
+                    isStructOrUnion(declared) && declared.tree().name().isEmpty() -> declared.tree();
+            case null, default -> null;
+        };
     }
 
     /**

--- a/test/jtreg/generator/nestedTypes/TestNestedTypesUnsupported.java
+++ b/test/jtreg/generator/nestedTypes/TestNestedTypesUnsupported.java
@@ -49,7 +49,6 @@ public class TestNestedTypesUnsupported {
         checkLayout(Outer.layout(), UNDEFINED_STRUCT);
         checkLayout(outer_var.layout(), UNDEFINED_STRUCT);
         checkLayout(outer_td.layout(), UNDEFINED_STRUCT);
-        checkLayout(outer_td$0.layout(), UNDEFINED_STRUCT);
         checkLayout(f2$return.layout(), UNDEFINED_STRUCT);
         checkLayout(f3$x0.layout(), UNDEFINED_STRUCT);
     }

--- a/test/testng/org/openjdk/jextract/test/toolprovider/TestClassGeneration.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/TestClassGeneration.java
@@ -115,8 +115,8 @@ public class TestClassGeneration extends JextractToolRunner {
             { "Foo", C_LONG_LONG.withName("ll"), long.class,          10L },
             { "Foo", C_FLOAT.withName("f"),     float.class,         10F },
             { "Foo", C_DOUBLE.withName("d"),    double.class,        10D },
-            { "Bar$0", C_INT.withName("a"),       int.class,           10 },
-            { "Bar$0", C_INT.withName("b"),       int.class,           10 },
+            { "Bar", C_INT.withName("a"),       int.class,           10 },
+            { "Bar", C_INT.withName("b"),       int.class,           10 },
         };
     }
 


### PR DESCRIPTION
This PR tweaks jextract so that typedefs of anonymous structs only generate one class (that of the struct).

This required some changes in both `NameMangler` (to make sure that the special naming rule was applied), and then in `OutputFactory`, to make sure that in such case the typedef class is not emitted.

I've tweaked a number of tests which now reflect the "less verbose" jextract output - as such I don't think we need to add further tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Issue
 * [CODETOOLS-7903644](https://bugs.openjdk.org/browse/CODETOOLS-7903644): typedef of anonymous struct generates a redundant class (**Bug** - P3)


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - Committer) ⚠️ Review applies to [726967aa](https://git.openjdk.org/jextract/pull/195/files/726967aaeb20caf025d1924e5d934570b80721fa)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/195/head:pull/195` \
`$ git checkout pull/195`

Update a local copy of the PR: \
`$ git checkout pull/195` \
`$ git pull https://git.openjdk.org/jextract.git pull/195/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 195`

View PR using the GUI difftool: \
`$ git pr show -t 195`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/195.diff">https://git.openjdk.org/jextract/pull/195.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/195#issuecomment-1910674183)