### PR TITLE
7903647: typedef of function pointers generates a redundant class

### DIFF
--- a/src/main/java/org/openjdk/jextract/impl/Utils.java
+++ b/src/main/java/org/openjdk/jextract/impl/Utils.java
@@ -165,7 +165,7 @@ class Utils {
 
     static Function getAsFunctionPointer(Type type) {
         return switch (type) {
-            case Type.Delegated delegated -> getAsFunctionPointer(delegated.type());
+            case Type.Delegated delegated when delegated.kind() == Kind.POINTER -> getAsFunctionPointer(delegated.type());
             case Type.Function function -> function;
             default -> null;
         };

--- a/test/testng/org/openjdk/jextract/test/toolprovider/typedefs/TestRedundantTypedefs.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/typedefs/TestRedundantTypedefs.java
@@ -62,7 +62,9 @@ public class TestRedundantTypedefs extends JextractToolRunner {
     public void testFunctionTypedefs() {
         assertNotNull(loader.loadClass("f"));
         assertNotNull(loader.loadClass("g"));
-        assertNull(loader.loadClass("f$ptr"));
-        assertNull(loader.loadClass("g$ptr"));
+        assertNull(loader.loadClass("foo_f$ptr_f"));
+        assertNull(loader.loadClass("foo_f$return"));
+        assertNull(loader.loadClass("foo_g$ptr_f"));
+        assertNull(loader.loadClass("foo_g$return"));
     }
 }

--- a/test/testng/org/openjdk/jextract/test/toolprovider/typedefs/TestRedundantTypedefs.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/typedefs/TestRedundantTypedefs.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package org.openjdk.jextract.test.toolprovider.typedefs;
+
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import testlib.JextractToolRunner;
+
+import java.nio.file.Path;
+
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+
+public class TestRedundantTypedefs extends JextractToolRunner {
+
+    Loader loader;
+
+    @BeforeClass
+    public void beforeClass() {
+        Path output = getOutputFilePath("TestRedundantTypedefs-typedefs.h");
+        Path input = getInputFilePath("typedefs.h");
+        runAndCompile(output, input.toString());
+        loader = classLoader(output);
+    }
+
+    @AfterClass
+    public void afterClass() {
+        loader.close();
+    }
+
+    @Test
+    public void testStructTypedefs() {
+        assertNotNull(loader.loadClass("P"));
+        assertNotNull(loader.loadClass("Q"));
+        assertNull(loader.loadClass("P$0"));
+        assertNull(loader.loadClass("Q$0"));
+    }
+
+    @Test
+    public void testFunctionTypedefs() {
+        assertNotNull(loader.loadClass("f"));
+        assertNotNull(loader.loadClass("g"));
+        assertNull(loader.loadClass("f$ptr"));
+        assertNull(loader.loadClass("g$ptr"));
+    }
+}

--- a/test/testng/org/openjdk/jextract/test/toolprovider/typedefs/typedefs.h
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/typedefs/typedefs.h
@@ -26,3 +26,11 @@ typedef P Q;
 
 typedef void (*f)(int, double);
 typedef f g;
+
+// add some uses
+
+P foo_P(P p);
+Q foo_P(Q q);
+
+f foo_f(f ptr_f);
+g foo_g(g ptr_g);

--- a/test/testng/org/openjdk/jextract/test/toolprovider/typedefs/typedefs.h
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/typedefs/typedefs.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+typedef struct { int x; int y; } P;
+typedef P Q;
+
+typedef void (*f)(int, double);
+typedef f g;


### PR DESCRIPTION
This PR fixes few more issues with typedefs.

The first issue is that function pointer typedefs generate two classes. The first is generated when we go in OutpoutFactory::visitTypedef (as expected). The second class is generated when we look at the parameters of a function that declares a parameter whose type is the function pointer typedef.

The second issue is that when a typedef for an anon struct is typedeffed again, we end up skipping the second typedef, as the underlying type of the typedef is - again- an anoymous struct.

The solution to the first issue is to tweak `Utils::getAsFunctionPointer` not to process typedef types. After looking at all usages of this method, it dawned on me that this is actually the behavior that we want: when processing nested types, we only want to emit stuff for declarations that are truly "inline", and not for typedefs of other declarations.

The solution to the second issue is to make the skipping logic for anon struct more nuanced, so that we only skip anon declarations that are _nested_ in the very typedef being processed.

I've added a test for both conditions, as existing tests were not enough to cover these discrepancies.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Issue
 * [CODETOOLS-7903647](https://bugs.openjdk.org/browse/CODETOOLS-7903647): typedef of function pointers generates a redundant class (**Bug** - P3)


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/196/head:pull/196` \
`$ git checkout pull/196`

Update a local copy of the PR: \
`$ git checkout pull/196` \
`$ git pull https://git.openjdk.org/jextract.git pull/196/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 196`

View PR using the GUI difftool: \
`$ git pr show -t 196`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/196.diff">https://git.openjdk.org/jextract/pull/196.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/196#issuecomment-1912012559)