### PR TITLE
7903649: Field and global variables of array type should have indexed accessors

### DIFF
--- a/src/main/java/org/openjdk/jextract/impl/ClassSourceBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/ClassSourceBuilder.java
@@ -40,8 +40,10 @@ import java.lang.foreign.MemorySegment;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodType;
 import java.lang.invoke.VarHandle;
+import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 /**
  * Superclass for .java source generator classes.
@@ -265,5 +267,17 @@ abstract class ClassSourceBuilder {
         Objects.requireNonNull(decl);
         String declString = DeclarationString.getOrThrow(decl);
         return declString.lines().collect(Collectors.joining("\n * ", " * ", ""));
+    }
+
+    record IndexList(String decl, String use) {
+        static IndexList of(int dims) {
+            List<String> indexNames = IntStream.range(0, dims).mapToObj(i -> "index" + i).toList();
+            String indexDecls = indexNames.stream()
+                    .map(i -> "long " + i)
+                    .collect(Collectors.joining(", "));
+            String indexUses = indexNames.stream()
+                    .collect(Collectors.joining(", "));
+            return new IndexList(indexDecls, indexUses);
+        }
     }
 }

--- a/src/main/java/org/openjdk/jextract/impl/Utils.java
+++ b/src/main/java/org/openjdk/jextract/impl/Utils.java
@@ -183,6 +183,20 @@ class Utils {
         return null;
     }
 
+    static int dimensions(Type type) {
+        return switch (type) {
+            case Type.Array array -> 1 + dimensions(array.elementType());
+            default -> 0;
+        };
+    }
+
+    static Type typeOrElemType(Type type) {
+        return switch (type) {
+            case Type.Array array -> typeOrElemType(array.elementType());
+            default -> type;
+        };
+    }
+
     /**
      * Is a character printable ASCII?
      */

--- a/test/jtreg/generator/arrayAccess/TestArrayAccess.java
+++ b/test/jtreg/generator/arrayAccess/TestArrayAccess.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+import test.jextract.arrayaccess.*;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+
+import static test.jextract.arrayaccess.array_access_h.*;
+
+/*
+ * @test
+ * @library /lib
+ * @run main/othervm JtregJextract -l ArrayAccess -t test.jextract.arrayaccess array_access.h
+ * @build TestArrayAccess
+ * @run testng/othervm --enable-native-access=ALL-UNNAMED TestArrayAccess
+ */
+
+public class TestArrayAccess {
+    @Test
+    public void testArrayAccessStructInt1() {
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment foo = Foo.allocate(arena);
+            for (int i = 0 ; i < 2 ; i++) {
+                Foo.ints1(foo, i, i + 1);
+                assertEquals(Foo.ints1(foo, i), i + 1);
+            }
+        }
+    }
+
+    @Test
+    public void testArrayAccessStructInt2() {
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment foo = Foo.allocate(arena);
+            for (int i = 0 ; i < 2 ; i++) {
+                for (int j = 0; j < 2; j++) {
+                    Foo.ints2(foo, i, j, i + j + 1);
+                    assertEquals(Foo.ints2(foo, i, j), i + j + 1);
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testArrayAccessStructInt3() {
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment foo = Foo.allocate(arena);
+            for (int i = 0 ; i < 2 ; i++) {
+                for (int j = 0; j < 2; j++) {
+                    for (int k = 0; k < 2; k++) {
+                        Foo.ints3(foo, i, j, k, i + j + k + 1);
+                        assertEquals(Foo.ints3(foo, i, j, k), i + j + k + 1);
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testArrayAccessGlobalInt1() {
+        for (int i = 0 ; i < 2 ; i++) {
+            ints1(i, i + 1);
+            assertEquals(ints1(i), i + 1);
+        }
+    }
+
+    @Test
+    public void testArrayAccessGlobalInt2() {
+        for (int i = 0 ; i < 2 ; i++) {
+            for (int j = 0; j < 2; j++) {
+                ints2(i, j, i + j + 1);
+                assertEquals(ints2(i, j), i + j + 1);
+            }
+        }
+    }
+
+    @Test
+    public void testArrayAccessGlobalInt3() {
+        for (int i = 0 ; i < 2 ; i++) {
+            for (int j = 0; j < 2; j++) {
+                for (int k = 0; k < 2; k++) {
+                    ints3(i, j, k, i + j + k + 1);
+                    assertEquals(ints3(i, j, k), i + j + k + 1);
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testArrayAccessStructStruct1() {
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment foo = Foo.allocate(arena);
+            for (int i = 0 ; i < 2 ; i++) {
+                MemorySegment point = Point.allocate(arena);
+                Point.x(point, i + 1);
+                Point.y(point, i + 2);
+                Foo.points1(foo, i, point);
+                assertEquals(Point.x(Foo.points1(foo, i)), i + 1);
+                assertEquals(Point.y(Foo.points1(foo, i)), i + 2);
+            }
+        }
+    }
+
+    @Test
+    public void testArrayAccessStructStruct2() {
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment foo = Foo.allocate(arena);
+            for (int i = 0 ; i < 2 ; i++) {
+                for (int j = 0; j < 2; j++) {
+                    MemorySegment point = Point.allocate(arena);
+                    Point.x(point, i + j + 1);
+                    Point.y(point, i + j + 2);
+                    Foo.points2(foo, i, j, point);
+                    assertEquals(Point.x(Foo.points2(foo, i, j)), i + j + 1);
+                    assertEquals(Point.y(Foo.points2(foo, i, j)), i + j + 2);
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testArrayAccessStructStruct3() {
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment foo = Foo.allocate(arena);
+            for (int i = 0 ; i < 2 ; i++) {
+                for (int j = 0; j < 2; j++) {
+                    for (int k = 0; k < 2; k++) {
+                        MemorySegment point = Point.allocate(arena);
+                        Point.x(point, i + j + k + 1);
+                        Point.y(point, i + j + k + 2);
+                        Foo.points3(foo, i, j, k, point);
+                        assertEquals(Point.x(Foo.points3(foo, i, j, k)), i + j + k + 1);
+                        assertEquals(Point.y(Foo.points3(foo, i, j, k)), i + j + k + 2);
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testArrayAccessGlobalStruct1() {
+        try (Arena arena = Arena.ofConfined()) {
+            for (int i = 0; i < 2; i++) {
+                MemorySegment point = Point.allocate(arena);
+                Point.x(point, i + 1);
+                Point.y(point, i + 2);
+                points1(i, point);
+                assertEquals(Point.x(points1(i)), i + 1);
+                assertEquals(Point.y(points1(i)), i + 2);
+            }
+        }
+    }
+
+    @Test
+    public void testArrayAccessGlobalStruct2() {
+        try (Arena arena = Arena.ofConfined()) {
+            for (int i = 0; i < 2; i++) {
+                for (int j = 0; j < 2; j++) {
+                    MemorySegment point = Point.allocate(arena);
+                    Point.x(point, i + j + 1);
+                    Point.y(point, i + j + 2);
+                    points2(i, j, point);
+                    assertEquals(Point.x(points2(i, j)), i + j + 1);
+                    assertEquals(Point.y(points2(i, j)), i + j + 2);
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testArrayAccessGlobalStruct3() {
+        try (Arena arena = Arena.ofConfined()) {
+            for (int i = 0 ; i < 2 ; i++) {
+                for (int j = 0; j < 2; j++) {
+                    for (int k = 0; k < 2; k++) {
+                        MemorySegment point = Point.allocate(arena);
+                        Point.x(point, i + j + k + 1);
+                        Point.y(point, i + j + k + 2);
+                        points3(i, j, k, point);
+                        assertEquals(Point.x(points3(i, j, k)), i + j + k + 1);
+                        assertEquals(Point.y(points3(i, j, k)), i + j + k + 2);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/test/jtreg/generator/arrayAccess/array_access.h
+++ b/test/jtreg/generator/arrayAccess/array_access.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+#ifdef _WIN64
+#define EXPORT __declspec(dllexport)
+#else
+#define EXPORT
+#endif
+
+struct Point {
+    int x;
+    int y;
+};
+
+// array fields in struct
+
+struct Foo {
+    struct Point points1[2];
+    struct Point points2[2][2];
+    struct Point points3[2][2][2];
+
+    int ints1[2];
+    int ints2[2][2];
+    int ints3[2][2][2];
+};
+
+// array global vars
+
+extern struct Point points1[2];
+extern struct Point points2[2][2];
+extern struct Point points3[2][2][2];
+
+extern int ints1[2];
+extern int ints2[2][2];
+extern int ints3[2][2][2];

--- a/test/jtreg/generator/arrayAccess/libArrayAccess.c
+++ b/test/jtreg/generator/arrayAccess/libArrayAccess.c
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include "array_access.h"
+
+EXPORT struct Point points1[2];
+EXPORT struct Point points2[2][2];
+EXPORT struct Point points3[2][2][2];
+
+EXPORT int ints1[2];
+EXPORT int ints2[2][2];
+EXPORT int ints3[2][2][2];

--- a/test/testng/org/openjdk/jextract/test/toolprovider/docComments/TestDocComments.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/docComments/TestDocComments.java
@@ -78,17 +78,27 @@ public class TestDocComments extends JextractToolRunner {
     @Test
     public void testArrays() throws IOException {
         var comments = getDocComments("arrays.h", "arrays_h.java");
-        assertEquals(comments, List.of(
+        assertContains(comments, List.of(
             "Getter for variable: int abc[10]",
+            "Indexed getter for variable: int abc[10]",
             "Setter for variable: int abc[10]",
+            "Indexed setter for variable: int abc[10]",
             "Getter for variable: float numbers[3]",
+            "Indexed getter for variable: float numbers[3]",
             "Setter for variable: float numbers[3]",
+            "Indexed setter for variable: float numbers[3]",
             "Getter for variable: char *msg[5]",
+            "Indexed getter for variable: char *msg[5]",
             "Setter for variable: char *msg[5]",
+            "Indexed setter for variable: char *msg[5]",
             "Getter for variable: int pixels[200][100]",
+            "Indexed getter for variable: int pixels[200][100]",
             "Setter for variable: int pixels[200][100]",
+            "Indexed setter for variable: int pixels[200][100]",
             "Getter for variable: int points[10][20][30]",
-            "Setter for variable: int points[10][20][30]"));
+            "Indexed getter for variable: int points[10][20][30]",
+            "Setter for variable: int points[10][20][30]",
+            "Indexed setter for variable: int points[10][20][30]"));
     }
 
     @Test


### PR DESCRIPTION
This PR adds support for indexed accessors for struct fields and global variables whose type is an array type. These accessors feature a number of `long` access coordinates which has the same cardinality as that of the underlying array type.

For instance, consider the following global variable declaration:

```c
int ints[2][3][4];
```

For this, jextract now emits:

```java
    private static SequenceLayout ints$LAYOUT() {
        class Holder {
            static final SequenceLayout LAYOUT = MemoryLayout.sequenceLayout(2, MemoryLayout.sequenceLayout(3, MemoryLayout.sequenceLayout(4, foo_h.C_INT)));
        }
        return Holder.LAYOUT;
    }

    private static MemorySegment ints$SEGMENT() {
        class Holder {
            static final MemorySegment SEGMENT = foo_h.findOrThrow("ints")
                .reinterpret(ints$LAYOUT().byteSize());
        }
        return Holder.SEGMENT;
    }

    /**
     * Getter for variable:
     * {@snippet lang=c :
     * int ints[2][3][4]
     * }
     */
    public static MemorySegment ints() {
        return ints$SEGMENT();
    }

    /**
     * Setter for variable:
     * {@snippet lang=c :
     * int ints[2][3][4]
     * }
     */
    public static void ints(MemorySegment varValue) {
        MemorySegment.copy(varValue, 0L, ints$SEGMENT(), 0L, ints$LAYOUT().byteSize());
    }

    private static VarHandle ints$ELEM_HANDLE() {
        class Holder {
            static final VarHandle HANDLE = ints$LAYOUT().varHandle(sequenceElement(), sequenceElement(), sequenceElement());
        }
        return Holder.HANDLE;
    }

    /**
     * Indexed getter for variable:
     * {@snippet lang=c :
     * int ints[2][3][4]
     * }
     */
    public static int ints(long index0, long index1, long index2) {
        return (int)ints$ELEM_HANDLE().get(ints$SEGMENT(), 0L, index0, index1, index2);
    }

    /**
     * Indexed setter for variable:
     * {@snippet lang=c :
     * int ints[2][3][4]
     * }
     */
    public static void ints(long index0, long index1, long index2, int varValue) {
        ints$ELEM_HANDLE().set(ints$SEGMENT(), 0L, index0, index1, index2, varValue);
    }
```

If the array element type is a struct, different code needs to be generated. Consider this global variable declaration:

```c
struct Point { int x; int y; } points[2][3][4];
```

This generates the following:

```java
    private static SequenceLayout points$LAYOUT() {
        class Holder {
            static final SequenceLayout LAYOUT = MemoryLayout.sequenceLayout(2, MemoryLayout.sequenceLayout(3, MemoryLayout.sequenceLayout(4, Point.layout())));
        }
        return Holder.LAYOUT;
    }

    private static MemorySegment points$SEGMENT() {
        class Holder {
            static final MemorySegment SEGMENT = foo_h.findOrThrow("points")
                .reinterpret(points$LAYOUT().byteSize());
        }
        return Holder.SEGMENT;
    }

    /**
     * Getter for variable:
     * {@snippet lang=c :
     * struct Point points[2][3][4]
     * }
     */
    public static MemorySegment points() {
        return points$SEGMENT();
    }

    /**
     * Setter for variable:
     * {@snippet lang=c :
     * struct Point points[2][3][4]
     * }
     */
    public static void points(MemorySegment varValue) {
        MemorySegment.copy(varValue, 0L, points$SEGMENT(), 0L, points$LAYOUT().byteSize());
    }

    private static MethodHandle points$ELEM_HANDLE() {
        class Holder {
            static final MethodHandle HANDLE = points$LAYOUT().sliceHandle(sequenceElement(), sequenceElement(), sequenceElement());
        }
        return Holder.HANDLE;
    }

    /**
     * Indexed getter for variable:
     * {@snippet lang=c :
     * struct Point points[2][3][4]
     * }
     */
    public static MemorySegment points(long index0, long index1, long index2) {
        try {
            return (MemorySegment)points$ELEM_HANDLE().invokeExact(points$SEGMENT(), 0L, index0, index1, index2);
        } catch (Throwable ex$) {
            throw new AssertionError("should not reach here", ex$);
        }
    }

    /**
     * Indexed setter for variable:
     * {@snippet lang=c :
     * struct Point points[2][3][4]
     * }
     */
    public static void points(long index0, long index1, long index2, MemorySegment varValue) {
        MemorySegment.copy(varValue, 0L, points(index0, index1, index2), 0L, Point.layout().byteSize());
    }
```

(note that bulk copy is used for the setter).

For struct fields, we generate similar code - the only difference is that the var/method handle for accessing the array element is declared in a plain field (instead of using the holder idiom), similarly to what happens with other struct declarations. Note also that, for structs, the indexed accessors must receive an additional `MemorySegment` parameter (the segment struct being accessed).


