### PR TITLE
Fix curl sample

### DIFF
--- a/samples/libcurl/CurlMain.java
+++ b/samples/libcurl/CurlMain.java
@@ -43,7 +43,7 @@ public class CurlMain {
        if(!curl.equals(NULL)) {
            try (var arena = Arena.ofConfined()) {
                var url = arena.allocateFrom(urlStr);
-               curl_easy_setopt(curl, CURLOPT_URL(), url.address());
+               curl_easy_setopt.invoke(curl, CURLOPT_URL(), url.address());
                int res = curl_easy_perform(curl);
                if (res != CURLE_OK()) {
                    String error = curl_easy_strerror(res).getString(0);


### PR DESCRIPTION
Noticed a small issue in the curl sample. We recently moved the varargs invoker that infers layouts to nested class under the name `invoke`. Switch the sample to the new scheme as well.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/199/head:pull/199` \
`$ git checkout pull/199`

Update a local copy of the PR: \
`$ git checkout pull/199` \
`$ git pull https://git.openjdk.org/jextract.git pull/199/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 199`

View PR using the GUI difftool: \
`$ git pr show -t 199`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/199.diff">https://git.openjdk.org/jextract/pull/199.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/199#issuecomment-1927211583)