### PR TITLE
Streamline gradle task dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -149,7 +149,7 @@ task verify(type: Exec) {
 
 // jlink a JDK image with org.openjdk.jextract for testing
 task createRuntimeImageForTest(type: Exec) {
-    dependsOn verify
+    dependsOn createJextractJmod
 
     def out_dir = "$buildDir/jextract-jdk-test-image"
 
@@ -248,3 +248,5 @@ tasks.register("coverage", JavaExec) {
             "--html", "$buildDir/jacoco-report"
     ]
 }
+
+test.dependsOn(verify, jtreg)

--- a/build.gradle
+++ b/build.gradle
@@ -40,8 +40,7 @@ def clang_version = clang_versions[0]
 def jextract_version = "21"
 def jmods_dir = "$buildDir/jmods"
 def jextract_jmod_file = "$jmods_dir/org.openjdk.jextract.jmod"
-def jextract_jmod_libs_dir = "$buildDir/jextract_jmod_libs"
-def jextract_jmod_conf_dir = "$buildDir/jextract_jmod_conf";
+def jextract_jmod_inputs = "$buildDir/jmod_inputs"
 def jextract_app_dir = "$buildDir/jextract"
 def clang_include_dir = "${llvm_home}/lib/clang/${clang_version}/include"
 checkPath(clang_include_dir)
@@ -67,31 +66,24 @@ jar {
 }
 
 task copyLibClang(type: Copy) {
-    dependsOn jar
-
-    def dir_prefix_len = "$buildDir".length()
-    def libs_dir = jextract_jmod_libs_dir.substring(dir_prefix_len)
-    def conf_dir = jextract_jmod_conf_dir.substring(dir_prefix_len)
-
-    into("$buildDir")
+    into("$buildDir/jmod_inputs")
 
     from("${libclang_dir}") {
         include("*clang.*")
         include("libLLVM.*")
-        into(libs_dir)
+        into("libs")
     }
 
     from("$clang_include_dir") {
         include("*.h")
-        into(conf_dir + "/jextract")
+        into("conf/jextract")
     }
 }
 
 task createJextractJmod(type: Exec) {
-    dependsOn copyLibClang
+    dependsOn jar, copyLibClang
 
     // if these inputs or outputs change, gradle will rerun the task
-    inputs.file(jar.archiveFile.get())
     outputs.file(jextract_jmod_file)
 
     doFirst {
@@ -103,8 +95,8 @@ task createJextractJmod(type: Exec) {
           "create",
           "--module-version=$jextract_version",
           "--class-path=" + jar.archiveFile.get(),
-          "--libs=$jextract_jmod_libs_dir",
-          "--conf=$jextract_jmod_conf_dir",
+          "--libs=$jextract_jmod_inputs/libs",
+          "--conf=$jextract_jmod_inputs/conf",
           "${jextract_jmod_file}"
     ]
 }
@@ -113,7 +105,6 @@ task createJextractImage(type: Exec) {
     dependsOn createJextractJmod
 
     // if these inputs or outputs change, gradle will rerun the task
-    inputs.file(jar.archiveFile.get())
     outputs.dir(jextract_app_dir)
 
     def quote_jlink_opts = Os.isFamily(Os.FAMILY_WINDOWS)?
@@ -154,7 +145,6 @@ task createRuntimeImageForTest(type: Exec) {
     def out_dir = "$buildDir/jextract-jdk-test-image"
 
     // if these inputs or outputs change, gradle will rerun the task
-    inputs.file(jar.archiveFile.get())
     outputs.dir(out_dir)
 
     doFirst {

--- a/build.gradle
+++ b/build.gradle
@@ -238,5 +238,3 @@ tasks.register("coverage", JavaExec) {
             "--html", "$buildDir/jacoco-report"
     ]
 }
-
-test.dependsOn(verify, jtreg)


### PR DESCRIPTION
The main point of this PR is to remove the `verify` task as a dependency of the `createRuntimeImageForTest` task. Sometimes you have a broken jextract that you want to debug, which requires a test image, but the `verify` task is failing, meaning the `createRuntimeImageForTest` can not run. Removing `verify` as a dependency allows the test image to be built and debugged

~I've added both the `verify` and `jtreg` tasks as dependencies of `test`, so now the `test` task can be used to run all tests.~ (P.S. this added an invisible dependency of the `clean` task on the `jtreg` task, which makes the GHA build fail. I've remove this again)

I also took a look at the dependency setups of the other tasks. `copyLibClang` was depending on `jar` which is not required. I added the `jar` dependency to `createJextractJmod` instead which actually uses the jar file. This allows `copyLibClang` to run in parallel with other tasks. I had to slightly change it though: since it was using: `into("$buildDir")`, the entire build dir was treated as an output of the copy task, and this made gradle throw up several warnings because other tasks didn't have `copyLibClang` as a dependency. I've changed `copyLibClang` to copy the files into a build dir subdirectory instead, which is used exclusively as an output of the copy task.

Lastly, I removed some redundant inputs from tasks. A task is rebuilt if a dependency ran and the outputs changed, so there is no need to set the jar file as an explicit input. The images will be recreated if the jmod file changed, which will be recreated if the jar file changed. However, in this new setup, if the jar file was rebuilt, but the jmod didn't change as a result, we don't need to rebuild the images.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/200/head:pull/200` \
`$ git checkout pull/200`

Update a local copy of the PR: \
`$ git checkout pull/200` \
`$ git pull https://git.openjdk.org/jextract.git pull/200/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 200`

View PR using the GUI difftool: \
`$ git pr show -t 200`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/200.diff">https://git.openjdk.org/jextract/pull/200.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/200#issuecomment-1932204603)