### PR TITLE
7903656: Variadic invoker class names are not mangled

### DIFF
--- a/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
@@ -220,7 +220,7 @@ class HeaderFileBuilder extends ClassSourceBuilder {
                                 traceDowncall(\{traceArgList});
                             }
                             \{returnWithCast}mh$.invokeExact(\{paramList});
-                        } catch(IllegalArgumentException ex$)  {
+                        } catch(IllegalArgumentException | ClassCastException ex$)  {
                             throw ex$; // rethrow IAE from passing wrong number/type of args
                         } catch (Throwable ex$) {
                            throw new AssertionError("should not reach here", ex$);

--- a/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
@@ -190,12 +190,13 @@ class HeaderFileBuilder extends ClassSourceBuilder {
             }
             """);
         } else {
+            String invokerClassName = newHolderClassName(javaName);
             String paramExprs = paramExprs(declType, finalParamNames, isVarArg);
             String varargsParam = finalParamNames.get(finalParamNames.size() - 1);
             appendBlankLine();
             emitDocComment(decl, "Variadic invoker interface for:");
             appendLines(STR."""
-                public interface \{javaName} {
+                public interface \{invokerClassName} {
                     \{retType} apply(\{paramExprs});
 
                     /**
@@ -210,7 +211,7 @@ class HeaderFileBuilder extends ClassSourceBuilder {
                 """);
             emitDocComment(decl, "Variadic invoker factory for:");
             appendLines(STR."""
-                public static \{javaName} \{javaName}(MemoryLayout... layouts) {
+                public static \{invokerClassName} \{javaName}(MemoryLayout... layouts) {
                     FunctionDescriptor baseDesc$ = \{functionDescriptorString(2, decl.type())};
                     var mh$ = \{runtimeHelperName()}.downcallHandleVariadic("\{nativeName}", baseDesc$, layouts);
                     return (\{paramExprs}) -> {
@@ -466,7 +467,7 @@ class HeaderFileBuilder extends ClassSourceBuilder {
             String dimsString = dimensions.stream().map(d -> d.toString())
                     .collect(Collectors.joining(", "));
             appendIndentedLines(STR."""
-                private static class \{mangledName} {
+                public static class \{mangledName} {
                     public static final \{layoutType} LAYOUT = \{layoutString(varType)};
                     public static final MemorySegment SEGMENT = \{runtimeHelperName()}.findOrThrow("\{var.name()}").reinterpret(LAYOUT.byteSize());
                     \{accessHandle}
@@ -475,7 +476,7 @@ class HeaderFileBuilder extends ClassSourceBuilder {
                 """);
         } else {
             appendIndentedLines(STR."""
-                private static class \{mangledName} {
+                public static class \{mangledName} {
                     public static final \{layoutType} LAYOUT = \{layoutString(varType)};
                     public static final MemorySegment SEGMENT = \{runtimeHelperName()}.findOrThrow("\{var.name()}").reinterpret(LAYOUT.byteSize());
                 }
@@ -589,7 +590,7 @@ class HeaderFileBuilder extends ClassSourceBuilder {
     }
 
     private String newHolderClassName(String javaName) {
-        String holderClassName = STR."\{javaName}$constants";
+        String holderClassName = javaName;
         while (!holderClassNames.add(holderClassName.toLowerCase())) {
             holderClassName += "$";
         }

--- a/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
@@ -453,7 +453,7 @@ class HeaderFileBuilder extends ClassSourceBuilder {
 
     private String emitVarHolderClass(Declaration.Variable var, String javaName) {
         Type varType = var.type();
-        String mangledName = newHolderClassName(javaName);
+        String mangledName = newHolderClassName(STR."\{javaName}$constants");
         String layoutType = Utils.layoutCarrierFor(varType).getSimpleName();
         if (varType instanceof Type.Array) {
             List<Long> dimensions = Utils.dimensions(varType);
@@ -467,7 +467,7 @@ class HeaderFileBuilder extends ClassSourceBuilder {
             String dimsString = dimensions.stream().map(d -> d.toString())
                     .collect(Collectors.joining(", "));
             appendIndentedLines(STR."""
-                public static class \{mangledName} {
+                private static class \{mangledName} {
                     public static final \{layoutType} LAYOUT = \{layoutString(varType)};
                     public static final MemorySegment SEGMENT = \{runtimeHelperName()}.findOrThrow("\{var.name()}").reinterpret(LAYOUT.byteSize());
                     \{accessHandle}
@@ -476,7 +476,7 @@ class HeaderFileBuilder extends ClassSourceBuilder {
                 """);
         } else {
             appendIndentedLines(STR."""
-                public static class \{mangledName} {
+                private static class \{mangledName} {
                     public static final \{layoutType} LAYOUT = \{layoutString(varType)};
                     public static final MemorySegment SEGMENT = \{runtimeHelperName()}.findOrThrow("\{var.name()}").reinterpret(LAYOUT.byteSize());
                 }

--- a/test/jtreg/generator/testPrintf/TestPrintf.java
+++ b/test/jtreg/generator/testPrintf/TestPrintf.java
@@ -28,6 +28,7 @@ import org.testng.annotations.Test;
 
 import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
 
 import static org.testng.Assert.assertEquals;
 import static test.jextract.printf.printf_h.*;
@@ -63,7 +64,7 @@ public class TestPrintf {
         }
     }
 
-    @Test(dataProvider = "wrongArgsCases", expectedExceptions = IllegalArgumentException.class)
+    @Test(dataProvider = "wrongArgsCases", expectedExceptions = { IllegalArgumentException.class, ClassCastException.class })
     public void testsPrintfInvokerWrongArgs(String fmt, MemoryLayout[] layouts, Object[] args) {
         try (Arena arena = Arena.ofConfined()) {
             MemorySegment s = arena.allocate(1024);
@@ -95,11 +96,9 @@ public class TestPrintf {
     @DataProvider
     public Object[][] wrongArgsCases() {
         return new Object[][] {
-            {
-                "%d", new MemoryLayout[] {C_INT}, new Object[0], // too few args
-                "%d", new MemoryLayout[] {C_INT}, new Object[] { 1, 2 }, // too many args
-                "%.2f", new MemoryLayout[] {C_DOUBLE}, new Object[] { 1 }, // wrong type
-            }
+            { "%d", new MemoryLayout[] {C_INT}, new Object[0], /* too few args */ },
+            { "%d", new MemoryLayout[] {C_INT}, new Object[] { 1, 2 }, /* too many args */ },
+            { "%.2f", new MemoryLayout[] {C_POINTER}, new Object[] { 1 }, /* wrong type */ },
         };
     }
 

--- a/test/testng/org/openjdk/jextract/test/toolprovider/variadicNames/TestMangledVariadicNames.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/variadicNames/TestMangledVariadicNames.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.jextract.test.toolprovider.variadicNames;
+
+import java.nio.file.Path;
+
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import testlib.JextractToolRunner;
+
+import static org.testng.Assert.*;
+
+public class TestMangledVariadicNames extends JextractToolRunner {
+
+    Loader loader;
+
+    @BeforeClass
+    public void before() {
+        Path output = getOutputFilePath("TestMangledVariadicNames-variadic_names.h");
+        Path input = getInputFilePath("variadic_names.h");
+        runAndCompile(output, input.toString());
+        loader = classLoader(output);
+    }
+
+    @Test
+    public void testMangledVariadicNames() {
+        Class<?> headerClass = loader.loadClass("variadic_names_h");
+        assertNotNull(headerClass);
+        assertNotNull(findNestedClass(headerClass, "f"));
+        assertNotNull(findNestedClass(headerClass, "F$"));
+    }
+}

--- a/test/testng/org/openjdk/jextract/test/toolprovider/variadicNames/variadic_names.h
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/variadicNames/variadic_names.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+void f(int n, ...);
+void F(int n, ...);


### PR DESCRIPTION
This PR fixes an issue with the variadic invoker nested class names that are not mangled correctly. This might create issues for case-insensitive file systems.

While working on this, I noticed also that the current test we have for variadic classes (TestPrintf) was not executing as expected, because of a typo in a data provider. After fixing the test code, the test started to fail.

One of the test cases was expecting an `IllegalArgumentException` when passing an int value to a double variadic parameter. But, as we use a method handle argument spreader, no exception is throw, and the value is instead silently converted. I tweaked the test a bit, to create a situation where no conversion is possible, and I noticed that the call failed with `ClassCastException`, but that exception is not handled by the variadic invoker code, so I fixed that as well.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Issue
 * [CODETOOLS-7903656](https://bugs.openjdk.org/browse/CODETOOLS-7903656): Variadic invoker class names are not mangled (**Bug** - P3)


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - Committer) ⚠️ Review applies to [5080d83c](https://git.openjdk.org/jextract/pull/203/files/5080d83caaa50b9ba8ed9ee1f81351084c7d1d69)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/203/head:pull/203` \
`$ git checkout pull/203`

Update a local copy of the PR: \
`$ git checkout pull/203` \
`$ git pull https://git.openjdk.org/jextract.git pull/203/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 203`

View PR using the GUI difftool: \
`$ git pr show -t 203`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/203.diff">https://git.openjdk.org/jextract/pull/203.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/203#issuecomment-1935548576)