### PR TITLE
Add missing inputs to tasks in gradle build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,7 @@ jar {
     archiveVersion = project.version
 }
 
-task copyLibClang(type: Copy) {
+task copyLibClang(type: Sync) {
     into("$buildDir/jmod_inputs")
 
     from("${libclang_dir}") {
@@ -84,6 +84,8 @@ task createJextractJmod(type: Exec) {
     dependsOn jar, copyLibClang
 
     // if these inputs or outputs change, gradle will rerun the task
+    inputs.file(jar.archiveFile.get())
+    inputs.dir("$jextract_jmod_inputs")
     outputs.file(jextract_jmod_file)
 
     doFirst {
@@ -105,6 +107,7 @@ task createJextractImage(type: Exec) {
     dependsOn createJextractJmod
 
     // if these inputs or outputs change, gradle will rerun the task
+    inputs.file("$jextract_jmod_file")
     outputs.dir(jextract_app_dir)
 
     def quote_jlink_opts = Os.isFamily(Os.FAMILY_WINDOWS)?
@@ -145,6 +148,7 @@ task createRuntimeImageForTest(type: Exec) {
     def out_dir = "$buildDir/jextract-jdk-test-image"
 
     // if these inputs or outputs change, gradle will rerun the task
+    inputs.file("$jextract_jmod_file")
     outputs.dir(out_dir)
 
     doFirst {

--- a/build.gradle
+++ b/build.gradle
@@ -71,6 +71,7 @@ task copyLibClang(type: Sync) {
     from("${libclang_dir}") {
         include("*clang.*")
         include("libLLVM.*")
+        exclude("clang.exe")
         into("libs")
     }
 


### PR DESCRIPTION
I recently re-did some of the task dependencies of the gradle build: https://github.com/openjdk/jextract/pull/200

From my initial testing for that PR, and reading online, I was under the impression that tasks would re-run when the outputs of a dependency changes. After additional use & testing, this turns out to be not the case and we need to explicitly set task inputs any way. This PR does that. 

I also changed the `copyLibClang` task from `Copy` to `Sync`. If a file is removed from the source directory, `Copy` will not remove it from the output, but `Sync` will. This helps ensure that we don't package any stale files into the jextract jmod (which might create include conflicts). This is also something I noticed during more thorough testing.

Finally, I noticed that on Windows we were copying `clang.exe` to the jextract jmod archive, since we copy from the `bin` dir on Windows, which contains both the `libclang.dll` and the `clang.exe` file. I've added an exclude for `clang.exe`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/204/head:pull/204` \
`$ git checkout pull/204`

Update a local copy of the PR: \
`$ git checkout pull/204` \
`$ git pull https://git.openjdk.org/jextract.git pull/204/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 204`

View PR using the GUI difftool: \
`$ git pr show -t 204`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/204.diff">https://git.openjdk.org/jextract/pull/204.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/204#issuecomment-1936092781)