### PR TITLE
7903660: Drop layout-inferring varargs invoker + add method handle factory

### DIFF
--- a/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
@@ -218,14 +218,14 @@ class HeaderFileBuilder extends ClassSourceBuilder {
                     }
 
                     /**
-                     * {@return specialized method handle}
+                     * {@return the specialized method handle}
                      */
                     public MethodHandle handle() {
                         return handle;
                     }
 
                     /**
-                     * {@return specialized descriptor}
+                     * {@return the specialized descriptor}
                      */
                     public FunctionDescriptor descriptor() {
                         return descriptor;

--- a/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
@@ -208,14 +208,21 @@ class HeaderFileBuilder extends ClassSourceBuilder {
                         this.descriptor = descriptor;
                         this.spreader = spreader;
                     }
-
-                    static \{invokerClassName} specialize(MemoryLayout... layouts) {
-                        FunctionDescriptor desc$ = BASE_DESC.appendArgumentLayouts(layouts);
-                        Linker.Option fva$ = Linker.Option.firstVariadicArg(BASE_DESC.argumentLayouts().size());
-                        var mh$ = Linker.nativeLinker().downcallHandle(ADDR, desc$, fva$);
-                        var spreader$ = mh$.asSpreader(Object[].class, layouts.length);
-                        return new \{invokerClassName}(mh$, desc$, spreader$);
-                    }
+                """);
+            incrAlign();
+            appendBlankLine();
+            emitDocComment(decl, "Variadic invoker factory for:");
+            appendLines(STR."""
+                public static \{invokerClassName} makeInvoker(MemoryLayout... layouts) {
+                    FunctionDescriptor desc$ = BASE_DESC.appendArgumentLayouts(layouts);
+                    Linker.Option fva$ = Linker.Option.firstVariadicArg(BASE_DESC.argumentLayouts().size());
+                    var mh$ = Linker.nativeLinker().downcallHandle(ADDR, desc$, fva$);
+                    var spreader$ = mh$.asSpreader(Object[].class, layouts.length);
+                    return new \{invokerClassName}(mh$, desc$, spreader$);
+                }
+                """);
+            decrAlign();
+            appendLines(STR."""
 
                     /**
                      * {@return the specialized method handle}
@@ -244,14 +251,6 @@ class HeaderFileBuilder extends ClassSourceBuilder {
                         }
                     }
                 }
-
-                """);
-            emitDocComment(decl, "Variadic invoker factory for:");
-            appendLines(STR."""
-                public static \{invokerClassName} \{javaName}(MemoryLayout... layouts) {
-                    return \{invokerClassName}.specialize(layouts);
-                }
-
                 """);
         }
         decrAlign();

--- a/test/jtreg/generator/testPrintf/TestPrintf.java
+++ b/test/jtreg/generator/testPrintf/TestPrintf.java
@@ -46,7 +46,7 @@ public class TestPrintf {
 
     @Test
     public void testBaseDescriptor() {
-        my_sprintf invoker = my_sprintf();
+        my_sprintf invoker = my_sprintf.makeInvoker();
         assertEquals(invoker.descriptor(), FunctionDescriptor.of(C_INT, C_POINTER, C_POINTER, C_INT));
     }
 
@@ -54,7 +54,7 @@ public class TestPrintf {
     public void testsPrintfHandle(String fmt, Object[] args, String expected, MemoryLayout[] layouts) throws Throwable {
         try (Arena arena = Arena.ofConfined()) {
             MemorySegment s = arena.allocate(1024);
-            MethodHandle handle = my_sprintf(layouts).handle();
+            MethodHandle handle = my_sprintf.makeInvoker(layouts).handle();
             Object[] fullArgs = new Object[args.length + 3];
             fullArgs[0] = s;
             fullArgs[1] = arena.allocateFrom(fmt);
@@ -70,7 +70,7 @@ public class TestPrintf {
     public void testsPrintfInvoker(String fmt, Object[] args, String expected, MemoryLayout[] layouts) {
         try (Arena arena = Arena.ofConfined()) {
             MemorySegment s = arena.allocate(1024);
-            my_sprintf(layouts)
+            my_sprintf.makeInvoker(layouts)
                     .apply(s, arena.allocateFrom(fmt), args.length, args);
             String str = s.getString(0);
             assertEquals(str, expected);
@@ -81,7 +81,7 @@ public class TestPrintf {
     public void testsPrintfInvokerWrongArgs(String fmt, MemoryLayout[] layouts, Object[] args) {
         try (Arena arena = Arena.ofConfined()) {
             MemorySegment s = arena.allocate(1024);
-            my_sprintf(layouts)
+            my_sprintf.makeInvoker(layouts)
                     .apply(s, arena.allocateFrom(fmt), args.length, args); // should throw
         }
     }
@@ -89,7 +89,7 @@ public class TestPrintf {
     // linker does not except unpromoted layouts
     @Test(dataProvider = "illegalLinkCases", expectedExceptions = IllegalArgumentException.class)
     public void testsPrintfInvokerWrongArgs(MemoryLayout[] layouts) {
-        my_sprintf(layouts); // should throw
+        my_sprintf.makeInvoker(layouts); // should throw
     }
 
     // data providers:

--- a/test/jtreg/generator/testPrintf/TestPrintf.java
+++ b/test/jtreg/generator/testPrintf/TestPrintf.java
@@ -46,15 +46,15 @@ public class TestPrintf {
 
     @Test
     public void testBaseDescriptor() {
-        FunctionDescriptor baseDesc = my_sprintf.descriptor();
-        assertEquals(baseDesc, FunctionDescriptor.of(C_INT, C_POINTER, C_POINTER, C_INT));
+        my_sprintf invoker = my_sprintf();
+        assertEquals(invoker.descriptor(), FunctionDescriptor.of(C_INT, C_POINTER, C_POINTER, C_INT));
     }
 
     @Test(dataProvider = "cases")
     public void testsPrintfHandle(String fmt, Object[] args, String expected, MemoryLayout[] layouts) throws Throwable {
         try (Arena arena = Arena.ofConfined()) {
             MemorySegment s = arena.allocate(1024);
-            MethodHandle handle = my_sprintf.handle(layouts);
+            MethodHandle handle = my_sprintf(layouts).handle();
             Object[] fullArgs = new Object[args.length + 3];
             fullArgs[0] = s;
             fullArgs[1] = arena.allocateFrom(fmt);

--- a/test/testng/org/openjdk/jextract/test/toolprovider/JextractToolProviderTest.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/JextractToolProviderTest.java
@@ -125,8 +125,13 @@ public class JextractToolProviderTest extends JextractToolRunner {
         // check an interface for printf$invoker
         Class<?> invokerCls = findNestedClass(header, "printf");
         assertNotNull(invokerCls);
-        // check a method for "int printf(MemorySegment, Object[])"
-        assertNotNull(findMethod(invokerCls, "invoke", MemorySegment.class, Object[].class));
+        // check for base desc and address fields
+        assertNotNull(findField(invokerCls, "BASE_DESC"));
+        assertNotNull(findField(invokerCls, "ADDR"));
+        // check a method for "MethodHandle handle(MemoryLayout...)"
+        assertNotNull(findMethod(invokerCls, "handle", MemoryLayout[].class));
+        // check a method for "FunctionDescriptor descriptor(MemoryLayout...)"
+        assertNotNull(findMethod(invokerCls, "descriptor", MemoryLayout[].class));
     }
 
     @Test

--- a/test/testng/org/openjdk/jextract/test/toolprovider/JextractToolProviderTest.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/JextractToolProviderTest.java
@@ -120,8 +120,6 @@ public class JextractToolProviderTest extends JextractToolRunner {
     private static void checkHeaderMembers(Class<?> header) {
         // check a method for "void func(int)"
         assertNotNull(findMethod(header, "func", int.class));
-        // check a method for "printf(MemoryLayout...)"
-        assertNotNull(findMethod(header, "printf", MemoryLayout[].class));
         // check an interface for printf$invoker
         Class<?> invokerCls = findNestedClass(header, "printf");
         assertNotNull(invokerCls);
@@ -129,6 +127,8 @@ public class JextractToolProviderTest extends JextractToolRunner {
         assertNotNull(findMethod(invokerCls, "handle"));
         // check a method for "FunctionDescriptor descriptor()"
         assertNotNull(findMethod(invokerCls, "descriptor"));
+        // check a method for "<invokerCls> invoker(MemoryLayout...)"
+        assertNotNull(findMethod(invokerCls, "makeInvoker", MemoryLayout[].class));
     }
 
     @Test

--- a/test/testng/org/openjdk/jextract/test/toolprovider/JextractToolProviderTest.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/JextractToolProviderTest.java
@@ -125,13 +125,10 @@ public class JextractToolProviderTest extends JextractToolRunner {
         // check an interface for printf$invoker
         Class<?> invokerCls = findNestedClass(header, "printf");
         assertNotNull(invokerCls);
-        // check for base desc and address fields
-        assertNotNull(findField(invokerCls, "BASE_DESC"));
-        assertNotNull(findField(invokerCls, "ADDR"));
-        // check a method for "MethodHandle handle(MemoryLayout...)"
-        assertNotNull(findMethod(invokerCls, "handle", MemoryLayout[].class));
-        // check a method for "FunctionDescriptor descriptor(MemoryLayout...)"
-        assertNotNull(findMethod(invokerCls, "descriptor", MemoryLayout[].class));
+        // check a method for "MethodHandle handle()"
+        assertNotNull(findMethod(invokerCls, "handle"));
+        // check a method for "FunctionDescriptor descriptor()"
+        assertNotNull(findMethod(invokerCls, "descriptor"));
     }
 
     @Test


### PR DESCRIPTION
This PR removes the layout-inferring variadic invokers that we generate. Instead, users will have to create an instance of the invoker interface first, by specifying the layouts of the variadic args explicitly. This leads to a more WYSIWYG approach, where we don't have to guess what the correct variadic layouts are.

Additionally, a `handle` and `descriptor` factory are added to the invoker interface, which can be used to create specialized method handles and function descriptors for the variadic function. The base descriptor and function address are also exposed as fields. 

Open questions:
1. Should we try and hide these fields (with another private nested class)? And if not, should we expose the function address for regular functions as well?
2. Some layouts are illegal as variadic layouts (e.g. C_FLOAT). The `descriptor` factory currently doesn't reject these. Are we happy with that? On the other hand. Making this factory reject those layouts would be quite some work, and would need to be kept in sync with the linker implementation. This didn't seem worth it, so I've left this.

Finally, I've removed the now unused runtime helper code related to inferring variadic layouts.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Issue
 * [CODETOOLS-7903660](https://bugs.openjdk.org/browse/CODETOOLS-7903660): Drop layout-inferring varargs invoker + add method handle factory (**Bug** - P4)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/205/head:pull/205` \
`$ git checkout pull/205`

Update a local copy of the PR: \
`$ git checkout pull/205` \
`$ git pull https://git.openjdk.org/jextract.git pull/205/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 205`

View PR using the GUI difftool: \
`$ git pr show -t 205`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/205.diff">https://git.openjdk.org/jextract/pull/205.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/205#issuecomment-1938669847)