### PR TITLE
7903662: Javadoc generated by jextract breaks javac compilation

### DIFF
--- a/src/main/java/org/openjdk/jextract/impl/TreeMaker.java
+++ b/src/main/java/org/openjdk/jextract/impl/TreeMaker.java
@@ -503,7 +503,7 @@ class TreeMaker {
             default -> {
                 // heuristic, try w/o expanding first, and check if there are <anonymous> strings
                 String cursorString = declarationString(cursor, false);
-                if (cursorString.matches(".*\\(unnamed (struct|union|enum) at.*")) {
+                if (cursorString.matches(".*\\((unnamed|anonymous) (struct|union|enum) at.*")) {
                     // the output contains anonymous definitions, fallback and expand them
                     cursorString = declarationString(cursor, true);
                 }


### PR DESCRIPTION
We have recently switched to generate the source-like description of C API elements using the clang API, which allows for better fidelity with the original C code. While this works generally well, libclang has some strange behavior around anonymous structs, where some of them (not all!) are reported together with the path in which the declaration occurs.

Since adding paths to the javadoc is generally a bad idea, which can lead to all sorts of troubles, jextract implements a basic filtering logic, which uses a regex to detect the overly verbose description strings. It turns out that, while the regex works well for libclang 13 and later, earlier versions have issues, as instead of using the term "unnamed struct" libclang uses "anonymous struct".

Anyway, the fix is to tweak the regex we use to detect bogus descriptions to include "anonymous". This should make jextract a bit more robust w.r.t. changes across different libclang versions (and, I hope that this gets fixed upstream so that we don't have to apply such nasty workarounds).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Issue
 * [CODETOOLS-7903662](https://bugs.openjdk.org/browse/CODETOOLS-7903662): Javadoc generated by jextract breaks javac compilation (**Bug** - P3)


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/209/head:pull/209` \
`$ git checkout pull/209`

Update a local copy of the PR: \
`$ git checkout pull/209` \
`$ git pull https://git.openjdk.org/jextract.git pull/209/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 209`

View PR using the GUI difftool: \
`$ git pr show -t 209`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/209.diff">https://git.openjdk.org/jextract/pull/209.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/209#issuecomment-1944801473)