### PR TITLE
7903665: Function pointer code generation issues

### DIFF
--- a/src/main/java/org/openjdk/jextract/impl/FunctionalInterfaceBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/FunctionalInterfaceBuilder.java
@@ -41,20 +41,21 @@ final class FunctionalInterfaceBuilder extends ClassSourceBuilder {
     private final Optional<List<String>> parameterNames;
 
     private FunctionalInterfaceBuilder(SourceFileBuilder builder, String className, ClassSourceBuilder enclosing,
-                                       String runtimeHelperName, Type.Function funcType) {
-        super(builder, "public", Kind.CLASS, className, null, enclosing, runtimeHelperName);
+                                       String runtimeHelperName, Type.Function funcType, boolean isNested) {
+        super(builder, isNested ? "public static" : "public", Kind.CLASS, className, null, enclosing, runtimeHelperName);
         this.parameterNames = funcType.parameterNames().map(NameMangler::javaSafeIdentifiers);
         this.funcType = funcType;
         this.methodType = Utils.methodTypeFor(funcType);
     }
 
     public static void generate(SourceFileBuilder builder, String className, ClassSourceBuilder enclosing, String runtimeHelperName,
-                                Declaration parentDecl, Type.Function funcType) {
+                                Declaration parentDecl, Type.Function funcType, boolean isNested) {
         FunctionalInterfaceBuilder fib = new FunctionalInterfaceBuilder(builder, className,
-                enclosing, runtimeHelperName, funcType);
+                enclosing, runtimeHelperName, funcType, isNested);
         fib.appendBlankLine();
         fib.emitDocComment(parentDecl);
         fib.classBegin();
+        fib.emitDefaultConstructor();
         fib.emitFunctionalInterface();
         fib.emitDescriptorDecl();
         fib.emitFunctionalFactory();

--- a/src/main/java/org/openjdk/jextract/impl/StructBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/StructBuilder.java
@@ -126,7 +126,7 @@ final class StructBuilder extends ClassSourceBuilder implements OutputFactory.Bu
     public void addFunctionalInterface(Declaration parentDecl, Type.Function funcType) {
         incrAlign();
         FunctionalInterfaceBuilder.generate(sourceFileBuilder(), JavaFunctionalInterfaceName.getOrThrow(parentDecl),
-                this, runtimeHelperName(), parentDecl, funcType);
+                this, runtimeHelperName(), parentDecl, funcType, true);
         decrAlign();
     }
 

--- a/src/main/java/org/openjdk/jextract/impl/ToplevelBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/ToplevelBuilder.java
@@ -165,7 +165,7 @@ class ToplevelBuilder implements OutputFactory.Builder {
     public void addFunctionalInterface(Declaration parentDecl, Type.Function funcType) {
         SourceFileBuilder sfb = SourceFileBuilder.newSourceFile(packageName(), JavaFunctionalInterfaceName.getOrThrow(parentDecl));
         otherBuilders.add(sfb);
-        FunctionalInterfaceBuilder.generate(sfb, sfb.className(), null, mainHeaderClassName(), parentDecl, funcType);
+        FunctionalInterfaceBuilder.generate(sfb, sfb.className(), null, mainHeaderClassName(), parentDecl, funcType, false);
     }
 
     private HeaderFileBuilder nextHeader() {

--- a/test/testng/org/openjdk/jextract/test/toolprovider/nestedDecls/TestNestedDecls.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/nestedDecls/TestNestedDecls.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/testng/org/openjdk/jextract/test/toolprovider/nestedDecls/TestNestedDecls.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/nestedDecls/TestNestedDecls.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.jextract.test.toolprovider.nestedDecls;
+
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import testlib.JextractToolRunner;
+
+import java.lang.foreign.MemoryLayout;
+import java.lang.foreign.StructLayout;
+import java.lang.foreign.UnionLayout;
+import java.lang.reflect.Modifier;
+import java.nio.file.Path;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+public class TestNestedDecls extends JextractToolRunner {
+
+    Loader loader;
+
+    @BeforeClass
+    public void beforeClass() {
+        Path output = getOutputFilePath("TestNestedDecls-nestedDecls.h");
+        Path outputH = getInputFilePath("nested_decls.h");
+        runAndCompile(output, outputH.toString());
+
+        loader = classLoader(output);
+    }
+
+    @AfterClass
+    public void afterClass() {
+        loader.close();
+    }
+
+    @Test
+    public void testNestedDeclarations() {
+        Class<?> outerClass = loader.loadClass("Outer");
+        assertNotNull(outerClass);
+        Class<?> fpClass = findNestedClass(outerClass, "F");
+        checkStatic(fpClass);
+        Class<?> innerClass = findNestedClass(outerClass, "Inner");
+        assertNotNull(innerClass);
+        checkStatic(innerClass);
+    }
+
+    private void checkStatic(Class<?> cls) {
+        assertEquals(cls.getModifiers() & Modifier.STATIC, Modifier.STATIC);
+    }
+}

--- a/test/testng/org/openjdk/jextract/test/toolprovider/nestedDecls/nested_decls.h
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/nestedDecls/nested_decls.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+struct Outer {
+    void (*F)(int a, int b);
+    struct Inner {
+        int x;
+    } inner;
+};


### PR DESCRIPTION
This PR fixes two minor issues with function pointer generation:
* static is missing from some nested classes (function pointers)
* function pointers also miss a default constructor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Issue
 * [CODETOOLS-7903665](https://bugs.openjdk.org/browse/CODETOOLS-7903665): Function pointer code generation issues (**Bug** - P3)


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - Committer) ⚠️ Review applies to [4721eee2](https://git.openjdk.org/jextract/pull/212/files/4721eee28cc0aa1dabe9cb3fd120c5f513437c1a)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/212/head:pull/212` \
`$ git checkout pull/212`

Update a local copy of the PR: \
`$ git checkout pull/212` \
`$ git pull https://git.openjdk.org/jextract.git pull/212/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 212`

View PR using the GUI difftool: \
`$ git pr show -t 212`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/212.diff">https://git.openjdk.org/jextract/pull/212.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/212#issuecomment-1946437071)