### PR TITLE
7903662: Javadoc generated by jextract breaks javac compilation

### DIFF
--- a/src/main/java/org/openjdk/jextract/impl/TreeMaker.java
+++ b/src/main/java/org/openjdk/jextract/impl/TreeMaker.java
@@ -503,7 +503,7 @@ class TreeMaker {
             default -> {
                 // heuristic, try w/o expanding first, and check if there are <anonymous> strings
                 String cursorString = declarationString(cursor, false);
-                if (cursorString.matches(".*\\(unnamed (struct|union|enum) at.*")) {
+                if (cursorString.matches(".*\\((unnamed|anonymous) (struct|union|enum) at.*")) {
                     // the output contains anonymous definitions, fallback and expand them
                     cursorString = declarationString(cursor, true);
                 }


### PR DESCRIPTION
This is a backport of https://github.com/openjdk/jextract/pull/209 into the "master" branch.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Issue
 * [CODETOOLS-7903662](https://bugs.openjdk.org/browse/CODETOOLS-7903662): Javadoc generated by jextract breaks javac compilation (**Bug** - P3) ⚠️ Issue is already resolved. Consider making this a "backport pull request" by setting the PR title to `Backport <hash>` with the hash of the original commit. See [Backports](https://wiki.openjdk.org/display/SKARA/Backports).


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/213/head:pull/213` \
`$ git checkout pull/213`

Update a local copy of the PR: \
`$ git checkout pull/213` \
`$ git pull https://git.openjdk.org/jextract.git pull/213/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 213`

View PR using the GUI difftool: \
`$ git pr show -t 213`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/213.diff">https://git.openjdk.org/jextract/pull/213.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/213#issuecomment-1946624320)