### PR TITLE
7903666: Jextract should report issues with missing dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,30 @@ jextract -t org.jextract @includes.txt point.h
 
 It is easy to see how this mechanism allows developers to look into the set of symbols seen by `jextract` while parsing, and then process the generated include file, so as to prevent code generation for otherwise unused symbols.
 
+Users should exercise caution when filtering symbols, as it is relatively easy to filter out a declaration that is depended on by one or more declarations:
+
+```c
+// test.h
+struct A {
+   int x;
+}
+struct A aVar;
+```
+
+Here, we could run `jextract` and filter out `A`, like so:
+
+```
+jextract --include-var aVar test.h
+```
+
+However, doing so would lead to broken generated code, as the layout of the global variable `aVar` depends on the layout of the excluded struct `A`.
+
+In such cases, `jextract` will report the missing dependency and terminate without generating any bindings:
+
+```
+ERROR: aVar depends on A which has been excluded
+```
+
 #### Tracing support
 
 It is sometimes useful to inspect the parameters passed to a native call, especially when diagnosing application

--- a/src/main/java/org/openjdk/jextract/JextractTool.java
+++ b/src/main/java/org/openjdk/jextract/JextractTool.java
@@ -31,6 +31,7 @@ import org.openjdk.jextract.impl.CommandLine;
 import org.openjdk.jextract.impl.DuplicateFilter;
 import org.openjdk.jextract.impl.IncludeFilter;
 import org.openjdk.jextract.impl.IncludeHelper;
+import org.openjdk.jextract.impl.Logger;
 import org.openjdk.jextract.impl.NameMangler;
 import org.openjdk.jextract.impl.Options.Library;
 import org.openjdk.jextract.impl.OutputFactory;
@@ -65,15 +66,8 @@ import java.util.stream.Stream;
  * on top of the underlying memory access var handles. For each struct, a static layout field is generated.
  */
 public final class JextractTool {
-    private static final String MESSAGES_RESOURCE = "org.openjdk.jextract.impl.resources.Messages";
-
-    private static final ResourceBundle MESSAGES_BUNDLE;
-    static {
-        MESSAGES_BUNDLE = ResourceBundle.getBundle(MESSAGES_RESOURCE, Locale.getDefault());
-    }
 
     public static final boolean DEBUG = Boolean.getBoolean("jextract.debug");
-    public static final Optional<Path> PLATFORM_INCLUDE_PATH = inferPlatformIncludePath();
 
     // error codes
     private static final int SUCCESS       = 0;
@@ -83,16 +77,10 @@ public final class JextractTool {
     private static final int RUNTIME_ERROR = 4;
     private static final int OUTPUT_ERROR  = 5;
 
-    private final PrintWriter out;
-    private final PrintWriter err;
-
-    private static String format(String msgId, Object... args) {
-        return new MessageFormat(MESSAGES_BUNDLE.getString(msgId)).format(args);
-    }
+    private final Logger logger;
 
     private JextractTool(PrintWriter out, PrintWriter err) {
-        this.out = out;
-        this.err = err;
+        this.logger = new Logger(out, err);
     }
 
     private static Path generateTmpSource(List<Path> headers) {
@@ -121,28 +109,24 @@ public final class JextractTool {
 
     public static List<JavaSourceFile> generate(Declaration.Scoped decl, String headerName,
                                                 String targetPkg, List<Options.Library> libs,
-                                                boolean useSystemLoadLibrary, PrintWriter errStream) {
-        return List.of(generate(decl, headerName, targetPkg, new IncludeHelper(), libs, useSystemLoadLibrary, errStream));
+                                                boolean useSystemLoadLibrary, PrintWriter outStream, PrintWriter errStream) {
+        return generateInternal(decl, headerName, targetPkg, new IncludeHelper(),
+                libs, useSystemLoadLibrary, new Logger(outStream, errStream));
     }
 
     private static List<JavaSourceFile> generateInternal(Declaration.Scoped decl, String headerName,
                                                          String targetPkg, IncludeHelper includeHelper,
                                                          List<Options.Library> libs, boolean useSystemLoadLibrary,
-                                                         PrintWriter errStream) {
-        return List.of(generate(decl, headerName, targetPkg, includeHelper, libs, useSystemLoadLibrary, errStream));
-    }
-
-    private static JavaSourceFile[] generate(Declaration.Scoped decl, String headerName,
-                                             String targetPkg, IncludeHelper includeHelper,
-                                             List<Options.Library> libs, boolean useSystemLoadLibrary,
-                                             PrintWriter errStream) {
+                                                         Logger logger) {
         var transformedDecl = Stream.of(decl)
-                .map(new IncludeFilter(includeHelper)::scan)
+                .map(new IncludeFilter(includeHelper, logger)::scan)
                 .map(new DuplicateFilter()::scan)
                 .map(new NameMangler(headerName)::scan)
-                .map(new UnsupportedFilter(errStream)::scan)
+                .map(new UnsupportedFilter(logger)::scan)
                 .findFirst().get();
-        return OutputFactory.generateWrapped(transformedDecl, targetPkg, libs, useSystemLoadLibrary);
+        return logger.hasErrors() ?
+                List.of() :
+                List.of(OutputFactory.generateWrapped(transformedDecl, targetPkg, libs, useSystemLoadLibrary));
     }
 
     /**
@@ -185,22 +169,12 @@ public final class JextractTool {
     }
 
     private int printHelp(int exitCode) {
-        err.println(format("jextract.usage"));
+        logger.info("jextract.usage");
         return exitCode;
     }
 
-
-    private void printOptionError(Throwable throwable) {
-        printOptionError(throwable.getMessage());
-        if (DEBUG) {
-            throwable.printStackTrace(err);
-        }
-    }
-
     private void printOptionError(String message) {
-        err.println("OPTION ERROR: " + message);
-        err.println("Usage: jextract <options> <header file>");
-        err.println("Use --help for a list of possible options");
+        logger.err("jextract.opt.error", message);
     }
 
     /**
@@ -214,7 +188,9 @@ public final class JextractTool {
             return;
         }
 
-        JextractTool m = new JextractTool(new PrintWriter(System.out, true), new PrintWriter(System.err, true));
+        JextractTool m = new JextractTool(
+                new PrintWriter(System.out, true),
+                new PrintWriter(System.err, true));
         System.exit(m.run(args));
     }
 
@@ -369,41 +345,39 @@ public final class JextractTool {
         try {
             args = CommandLine.parse(Arrays.asList(args)).toArray(new String[0]);
         } catch (IOException ioexp) {
-            err.println(format("argfile.read.error", ioexp));
-            if (JextractTool.DEBUG) {
-                ioexp.printStackTrace(err);
-            }
+            logger.fatal(ioexp, "argfile.read.error", ioexp);
             return OPTION_ERROR;
         }
 
         OptionParser parser = new OptionParser();
-        parser.accepts("-D", List.of("--define-macro"), format("help.D"), true);
-        parser.accepts("--dump-includes", format("help.dump-includes"), true);
+        parser.accepts("-D", List.of("--define-macro"), "help.D", true);
+        parser.accepts("--dump-includes", "help.dump-includes", true);
         for (IncludeHelper.IncludeKind includeKind : IncludeHelper.IncludeKind.values()) {
-            parser.accepts("--" + includeKind.optionName(), format("help." + includeKind.optionName()), true);
+            parser.accepts("--" + includeKind.optionName(), "help." + includeKind.optionName(), true);
         }
-        parser.accepts("-h", List.of("-?", "--help"), format("help.h"), false);
-        parser.accepts("--header-class-name", format("help.header-class-name"), true);
-        parser.accepts("-I", List.of("--include-dir"), format("help.I"), true);
-        parser.accepts("-l", List.of("--library"), format("help.l"), true);
-        parser.accepts("--use-system-load-library", format("help.use.system.load.library"), false);
-        parser.accepts("--output", format("help.output"), true);
-        parser.accepts("-t", List.of("--target-package"), format("help.t"), true);
-        parser.accepts("--version", format("help.version"), false);
+        parser.accepts("-h", List.of("-?", "--help"), "help.h", false);
+        parser.accepts("--header-class-name", "help.header-class-name", true);
+        parser.accepts("-I", List.of("--include-dir"), "help.I", true);
+        parser.accepts("-l", List.of("--library"), "help.l", true);
+        parser.accepts("--use-system-load-library", "help.use.system.load.library", false);
+        parser.accepts("--output", "help.output", true);
+        parser.accepts("-t", List.of("--target-package"), "help.t", true);
+        parser.accepts("--version", "help.version", false);
 
         OptionSet optionSet;
         try {
             optionSet = parser.parse(args);
         } catch (OptionException oe) {
-            printOptionError(oe);
+            printOptionError(oe.getMessage());
             return OPTION_ERROR;
         }
 
         if (optionSet.has("--version")) {
             var version = JextractTool.class.getModule().getDescriptor().version();
-            err.printf("%s %s\n", "jextract", version.get());
-            err.printf("%s %s\n", "JDK version", System.getProperty("java.runtime.version"));
-            err.printf("%s\n", LibClang.version());
+            logger.info("jextract.version",
+                    version.get(),
+                    System.getProperty("java.runtime.version"),
+                    LibClang.version());
             return SUCCESS;
         }
 
@@ -423,10 +397,7 @@ public final class JextractTool {
             try {
                 Files.lines(compileFlagsTxt).forEach(opt -> builder.addClangArg(opt));
             } catch (IOException ioExp) {
-                err.println("compile_flags.txt reading failed " + ioExp);
-                if (JextractTool.DEBUG) {
-                    ioExp.printStackTrace(err);
-                }
+                logger.fatal(ioExp, "jextract.bad.compile.flags", ioExp.getMessage());
                 return OPTION_ERROR;
             }
         }
@@ -444,7 +415,7 @@ public final class JextractTool {
             builder.addClangArg("-I" + builtinInc);
         }
 
-        PLATFORM_INCLUDE_PATH.ifPresent(platformPath -> {
+        inferPlatformIncludePath().ifPresent(platformPath -> {
             builder.addClangArg("-I" + platformPath);
         });
 
@@ -487,10 +458,10 @@ public final class JextractTool {
                         builder.addLibrary(library);
                     } else {
                         // not an absolute path, but--use-system-load-library was specified
-                        err.println(format("l.option.value.absolute.path", lib));
+                        logger.err("l.option.value.absolute.path", lib);
                     }
                 } catch (IllegalArgumentException ex) {
-                    err.println(format("l.option.value.invalid", lib));
+                    logger.err("l.option.value.invalid", lib);
                     return OPTION_ERROR;
                 }
             }
@@ -503,11 +474,11 @@ public final class JextractTool {
 
         Path header = Paths.get(optionSet.nonOptionArguments().get(0));
         if (!Files.isReadable(header)) {
-            err.println(format("cannot.read.header.file", header));
+            logger.err("cannot.read.header.file", header);
             return INPUT_ERROR;
         }
         if (!(Files.isRegularFile(header))) {
-            err.println(format("not.a.file", header));
+            logger.err("not.a.file", header);
             return INPUT_ERROR;
         }
 
@@ -525,18 +496,15 @@ public final class JextractTool {
 
             files = generateInternal(
                 toplevel, headerName,
-                options.targetPackage, options.includeHelper, options.libraries, options.useSystemLoadLibrary, err);
+                options.targetPackage, options.includeHelper, options.libraries, options.useSystemLoadLibrary, logger);
         } catch (ClangException ce) {
-            err.println(ce.getMessage());
+            logger.err("jextract.clang.error", ce.getMessage());
             if (JextractTool.DEBUG) {
-                ce.printStackTrace(err);
+                logger.printStackTrace(ce);
             }
             return CLANG_ERROR;
         } catch (RuntimeException re) {
-            err.println(re.getMessage());
-            if (JextractTool.DEBUG) {
-                re.printStackTrace(err);
-            }
+            logger.fatal(re);
             return RUNTIME_ERROR;
         }
 
@@ -548,18 +516,12 @@ public final class JextractTool {
                 try {
                     write(output, files);
                 } catch (IOException e) {
-                    err.println(e.getMessage());
-                    if (JextractTool.DEBUG) {
-                        e.printStackTrace(err);
-                    }
+                    logger.fatal(e);
                     return OUTPUT_ERROR;
                 }
             }
         } catch (RuntimeException re) {
-            err.println(re.getMessage());
-            if (JextractTool.DEBUG) {
-                re.printStackTrace(err);
-            }
+            logger.fatal(re);
             return RUNTIME_ERROR;
         }
 
@@ -584,7 +546,7 @@ public final class JextractTool {
         }
     }
 
-    private static Optional<Path> inferPlatformIncludePath() {
+    private Optional<Path> inferPlatformIncludePath() {
         String os = System.getProperty("os.name");
         if (os.equals("Mac OS X")) {
             try {
@@ -598,7 +560,7 @@ public final class JextractTool {
                 }
             } catch (IOException ioExp) {
                 if (JextractTool.DEBUG) {
-                    ioExp.printStackTrace(System.err);
+                    logger.printStackTrace(ioExp);
                 }
             }
         }

--- a/src/main/java/org/openjdk/jextract/JextractTool.java
+++ b/src/main/java/org/openjdk/jextract/JextractTool.java
@@ -46,15 +46,12 @@ import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.List;
-import java.util.Locale;
 import java.util.Optional;
-import java.util.ResourceBundle;
 import java.util.spi.ToolProvider;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -71,11 +68,12 @@ public final class JextractTool {
 
     // error codes
     private static final int SUCCESS       = 0;
-    private static final int OPTION_ERROR  = 1;
-    private static final int INPUT_ERROR   = 2;
-    private static final int CLANG_ERROR   = 3;
-    private static final int RUNTIME_ERROR = 4;
-    private static final int OUTPUT_ERROR  = 5;
+    private static final int FAILURE       = 1;
+    private static final int OPTION_ERROR  = 2;
+    private static final int INPUT_ERROR   = 3;
+    private static final int CLANG_ERROR   = 4;
+    private static final int FATAL_ERROR   = 5;
+    private static final int OUTPUT_ERROR  = 6;
 
     private final Logger logger;
 
@@ -502,7 +500,7 @@ public final class JextractTool {
             return CLANG_ERROR;
         } catch (RuntimeException re) {
             logger.fatal(re);
-            return RUNTIME_ERROR;
+            return FATAL_ERROR;
         }
 
         try {
@@ -519,10 +517,12 @@ public final class JextractTool {
             }
         } catch (RuntimeException re) {
             logger.fatal(re);
-            return RUNTIME_ERROR;
+            return FATAL_ERROR;
         }
 
-        return SUCCESS;
+        return logger.hasErrors() ?
+                FAILURE :
+                SUCCESS;
     }
 
     /**

--- a/src/main/java/org/openjdk/jextract/impl/Logger.java
+++ b/src/main/java/org/openjdk/jextract/impl/Logger.java
@@ -91,4 +91,8 @@ public class Logger {
     public String format(String key, Object... args) {
         return new MessageFormat(MESSAGES_BUNDLE.getString(key)).format(args);
     }
+
+    public static Logger DEFAULT = new Logger(
+            new PrintWriter(System.out, true),
+            new PrintWriter(System.err, true));
 }

--- a/src/main/java/org/openjdk/jextract/impl/Logger.java
+++ b/src/main/java/org/openjdk/jextract/impl/Logger.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package org.openjdk.jextract.impl;
+
+import org.openjdk.jextract.JextractTool;
+
+import java.io.PrintWriter;
+import java.text.MessageFormat;
+import java.util.Locale;
+import java.util.ResourceBundle;
+
+/**
+ * Minimal utility class to print jextract warning/errors.
+ */
+public class Logger {
+
+    private static final ResourceBundle MESSAGES_BUNDLE =
+            ResourceBundle.getBundle("org.openjdk.jextract.impl.resources.Messages", Locale.getDefault());
+
+    final PrintWriter outWriter;
+    final PrintWriter errWriter;
+    private int nWarnings;
+    private int nErrors;
+
+    public Logger(PrintWriter outWriter, PrintWriter errStream) {
+        this.outWriter = outWriter;
+        this.errWriter = errStream;
+    }
+
+    public void err(String key, Object... args) {
+        errWriter.println(STR."ERROR: \{format(key, args)}");
+        nErrors++;
+    }
+
+    public void warn(String key, Object... args) {
+        errWriter.println(STR."WARNING: \{format(key, args)}");
+        nWarnings++;
+    }
+
+    public void info(String key, Object... args) {
+        errWriter.println(format(key, args));
+        nWarnings++;
+    }
+
+    public void printStackTrace(Throwable t) {
+        t.printStackTrace(errWriter);
+    }
+
+    public void fatal(Throwable t, String msg, Object... args) {
+        errWriter.println(STR."FATAL: \{format(msg, args)}");
+        if (JextractTool.DEBUG) {
+            printStackTrace(t);
+        }
+    }
+
+    public void fatal(Throwable t) {
+        fatal(t, "jextract.crash", t);
+    }
+
+    public boolean hasErrors() {
+        return nErrors > 0;
+    }
+
+    public boolean hasWarnings() {
+        return nWarnings > 0;
+    }
+
+    public String format(String key, Object... args) {
+        return new MessageFormat(MESSAGES_BUNDLE.getString(key)).format(args);
+    }
+}

--- a/src/main/java/org/openjdk/jextract/impl/OutputFactory.java
+++ b/src/main/java/org/openjdk/jextract/impl/OutputFactory.java
@@ -64,11 +64,7 @@ public class OutputFactory implements Declaration.Visitor<Void, Declaration> {
     }
 
     private void generateDecl(Declaration tree) {
-        try {
-            tree.accept(this, null);
-        } catch (Exception ex) {
-            ex.printStackTrace();
-        }
+        tree.accept(this, null);
     }
 
     @Override

--- a/src/main/java/org/openjdk/jextract/impl/Parser.java
+++ b/src/main/java/org/openjdk/jextract/impl/Parser.java
@@ -43,9 +43,11 @@ import java.util.Optional;
 
 public class Parser {
     private final TreeMaker treeMaker;
+    private final Logger logger;
 
-    public Parser() {
+    public Parser(Logger logger) {
         this.treeMaker = new TreeMaker();
+        this.logger = logger;
     }
 
     public Declaration.Scoped parse(Path path, Collection<String> args) {
@@ -57,7 +59,7 @@ public class Parser {
                     }
                 },
             true, args.toArray(new String[0])) ;
-            MacroParserImpl macroParser = MacroParserImpl.make(treeMaker, tu, args)) {
+            MacroParserImpl macroParser = MacroParserImpl.make(treeMaker, logger, tu, args)) {
 
             List<Declaration> decls = new ArrayList<>();
             Cursor tuCursor = tu.getCursor();

--- a/src/main/java/org/openjdk/jextract/impl/TreeMaker.java
+++ b/src/main/java/org/openjdk/jextract/impl/TreeMaker.java
@@ -503,7 +503,7 @@ class TreeMaker {
             default -> {
                 // heuristic, try w/o expanding first, and check if there are <anonymous> strings
                 String cursorString = declarationString(cursor, false);
-                if (cursorString.matches(".*\\(unnamed (struct|union|enum) at.*")) {
+                if (cursorString.matches(".*\\((unnamed|anonymous) (struct|union|enum) at.*")) {
                     // the output contains anonymous definitions, fallback and expand them
                     cursorString = declarationString(cursor, true);
                 }

--- a/src/main/resources/org/openjdk/jextract/impl/resources/Messages.properties
+++ b/src/main/resources/org/openjdk/jextract/impl/resources/Messages.properties
@@ -82,3 +82,37 @@ Option                             Description                                  
 -t, --target-package <package>     target package name for the generated classes. If this option\n\
 \                                   is not specified, then unnamed package is used.             \n\
 --version                          print version information and exit                           \n
+
+jextract.version=\
+jextract {0}\n\
+JDK version {1}\n\
+LibClang version {2}
+
+jextract.opt.error=\
+{0}\n\
+Usage: jextract <options> <header file>\n\
+Use --help for a list of possible options
+
+jextract.clang.error=\
+{0}
+
+jextract.crash=\
+Unexpected exception {0} occurred
+
+jextract.bad.compile.flags=\
+Unexpected exception {0} while reading compile_flags.txt
+
+jextract.skip.unsupported=\
+Skipping {0} ({1})
+
+unsupported.type=\
+type {0} is not supported
+
+unsupported.variadic.callback=\
+variadic callback {0} is not supported
+
+unsupported.bitfields=\
+bitfields are not supported
+
+jextract.bad.include=\
+{0} depends on {1} which has been excluded

--- a/src/main/resources/org/openjdk/jextract/impl/resources/Messages.properties
+++ b/src/main/resources/org/openjdk/jextract/impl/resources/Messages.properties
@@ -93,6 +93,9 @@ jextract.opt.error=\
 Usage: jextract <options> <header file>\n\
 Use --help for a list of possible options
 
+expected.one.header=\
+  Expected one header file, not {0}
+
 jextract.clang.error=\
 {0}
 
@@ -116,3 +119,6 @@ bitfields are not supported
 
 jextract.bad.include=\
 {0} depends on {1} which has been excluded
+
+jextract.debug.macro.error=\
+Error occurred while processing macro: {0}

--- a/test/lib/testlib/JextractToolRunner.java
+++ b/test/lib/testlib/JextractToolRunner.java
@@ -67,11 +67,12 @@ public class JextractToolRunner {
 
     // (private) exit codes from jextract tool. Copied from JextractTool.
     protected static final int SUCCESS       = 0;
-    protected static final int OPTION_ERROR  = 1;
-    protected static final int INPUT_ERROR   = 2;
-    protected static final int CLANG_ERROR   = 3;
-    protected static final int RUNTIME_ERROR = 4;
-    protected static final int OUTPUT_ERROR  = 5;
+    protected static final int FAILURE       = 1;
+    protected static final int OPTION_ERROR  = 2;
+    protected static final int INPUT_ERROR   = 3;
+    protected static final int CLANG_ERROR   = 4;
+    protected static final int RUNTIME_ERROR = 5;
+    protected static final int OUTPUT_ERROR  = 6;
 
     private static String safeFileName(String filename) {
         int ext = filename.lastIndexOf('.');

--- a/test/testng/org/openjdk/jextract/test/toolprovider/includeDeps/TestBadIncludes.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/includeDeps/TestBadIncludes.java
@@ -44,6 +44,7 @@ public class TestBadIncludes extends JextractToolRunner {
                 "--include-struct", "C",
                 "--include-function", "n",
                 outputH.toString());
+        result.checkFailure(FAILURE);
     }
 
     @Test(dataProvider = "cases")

--- a/test/testng/org/openjdk/jextract/test/toolprovider/includeDeps/TestBadIncludes.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/includeDeps/TestBadIncludes.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.jextract.test.toolprovider.includeDeps;
+
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import testlib.JextractToolRunner;
+
+import java.nio.file.Path;
+
+public class TestBadIncludes extends JextractToolRunner {
+
+    JextractResult result;
+
+    @BeforeClass
+    public void before() {
+        Path output = getOutputFilePath("TestBadIncludes-badIncludes.h");
+        Path outputH = getInputFilePath("bad_includes.h");
+        result = run(output,
+        "--include-struct", "B",
+                "--include-function", "m",
+                "--include-typedef", "T",
+                "--include-struct", "C",
+                "--include-function", "n",
+                outputH.toString());
+    }
+
+    @Test(dataProvider = "cases")
+    public void testBadIncludes(String badDeclName, String missingDepName) {
+        result.checkContainsOutput("ERROR: " + badDeclName + " depends on " + missingDepName);
+    }
+
+    @DataProvider
+    public static Object[][] cases() {
+        return new Object[][]{
+            {"B",   "A" },
+            {"m",   "A" },
+            {"T",   "A" },
+            {"a",   "A" }
+        };
+    }
+}

--- a/test/testng/org/openjdk/jextract/test/toolprovider/includeDeps/bad_includes.h
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/includeDeps/bad_includes.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+struct A { int x; };
+struct B { struct A a; };
+void m(struct A a);
+typedef struct A T;
+struct A a;

--- a/test/testng/org/openjdk/jextract/test/toolprovider/unsupported/TestUnsupportedTypes.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/unsupported/TestUnsupportedTypes.java
@@ -42,11 +42,11 @@ public class TestUnsupportedTypes extends JextractToolRunner {
 
     @Test(dataProvider = "cases")
     public void testUnsupportedTypes(String skippedName, String reason) {
-        result.checkContainsOutput("WARNING: skipping " + skippedName + ": " + reason);
+        result.checkContainsOutput("WARNING: Skipping " + skippedName + " (" + reason);
     }
 
-    private static final String REASON_UNSUPPORTED_TYPE = "unsupported type usage";
-    private static final String REASON_VARARGS_CALLBACK = "varargs in callbacks is not supported";
+    private static final String REASON_UNSUPPORTED_TYPE = "type";
+    private static final String REASON_VARARGS_CALLBACK = "variadic callback";
 
     @DataProvider
     public static Object[][] cases() {


### PR DESCRIPTION
When custom include filters are specified on the command line, it is possible for jextract to generate non-sensical code (now even more so than in the past). Possible issues:

* a function descriptor refers to a non-existent struct/union
* a struct/union typedef refers to a non-existent struct/union
* a struct/union field refers to a non-existent struct/union
* a global variable refers to a non-existent struct/union

In such cases, jextract should terminate (and report the problem to the user), rather than generating buggy code.

The fix is relatively simple, and amounts at checking whether a declaration depends on a skipped struct in `IncludeHelper`. That said, when we detect an issue, we should stop jextract. So we need some way to notify jextract that some error occurred, and stop.

I initially had a hacky approach with some mutable field in `IncludeFilter`, but I've decided to implement a minimal Logger class, and make _all_ error/warnings go through the Logger. This way we can easily check how many errors occurred, and stop jextract if needed. Of course, this led to several changes, as I realized that we were being inconsistent on our usage of the property file. I now made sure that all messages use some key in the property file (e.g. no lone strings). This might be important if jextract message will ever be translated to languages other than English.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Issue
 * [CODETOOLS-7903666](https://bugs.openjdk.org/browse/CODETOOLS-7903666): Jextract should report issues with missing dependencies (**Bug** - P3)


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/214/head:pull/214` \
`$ git checkout pull/214`

Update a local copy of the PR: \
`$ git checkout pull/214` \
`$ git pull https://git.openjdk.org/jextract.git pull/214/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 214`

View PR using the GUI difftool: \
`$ git pr show -t 214`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/214.diff">https://git.openjdk.org/jextract/pull/214.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/214#issuecomment-1948663270)