### PR TITLE
7903667: Functional interface name nested inside function pointer class should be mangled

### DIFF
--- a/test/testng/org/openjdk/jextract/test/toolprovider/fiMangle/nestedDecls/TestFunctionalInterfaceMangle.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/fiMangle/nestedDecls/TestFunctionalInterfaceMangle.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.jextract.test.toolprovider.fiMangle.nestedDecls;
+
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import testlib.JextractToolRunner;
+
+import java.lang.reflect.Modifier;
+import java.nio.file.Path;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+public class TestFunctionalInterfaceMangle extends JextractToolRunner {
+
+    Loader loader;
+
+    @BeforeClass
+    public void beforeClass() {
+        Path output = getOutputFilePath("TestFunctionalInterfaceMangler-fiMangle.h");
+        Path outputH = getInputFilePath("fi_mangle.h");
+        runAndCompile(output, outputH.toString());
+
+        loader = classLoader(output);
+    }
+
+    @AfterClass
+    public void afterClass() {
+        loader.close();
+    }
+
+    @Test
+    public void testFunctionPointer() {
+        Class<?> fpClass = loader.loadClass("Function");
+        assertNotNull(fpClass);
+        Class<?> fiClass = findNestedClass(fpClass, "Function$");
+    }
+}

--- a/test/testng/org/openjdk/jextract/test/toolprovider/fiMangle/nestedDecls/fi_mangle.h
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/fiMangle/nestedDecls/fi_mangle.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+typedef void (*Function)(int);


### PR DESCRIPTION
This simple PR adds name mangling for the functional interface nested inside the function pointer class, in case the latter is called "Function".

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Issue
 * [CODETOOLS-7903667](https://bugs.openjdk.org/browse/CODETOOLS-7903667): Functional interface name nested inside function pointer class should be mangled (**Bug** - P3)


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/215/head:pull/215` \
`$ git checkout pull/215`

Update a local copy of the PR: \
`$ git checkout pull/215` \
`$ git pull https://git.openjdk.org/jextract.git pull/215/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 215`

View PR using the GUI difftool: \
`$ git pr show -t 215`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/215.diff">https://git.openjdk.org/jextract/pull/215.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/215#issuecomment-1948836740)