### PR TITLE
7903672: Some issues with missing dependency errors

### DIFF
--- a/src/main/java/org/openjdk/jextract/JextractTool.java
+++ b/src/main/java/org/openjdk/jextract/JextractTool.java
@@ -32,7 +32,7 @@ import org.openjdk.jextract.impl.DuplicateFilter;
 import org.openjdk.jextract.impl.IncludeFilter;
 import org.openjdk.jextract.impl.IncludeHelper;
 import org.openjdk.jextract.impl.Logger;
-import org.openjdk.jextract.impl.MissingDepWarner;
+import org.openjdk.jextract.impl.MissingDepChecker;
 import org.openjdk.jextract.impl.NameMangler;
 import org.openjdk.jextract.impl.Options.Library;
 import org.openjdk.jextract.impl.OutputFactory;
@@ -127,7 +127,7 @@ public final class JextractTool {
                 .map(new DuplicateFilter()::scan)
                 .map(new UnsupportedFilter(logger)::scan)
                 // then do the rest
-                .map(new MissingDepWarner(logger)::scan)
+                .map(new MissingDepChecker(logger)::scan)
                 .map(new NameMangler(headerName)::scan)
                 .findFirst().get();
         return logger.hasErrors() ?

--- a/src/main/java/org/openjdk/jextract/impl/IncludeFilter.java
+++ b/src/main/java/org/openjdk/jextract/impl/IncludeFilter.java
@@ -63,9 +63,10 @@ public final class IncludeFilter implements Declaration.Visitor<Void, Declaratio
         if (!includeHelper.isIncluded(funcTree)) {
             //skip
             Skip.with(funcTree);
+        } else {
+            warnMissingDep(funcTree, funcTree.type().returnType());
+            funcTree.type().argumentTypes().forEach(p -> warnMissingDep(funcTree, p));
         }
-        warnMissingDep(funcTree, funcTree.type().returnType());
-        funcTree.type().argumentTypes().forEach(p -> warnMissingDep(funcTree, p));
         return null;
     }
 
@@ -89,8 +90,9 @@ public final class IncludeFilter implements Declaration.Visitor<Void, Declaratio
         if (!includeHelper.isIncluded(tree)) {
             //skip
             Skip.with(tree);
+        } else {
+            warnMissingDep(tree, tree.type());
         }
-        warnMissingDep(tree, tree.type());
         return null;
     }
 
@@ -99,8 +101,13 @@ public final class IncludeFilter implements Declaration.Visitor<Void, Declaratio
         if (parent == null && !includeHelper.isIncluded(tree)) {
             //skip
             Skip.with(tree);
+        } else if (parent != null)  {
+            if (!Skip.isPresent(parent)) {
+                warnMissingDep(parent, tree.type());
+            }
+        } else {
+            warnMissingDep(tree, tree.type());
         }
-        warnMissingDep(parent != null ? parent : tree, tree.type());
         return null;
     }
 

--- a/src/main/java/org/openjdk/jextract/impl/IncludeFilter.java
+++ b/src/main/java/org/openjdk/jextract/impl/IncludeFilter.java
@@ -127,6 +127,8 @@ public final class IncludeFilter implements Declaration.Visitor<Void, Declaratio
         } else if (type instanceof Type.Delegated delegated &&
                         delegated.kind() == Delegated.Kind.TYPEDEF) {
             warnMissingDep(decl, delegated.type());
+        } else if (type instanceof Type.Array arrayType) {
+            warnMissingDep(decl, arrayType.elementType());
         }
     }
 }

--- a/src/main/java/org/openjdk/jextract/impl/UnsupportedFilter.java
+++ b/src/main/java/org/openjdk/jextract/impl/UnsupportedFilter.java
@@ -70,6 +70,8 @@ public class UnsupportedFilter implements Declaration.Visitor<Void, Declaration>
 
     @Override
     public Void visitFunction(Function funcTree, Declaration firstNamedParent) {
+        if(Skip.isPresent(funcTree)) return null;
+
         Utils.forEachNested(funcTree, s -> s.accept(this, firstNamedParent));
 
         //generate static wrapper for function
@@ -106,6 +108,8 @@ public class UnsupportedFilter implements Declaration.Visitor<Void, Declaration>
 
     @Override
     public Void visitVariable(Variable varTree, Declaration firstNamedParent) {
+        if(Skip.isPresent(varTree)) return null;
+
         Utils.forEachNested(varTree, s -> s.accept(this, varTree));
 
         Type unsupportedType = firstUnsupportedType(varTree.type(), false);
@@ -127,6 +131,8 @@ public class UnsupportedFilter implements Declaration.Visitor<Void, Declaration>
 
     @Override
     public Void visitScoped(Scoped scoped, Declaration firstNamedParent) {
+        if(Skip.isPresent(scoped)) return null;
+
         Type unsupportedType = firstUnsupportedType(Type.declared(scoped), false);
         if (unsupportedType != null) {
             warnSkip(scoped.name(), unsupportedType(unsupportedType));
@@ -154,6 +160,8 @@ public class UnsupportedFilter implements Declaration.Visitor<Void, Declaration>
 
     @Override
     public Void visitTypedef(Typedef typedefTree, Declaration firstNamedParent) {
+        if(Skip.isPresent(typedefTree)) return null;
+
         // propagate
         if (typedefTree.type() instanceof Declared declared) {
             visitScoped(declared.tree(), null);
@@ -175,6 +183,8 @@ public class UnsupportedFilter implements Declaration.Visitor<Void, Declaration>
 
     @Override
     public Void visitConstant(Constant d, Declaration firstNamedParent) {
+        if(Skip.isPresent(d)) return null;
+
         Type unsupportedType = firstUnsupportedType(d.type(), false);
         String name = fieldName(firstNamedParent, d);
         if (unsupportedType != null) {

--- a/test/lib/testlib/JextractToolRunner.java
+++ b/test/lib/testlib/JextractToolRunner.java
@@ -45,6 +45,7 @@ import java.lang.foreign.ValueLayout;
 import org.openjdk.jextract.JextractTool;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
@@ -130,6 +131,12 @@ public class JextractToolRunner {
         public JextractResult checkContainsOutput(String expected) {
             Objects.requireNonNull(expected);
             assertTrue(output.contains(expected), "Output does not contain string: " + expected);
+            return this;
+        }
+
+        public JextractResult checkDoesNotContainOutput(String expected) {
+            Objects.requireNonNull(expected);
+            assertFalse(output.contains(expected), "Output contains string: " + expected);
             return this;
         }
 

--- a/test/testng/org/openjdk/jextract/test/toolprovider/includeDeps/TestBadIncludes.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/includeDeps/TestBadIncludes.java
@@ -59,7 +59,8 @@ public class TestBadIncludes extends JextractToolRunner {
             {"B",   "A" },
             {"m",   "A" },
             {"T",   "A" },
-            {"a",   "A" }
+            {"a",   "A" },
+            {"C",   "A" }
         };
     }
 }

--- a/test/testng/org/openjdk/jextract/test/toolprovider/includeDeps/TestSkippedBadIncludes.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/includeDeps/TestSkippedBadIncludes.java
@@ -37,7 +37,6 @@ public class TestSkippedBadIncludes extends JextractToolRunner {
         Path outputH = getInputFilePath("bad_includes.h");
         JextractResult result = run(output,
                 // some random includes so that we don't include everything
-                "--include-struct", "C",
                 "--include-function", "n",
                 outputH.toString());
         // if nothing that depends on struct A is included

--- a/test/testng/org/openjdk/jextract/test/toolprovider/includeDeps/TestSkippedBadIncludes.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/includeDeps/TestSkippedBadIncludes.java
@@ -29,37 +29,19 @@ import testlib.JextractToolRunner;
 
 import java.nio.file.Path;
 
-public class TestBadIncludes extends JextractToolRunner {
+public class TestSkippedBadIncludes extends JextractToolRunner {
 
-    JextractResult result;
-
-    @BeforeClass
-    public void before() {
+    @Test
+    public void run() {
         Path output = getOutputFilePath("TestBadIncludes-badIncludes.h");
         Path outputH = getInputFilePath("bad_includes.h");
-        result = run(output,
-                "--include-var", "a",
-                "--include-struct", "B",
-                "--include-function", "m",
-                "--include-typedef", "T",
+        JextractResult result = run(output,
+                // some random includes so that we don't include everything
                 "--include-struct", "C",
                 "--include-function", "n",
                 outputH.toString());
-        result.checkFailure(FAILURE);
-    }
-
-    @Test(dataProvider = "cases")
-    public void testBadIncludes(String badDeclName, String missingDepName) {
-        result.checkContainsOutput("ERROR: " + badDeclName + " depends on " + missingDepName);
-    }
-
-    @DataProvider
-    public static Object[][] cases() {
-        return new Object[][]{
-            {"B",   "A" },
-            {"m",   "A" },
-            {"T",   "A" },
-            {"a",   "A" }
-        };
+        // if nothing that depends on struct A is included
+        // there should be no errors
+        result.checkSuccess();
     }
 }

--- a/test/testng/org/openjdk/jextract/test/toolprovider/includeDeps/bad_includes.h
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/includeDeps/bad_includes.h
@@ -26,3 +26,4 @@ struct B { struct A a; };
 void m(struct A a);
 typedef struct A T;
 struct A a;
+struct C { struct A arr[]; };

--- a/test/testng/org/openjdk/jextract/test/toolprovider/includeDeps/bad_includes.h
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/includeDeps/bad_includes.h
@@ -26,4 +26,4 @@ struct B { struct A a; };
 void m(struct A a);
 typedef struct A T;
 struct A a;
-struct C { struct A arr[]; };
+struct C { int x; struct A arr[]; };

--- a/test/testng/org/openjdk/jextract/test/toolprovider/unsupported/TestSkipped.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/unsupported/TestSkipped.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.jextract.test.toolprovider.unsupported;
+
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import testlib.JextractToolRunner;
+
+import java.nio.file.Path;
+
+public class TestSkipped extends JextractToolRunner {
+
+    JextractResult result;
+
+    @BeforeClass
+    public void before() {
+        Path output = getOutputFilePath("TestUnsupportedTypes-unsupportedTypes.h");
+        Path outputH = getInputFilePath("unsupportedTypes.h");
+        result = run(output,
+                // dummy include to turn on exclusions
+                "--include-function", "nonexistent",
+                outputH.toString());
+    }
+
+    @Test(dataProvider = "cases")
+    public void testUnsupportedTypes(String skippedName) {
+        result.checkDoesNotContainOutput("WARNING: Skipping " + skippedName);
+    }
+
+    @DataProvider
+    public static Object[][] cases() {
+        return new Object[][]{
+            {"returns_unsupported"              },
+            {"accepts_unsupported"              },
+            {"unsupported_t"                    },
+            {"unsupported_func_t"               },
+            {"returns_unsupported_func"         },
+            {"accepts_unsupported_func"         },
+            {"accepts_unsupported_func_varargs" },
+            {"GLOBAL_UNSUPPORTED"               },
+            {"GLOBAL_UNSUPPORTED_FUNC"          },
+            {"accepts_undefined"                },
+            {"returns_undefined"                },
+            {"accepts_undefined_func"           },
+            {"GLOBAL_UNDECLARED"                },
+            {"undefined_typedef"                },
+            {"INT_128_NUM"                      }
+        };
+    }
+}


### PR DESCRIPTION
- Only error on missing dependencies, if the dependent is not skipped
- Scan element types of arrays for missing dependencies as well
- Don't issue warnings about unsupported types/fields for skipped elements

I've pulled the code that issues errors for missing dependencies into a separate phase (`MissingDepWarner`), since the control flow in some of the visitor methods was kinda tricky to follow if this stayed mixed in with the `IncludeFilter` code. The new phase just cleanly checks whether the visited element has a `Skip` on it and then returns at the start, before doing any work.

I've also re-ordered the phases a bit so that the phases that add Skips run first, so that we don't issue warnings/errors for things that are skipped any way by a later phase. Since `UnsupportedFilter` both adds Skips and issues warnings, it sits right in the middle.

Q: should we also return early in `NameMangler` if an element is skipped? (Right now it's just doing extra work).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Issue
 * [CODETOOLS-7903672](https://bugs.openjdk.org/browse/CODETOOLS-7903672): Some issues with missing dependency errors (**Bug** - P4)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**) ⚠️ Review applies to [fa6e182b](https://git.openjdk.org/jextract/pull/217/files/fa6e182b5a31027cdedf695791f612c5e027f861)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/217/head:pull/217` \
`$ git checkout pull/217`

Update a local copy of the PR: \
`$ git checkout pull/217` \
`$ git pull https://git.openjdk.org/jextract.git pull/217/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 217`

View PR using the GUI difftool: \
`$ git pr show -t 217`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/217.diff">https://git.openjdk.org/jextract/pull/217.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/217#issuecomment-1952585830)