### PR TITLE
7903670: jextract generates wrong packed struct layout

### DIFF
--- a/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
@@ -333,6 +333,20 @@ class HeaderFileBuilder extends ClassSourceBuilder {
                     throw new AssertionError(ex);
                 }
             }
+
+            static MemoryLayout align(MemoryLayout layout, long align) {
+                return switch (layout) {
+                    case PaddingLayout p -> p;
+                    case ValueLayout v -> v.withByteAlignment(align);
+                    case GroupLayout g -> {
+                        MemoryLayout[] alignedMembers = g.memberLayouts().stream()
+                                .map(m -> align(m, align)).toArray(MemoryLayout[]::new);
+                        yield g instanceof StructLayout ?
+                                MemoryLayout.structLayout(alignedMembers) : MemoryLayout.unionLayout(alignedMembers);
+                    }
+                    case SequenceLayout s -> MemoryLayout.sequenceLayout(s.elementCount(), align(s.elementLayout(), align));
+                };
+            }
             """);
     }
 

--- a/test/jtreg/generator/packed/TestPackedStructs.java
+++ b/test/jtreg/generator/packed/TestPackedStructs.java
@@ -49,6 +49,10 @@ public class TestPackedStructs {
         checkLayout(S6.layout());
         checkLayout(S7.layout());
         checkLayout(S8.layout());
+        checkLayout(S9.layout());
+        checkLayout(S10.layout());
+        checkLayout(S11.layout());
+        checkLayout(S12.layout());
     }
 
     private void checkLayout(MemoryLayout layout) {

--- a/test/jtreg/generator/packed/packedstructs.h
+++ b/test/jtreg/generator/packed/packedstructs.h
@@ -68,3 +68,31 @@ struct S8 {
    struct S7 first[1];
    struct S7 second[1];
 };
+
+struct NonPacked {
+  long long aField;
+};
+
+#pragma pack(1)
+struct S9 {
+  char first;
+  struct NonPacked second;
+};
+
+#pragma pack(1)
+struct S10 {
+   char first;
+   long long second[2];
+};
+
+#pragma pack(1)
+struct S11 {
+   char first;
+   void *second;
+};
+
+#pragma pack(1)
+struct S12 {
+   char first;
+   void (*second)(int);
+};


### PR DESCRIPTION
The change to refer to other struct layouts by name resulted in an interesting issue with the `pragma pack` support. When jextract simply re-inlined all nested struct layouts into the enclosing struct, it was simply necessary to add as many calls to `withByteAlignment` as needed, to force struct alignment to adhere to the pragma directive.

But now that nested layouts just refer to a layout declared somewhere else, we can no longer add `withByteAlignment` to the fields of the _nested_ struct. So we run into issues if:

* the enclosing struct is packed, and
* the nested struct is declared as non-packed

Because, in this case, the layout declaration of the nested struct just contains natural alignment constraints. As such, when this layout is referred to by the enclosing struct layout (e.g. in a field), packed alignment constraints are violated. Note also that simply calling `withByteAlignment` on the nested struct is not enough, as the struct alignment can be stricter than the alignment of any of the fields.

In other words, we'd need to duplicate the nested layout into the packed enclosing struct, and decorate all its fields with the necessary `withByteAlignment` calls. I found this solution not satisfying, as now we'd have _two_ (or more!) different declaration for the layout of a struct: one corresponding to the place where it was declared; another for the place where it was _used_ with stricter alignment constraints. This is bad, because if users tweak the layout of the nested struct in any way (e.g. using big endian order for some of its fields), such changes will _not_ be reflected by the packed layout view.

For this reason, I've opted for a solution where packed views are generated _dynamically_, with the help of a compact function in the main header class. This allows jextract to pack layouts (of any kind) at will, according to the constraints of the struct that is currently emitting.

In other words, given this:

```c
typedef union epoll_data
{
  void *ptr;
  int fd;
  int u32;
  long u64;
} epoll_data_t;

#pragma pack(1)
struct epoll_event
{
  int events;
  epoll_data_t data;
} __EPOLL_PACKED; 
```

We now generate:

```java
private static final GroupLayout $LAYOUT = MemoryLayout.unionLayout(
        foo_h.C_POINTER.withName("ptr"),
        foo_h.C_INT.withName("fd"),
        foo_h.C_INT.withName("u32"),
        foo_h.C_LONG.withName("u64")
    ).withName("epoll_data");

private static final GroupLayout $LAYOUT = MemoryLayout.structLayout(
        foo_h.align(foo_h.C_INT, 1).withName("events"),
        foo_h.align(epoll_data.layout(), 1).withName("data")
    ).withName("epoll_event");
```

Note the calls to `foo_h::align` in the `epoll_event` packed layout.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Issue
 * [CODETOOLS-7903670](https://bugs.openjdk.org/browse/CODETOOLS-7903670): jextract generates wrong packed struct layout (**Bug** - P2)


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/218/head:pull/218` \
`$ git checkout pull/218`

Update a local copy of the PR: \
`$ git checkout pull/218` \
`$ git pull https://git.openjdk.org/jextract.git pull/218/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 218`

View PR using the GUI difftool: \
`$ git pr show -t 218`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/218.diff">https://git.openjdk.org/jextract/pull/218.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/218#issuecomment-1952220394)