### PR TITLE
7903673: Jextract throws NPE when generating enum constant javadoc

### DIFF
--- a/src/main/java/org/openjdk/jextract/impl/TreeMaker.java
+++ b/src/main/java/org/openjdk/jextract/impl/TreeMaker.java
@@ -370,7 +370,7 @@ class TreeMaker {
             List<Declaration> decls = new ArrayList<>();
             c.forEach(child -> {
                 Declaration enumConstantDecl = createTree(child);
-                if (enumConstantDecl != null) {
+                if (enumConstantDecl != null) { // see CODETOOLS-7903673
                     DeclarationString.with(enumConstantDecl, enumConstantString(c.spelling(), (Declaration.Constant) enumConstantDecl));
                     decls.add(enumConstantDecl);
                 }

--- a/src/main/java/org/openjdk/jextract/impl/TreeMaker.java
+++ b/src/main/java/org/openjdk/jextract/impl/TreeMaker.java
@@ -366,13 +366,14 @@ class TreeMaker {
     }
 
     public Declaration.Scoped createEnum(Cursor c) {
-        List<Declaration> decls = new ArrayList<>();
-        c.forEach(child -> decls.add(createTree(child)));
         if (c.isDefinition()) {
-            //just a declaration AND definition, we have a layout
-            decls.forEach(d -> {
-                // append declaration string
-                DeclarationString.with(d, enumConstantString(c.spelling(), (Declaration.Constant)d));
+            List<Declaration> decls = new ArrayList<>();
+            c.forEach(child -> {
+                Declaration enumConstantDecl = createTree(child);
+                if (enumConstantDecl != null) {
+                    DeclarationString.with(enumConstantDecl, enumConstantString(c.spelling(), (Declaration.Constant) enumConstantDecl));
+                    decls.add(enumConstantDecl);
+                }
             });
             return Declaration.enum_(CursorPosition.of(c), c.spelling(), decls.toArray(new Declaration[0]));
         } else {


### PR DESCRIPTION
This PR fixes `TreeMaker` so that it doesn't try to generate javadoc for `null` enum constants.

Unfortunately I was not able to reproduce on Linux. The problem seems to appear on MacOS when extracting this enum:

```
enum __CFByteOrder {
    CFByteOrderUnknown,
    CFByteOrderLittleEndian,
    CFByteOrderBigEndian
}; 
```

But there doesn't seem to be anything peculiar with this (and this does work when extracted in isolation).
It might indicate a deeper issue in libclang. For now, I made the code more robust, so that it handles possible null enum constants (these are left out from the IR).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Issue
 * [CODETOOLS-7903673](https://bugs.openjdk.org/browse/CODETOOLS-7903673): Jextract throws NPE when generating enum constant javadoc (**Bug** - P2)


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - Committer)
 * [Athijegannathan Sundararajan](https://openjdk.org/census#sundar) (@sundararajana - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/219/head:pull/219` \
`$ git checkout pull/219`

Update a local copy of the PR: \
`$ git checkout pull/219` \
`$ git pull https://git.openjdk.org/jextract.git pull/219/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 219`

View PR using the GUI difftool: \
`$ git pr show -t 219`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/219.diff">https://git.openjdk.org/jextract/pull/219.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/219#issuecomment-1952518551)