### PR TITLE
7903669: jextract-22 jextract tool shows enable native access warning

### DIFF
--- a/make/Build.gmk
+++ b/make/Build.gmk
@@ -83,9 +83,7 @@ $(JEXTRACT_IMAGE_DIR): $(BUILD_MODULES_DIR)
 	    --output "$(JEXTRACT_IMAGE_DIR)" \
 	    --module-path "$(BUILD_MODULES_DIR)" \
 	    --add-modules org.openjdk.jextract \
-	    --add-modules jdk.compiler \
-	    --add-options \"--enable-native-access=org.openjdk.jextract\" \
-	    --add-options \"--enable-preview\" \
+	    --add-options '\"--enable-native-access=org.openjdk.jextract\" \"--enable-preview\"' \
 	    --launcher jextract=org.openjdk.jextract/org.openjdk.jextract.JextractTool
 
 $(JEXTRACT_IMAGE_TEST_JDK_DIR): $(JEXTRACT_IMAGE_DIR)


### PR DESCRIPTION
--add-options was defined twice in jlink command line. The latter one overrides the previous one! To specify multiple launcher options, single --add-options with quoted, space separated options has to specified in the jlink command line.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Issue
 * [CODETOOLS-7903669](https://bugs.openjdk.org/browse/CODETOOLS-7903669): jextract-22 jextract tool shows enable native access warning (**Bug** - P4)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/220/head:pull/220` \
`$ git checkout pull/220`

Update a local copy of the PR: \
`$ git checkout pull/220` \
`$ git pull https://git.openjdk.org/jextract.git pull/220/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 220`

View PR using the GUI difftool: \
`$ git pr show -t 220`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/220.diff">https://git.openjdk.org/jextract/pull/220.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/220#issuecomment-1952701219)