### PR TITLE
7903674: jextract should ignore non-enum constants inside enum

### DIFF
--- a/src/main/java/org/openjdk/jextract/impl/TreeMaker.java
+++ b/src/main/java/org/openjdk/jextract/impl/TreeMaker.java
@@ -289,15 +289,13 @@ class TreeMaker {
                     if (fc.isAnonymousStruct()) {
                         // process struct recursively
                         pendingFields.add(recordDeclaration(parent, fc).tree());
-                    } else {
-                        if (fc.kind() == CursorKind.FieldDecl) {
-                            Declaration fieldDecl = createTree(fc);
-                            ClangSizeOf.with(fieldDecl, fc.type().kind() == TypeKind.IncompleteArray ?
+                    } else if (fc.kind() == CursorKind.FieldDecl) {
+                        Declaration fieldDecl = createTree(fc);
+                        ClangSizeOf.with(fieldDecl, fc.type().kind() == TypeKind.IncompleteArray ?
                                     0 : fc.type().size() * 8);
-                            ClangOffsetOf.with(fieldDecl, parent.type().getOffsetOf(fc.spelling()));
-                            ClangAlignOf.with(fieldDecl, fc.type().align() * 8);
-                            pendingFields.add(fieldDecl);
-                        }
+                        ClangOffsetOf.with(fieldDecl, parent.type().getOffsetOf(fc.spelling()));
+                        ClangAlignOf.with(fieldDecl, fc.type().align() * 8);
+                        pendingFields.add(fieldDecl);
                     }
                 }
             } else {

--- a/src/main/java/org/openjdk/jextract/impl/TreeMaker.java
+++ b/src/main/java/org/openjdk/jextract/impl/TreeMaker.java
@@ -289,7 +289,7 @@ class TreeMaker {
                     if (fc.isAnonymousStruct()) {
                         // process struct recursively
                         pendingFields.add(recordDeclaration(parent, fc).tree());
-                    } else if (fc.kind() == CursorKind.FieldDecl) {
+                    } else {
                         Declaration fieldDecl = createTree(fc);
                         ClangSizeOf.with(fieldDecl, fc.type().kind() == TypeKind.IncompleteArray ?
                                     0 : fc.type().size() * 8);
@@ -474,9 +474,7 @@ class TreeMaker {
                     collectNestedTypes(m, nestedTypes, ignoreNestedParams);
                 } else {
                     Declaration decl = createTree(m);
-                    if (decl != null) {
-                        nestedTypes.add(decl);
-                    }
+                    nestedTypes.add(decl);
                 }
             }
         });

--- a/src/main/java/org/openjdk/jextract/impl/TreeMaker.java
+++ b/src/main/java/org/openjdk/jextract/impl/TreeMaker.java
@@ -371,10 +371,8 @@ class TreeMaker {
             c.forEach(child -> {
                 if (child.kind() == CursorKind.EnumConstantDecl) {
                     Declaration enumConstantDecl = createTree(child);
-                    if (enumConstantDecl != null) {
-                        DeclarationString.with(enumConstantDecl, enumConstantString(c.spelling(), (Declaration.Constant) enumConstantDecl));
-                        decls.add(enumConstantDecl);
-                    }
+                    DeclarationString.with(enumConstantDecl, enumConstantString(c.spelling(), (Declaration.Constant) enumConstantDecl));
+                    decls.add(enumConstantDecl);
                 }
             });
             return Declaration.enum_(CursorPosition.of(c), c.spelling(), decls.toArray(new Declaration[0]));

--- a/src/main/java/org/openjdk/jextract/impl/TreeMaker.java
+++ b/src/main/java/org/openjdk/jextract/impl/TreeMaker.java
@@ -292,7 +292,7 @@ class TreeMaker {
                     } else {
                         Declaration fieldDecl = createTree(fc);
                         ClangSizeOf.with(fieldDecl, fc.type().kind() == TypeKind.IncompleteArray ?
-                                    0 : fc.type().size() * 8);
+                                0 : fc.type().size() * 8);
                         ClangOffsetOf.with(fieldDecl, parent.type().getOffsetOf(fc.spelling()));
                         ClangAlignOf.with(fieldDecl, fc.type().align() * 8);
                         pendingFields.add(fieldDecl);
@@ -473,8 +473,7 @@ class TreeMaker {
                 if (m.kind() == CursorKind.ParmDecl && !ignoreNestedParams) {
                     collectNestedTypes(m, nestedTypes, ignoreNestedParams);
                 } else {
-                    Declaration decl = createTree(m);
-                    nestedTypes.add(decl);
+                    nestedTypes.add(createTree(m));
                 }
             }
         });

--- a/test/testng/org/openjdk/jextract/test/api/attributes/Test7903674.java
+++ b/test/testng/org/openjdk/jextract/test/api/attributes/Test7903674.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.jextract.test.api.attributes;
+
+import org.testng.annotations.Test;
+import testlib.JextractApiTestBase;
+
+public class Test7903674 extends JextractApiTestBase {
+    @Test
+    public void testEnum() {
+        parse("enum_with_attribute.h");
+    }
+
+    @Test
+    public void testStruct() {
+        parse("struct_with_attribute.h");
+    }
+
+    @Test
+    public void testTypedef() {
+        parse("typedef_with_attribute.h");
+    }
+}

--- a/test/testng/org/openjdk/jextract/test/api/attributes/TestNestedAttributes.java
+++ b/test/testng/org/openjdk/jextract/test/api/attributes/TestNestedAttributes.java
@@ -25,7 +25,7 @@ package org.openjdk.jextract.test.api.attributes;
 import org.testng.annotations.Test;
 import testlib.JextractApiTestBase;
 
-public class Test7903674 extends JextractApiTestBase {
+public class TestNestedAttributes extends JextractApiTestBase {
     @Test
     public void testEnum() {
         parse("enum_with_attribute.h");

--- a/test/testng/org/openjdk/jextract/test/api/attributes/enum_with_attribute.h
+++ b/test/testng/org/openjdk/jextract/test/api/attributes/enum_with_attribute.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+enum __attribute((deprecated)) Foo {
+    CFByteOrderUnknown
+};

--- a/test/testng/org/openjdk/jextract/test/api/attributes/struct_with_attribute.h
+++ b/test/testng/org/openjdk/jextract/test/api/attributes/struct_with_attribute.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+struct __attribute((deprecated)) Foo {
+   int x;
+};

--- a/test/testng/org/openjdk/jextract/test/api/attributes/typedef_with_attribute.h
+++ b/test/testng/org/openjdk/jextract/test/api/attributes/typedef_with_attribute.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+typedef __attribute((deprecated)) struct  { int x; } BAR;


### PR DESCRIPTION
* checking cursor kind of child cursor to be CursorKind.EnumConstantDecl. 
* Piggybacking to fix similar check of record child element kinds to be CursorKind.FieldDecl.  
* Added null check for createTree return value in collectNestedTypes method as well.
* In addition to jextract tests, I ran all samples on Mac OS. All fine with this change. Also, ran jextract script for Mac OS from  https://github.com/manuelbl/JavaDoesUSB.git.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Issue
 * [CODETOOLS-7903674](https://bugs.openjdk.org/browse/CODETOOLS-7903674): jextract should ignore non-enum constants inside enum (**Bug** - P3)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**) ⚠️ Review applies to [aca001e3](https://git.openjdk.org/jextract/pull/221/files/aca001e3a69cd30575bbc1b2f16a8aaf03452584)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/221/head:pull/221` \
`$ git checkout pull/221`

Update a local copy of the PR: \
`$ git checkout pull/221` \
`$ git pull https://git.openjdk.org/jextract.git pull/221/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 221`

View PR using the GUI difftool: \
`$ git pr show -t 221`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/221.diff">https://git.openjdk.org/jextract/pull/221.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/221#issuecomment-1953615221)