### PR TITLE
7903678: regression: jextract tool is broken in the latest early access build

### DIFF
--- a/make/Build.gmk
+++ b/make/Build.gmk
@@ -83,7 +83,7 @@ $(JEXTRACT_IMAGE_DIR): $(BUILD_MODULES_DIR)
 	    --output "$(JEXTRACT_IMAGE_DIR)" \
 	    --module-path "$(BUILD_MODULES_DIR)" \
 	    --add-modules org.openjdk.jextract \
-	    --add-options '\"--enable-native-access=org.openjdk.jextract\" \"--enable-preview\"' \
+	    --add-options "\"--enable-native-access=org.openjdk.jextract\" \"--enable-preview\"" \
 	    --launcher jextract=org.openjdk.jextract/org.openjdk.jextract.JextractTool
 
 $(JEXTRACT_IMAGE_TEST_JDK_DIR): $(JEXTRACT_IMAGE_DIR)


### PR DESCRIPTION
double-quote should be used instead of single-quote around the value of --add-options option.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Issue
 * [CODETOOLS-7903678](https://bugs.openjdk.org/browse/CODETOOLS-7903678): regression: jextract tool is broken in the latest early access build (**Bug** - P2)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/223/head:pull/223` \
`$ git checkout pull/223`

Update a local copy of the PR: \
`$ git checkout pull/223` \
`$ git pull https://git.openjdk.org/jextract.git pull/223/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 223`

View PR using the GUI difftool: \
`$ git pr show -t 223`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/223.diff">https://git.openjdk.org/jextract/pull/223.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/223#issuecomment-1956371213)