### PR TITLE
7903680: Dependency checker doesn't handle function pointers and nested types

### DIFF
--- a/test/testng/org/openjdk/jextract/test/toolprovider/includeDeps/TestNestedBadIncludes.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/includeDeps/TestNestedBadIncludes.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package org.openjdk.jextract.test.toolprovider.includeDeps;
+
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import testlib.JextractToolRunner;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class TestNestedBadIncludes extends JextractToolRunner {
+
+    JextractResult result;
+
+    @BeforeClass
+    public void before() {
+        Path output = getOutputFilePath("TestNestedBadIncludes-nestedBadIncludes.h");
+        Path outputH = getInputFilePath("nested_bad_includes.h");
+        List<String> options = new ArrayList<>();
+        Stream.of(cases()).flatMap(
+                arr -> Stream.of((String)arr[0], (String)arr[1])
+        ).collect(Collectors.toCollection(() -> options));
+        options.add(outputH.toString());
+        result = run(output, options.toArray(new String[0]));
+        result.checkFailure(FAILURE);
+    }
+
+    @Test(dataProvider = "cases")
+    public void testBadIncludes(String includeOption, String badDeclName, String missingDepName) {
+        result.checkContainsOutput("ERROR: " + badDeclName + " depends on " + missingDepName);
+    }
+
+    @DataProvider
+    public static Object[][] cases() {
+        return new Object[][]{
+            {"--include-typedef",        "t_str",          "A" },
+            {"--include-function",       "f_str_arg",      "A" },
+            {"--include-function",       "f_str_ret",      "A" },
+            {"--include-var",            "v_str",          "A" },
+            {"--include-typedef",        "t_fp_arg",       "A" },
+            {"--include-typedef",        "t_fp_ret",       "A" },
+            {"--include-function",       "f_fp_arg",       "A" },
+            {"--include-function",       "f_fp_ret",       "A" },
+            {"--include-var",            "v_fp_arg",       "A" },
+            {"--include-var",            "v_fp_ret",       "A" },
+        };
+    }
+}

--- a/test/testng/org/openjdk/jextract/test/toolprovider/includeDeps/nested_bad_includes.h
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/includeDeps/nested_bad_includes.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+struct A { };
+
+// nested
+
+typedef struct { struct A a; } t_str;
+
+void f_str_arg(struct { struct A a; });
+
+struct { struct A a; } f_str_ret();
+
+struct { struct A a; } v_str;
+
+// function pointers
+
+typedef void (*t_fp_arg)(struct A);
+
+typedef struct A (*t_fp_ret)(int);
+
+void f_fp_arg(void (*p)(struct A));
+
+void f_fp_ret(struct A (*p)(int));
+
+void (*v_fp_arg)(struct A);
+
+struct A (*v_fp_ret)(int);


### PR DESCRIPTION
This patch fixes few issues in the new dependency checker. As usual, the new visitor was skipping a bunch of cases, which resulted in errors not being reported:
* if a variable, function parameter/return, typedef had function pointer type, we did not propagate the visit to the function type
* if there's nested declarations in a typedef, function, variable, we also did not propagate.

I added the required propagation, and a new test which checks that errors are generated in these cornery situations.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Issue
 * [CODETOOLS-7903680](https://bugs.openjdk.org/browse/CODETOOLS-7903680): Dependency checker doesn't handle function pointers and nested types (**Bug** - P3)


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/224/head:pull/224` \
`$ git checkout pull/224`

Update a local copy of the PR: \
`$ git checkout pull/224` \
`$ git pull https://git.openjdk.org/jextract.git pull/224/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 224`

View PR using the GUI difftool: \
`$ git pr show -t 224`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/224.diff">https://git.openjdk.org/jextract/pull/224.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/224#issuecomment-1959183777)