### PR TITLE
7903682: Misformatted --help message

### DIFF
--- a/src/main/resources/org/openjdk/jextract/impl/resources/Messages.properties
+++ b/src/main/resources/org/openjdk/jextract/impl/resources/Messages.properties
@@ -66,16 +66,16 @@ Option                             Description                                  
 --include-union <name>             name of union definition to include                          \n\
 --include-var <name>               name of global variable to include                           \n\
 -l, --library <libspec>            specify a shared library that should be loaded by the        \n\
-\                                  generated header class. If <libspec> starts with ':', then   \n\
+\                                   generated header class. If <libspec> starts with ':', then  \n\
 \                                   what follows is interpreted as a library path. Otherwise,   \n\
 \                                   <libspec> denotes a library name. Examples:                 \n\
 \                                      -l GL                                                    \n\
 \                                      -l :libGL.so.1                                           \n\
 \                                      -l :/usr/lib/libGL.so.1                                  \n\
 --use-system-load-library          libraries specified using -l are loaded in the loader symbol \n\
-                                   lookup (using either System::loadLibrary, or System::load).  \n\
-                                   Useful if the libraries must be loaded from one of the paths \n\
-                                   in 'java.library.path'.                                      \n\ 
+\                                   lookup (using either System::loadLibrary, or System::load). \n\
+\                                   Useful if the libraries must be loaded from one of the paths\n\
+\                                   in 'java.library.path'.                                     \n\
 --output <path>                    specify the directory to place generated files. If this      \n\
 \                                   option is not specified, then current directory is used.    \n\
 --source                           generate java sources                                        \n\


### PR DESCRIPTION
Fix some formatting issues in the `--help` message. The new message looks correct to me now:

```
> .\build\jextract\bin\jextract.bat --help
Usage: jextract <options> <header file>

Option                             Description
------                             -----------
-?, -h, --help                     print help
-D --define-macro <macro>=<value>  define <macro> to <value> (or 1 if <value> omitted)
-I, --include-dir <dir>            add directory to the end of the list of include search paths
--dump-includes <file>             dump included symbols into specified file
--header-class-name <name>         name of the generated header class. If this option is not
                                   specified, then header class name is derived from the header
                                   file name. For example, class "foo_h" for header "foo.h".
--include-function <name>          name of function to include
--include-constant <name>          name of macro or enum constant to include
--include-struct <name>            name of struct definition to include
--include-typedef <name>           name of type definition to include
--include-union <name>             name of union definition to include
--include-var <name>               name of global variable to include
-l, --library <libspec>            specify a shared library that should be loaded by the
                                   generated header class. If <libspec> starts with :, then
                                   what follows is interpreted as a library path. Otherwise,
                                   <libspec> denotes a library name. Examples:
                                      -l GL
                                      -l :libGL.so.1
                                      -l :/usr/lib/libGL.so.1
--use-system-load-library          libraries specified using -l are loaded in the loader symbol
                                   lookup (using either System::loadLibrary, or System::load).
                                   Useful if the libraries must be loaded from one of the paths
                                   in java.library.path.
--output <path>                    specify the directory to place generated files. If this
                                   option is not specified, then current directory is used.
--source                           generate java sources
-t, --target-package <package>     target package name for the generated classes. If this option
                                   is not specified, then unnamed package is used.
--version                          print version information and exit
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Issue
 * [CODETOOLS-7903682](https://bugs.openjdk.org/browse/CODETOOLS-7903682): Misformatted --help message (**Bug** - P4)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/225/head:pull/225` \
`$ git checkout pull/225`

Update a local copy of the PR: \
`$ git checkout pull/225` \
`$ git pull https://git.openjdk.org/jextract.git pull/225/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 225`

View PR using the GUI difftool: \
`$ git pr show -t 225`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/225.diff">https://git.openjdk.org/jextract/pull/225.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/225#issuecomment-1961901675)