### PR TITLE
Remove --source from help message

### DIFF
--- a/src/main/resources/org/openjdk/jextract/impl/resources/Messages.properties
+++ b/src/main/resources/org/openjdk/jextract/impl/resources/Messages.properties
@@ -78,7 +78,6 @@ Option                             Description                                  
 \                                   in 'java.library.path'.                                     \n\
 --output <path>                    specify the directory to place generated files. If this      \n\
 \                                   option is not specified, then current directory is used.    \n\
---source                           generate java sources                                        \n\
 -t, --target-package <package>     target package name for the generated classes. If this option\n\
 \                                   is not specified, then unnamed package is used.             \n\
 --version                          print version information and exit                           \n


### PR DESCRIPTION
This last reference to the `--source` option was missed when https://github.com/openjdk/jextract/pull/186 was fixed.

Removes `--source` from the help message.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Reviewers
 * [Athijegannathan Sundararajan](https://openjdk.org/census#sundar) (@sundararajana - Committer)
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/226/head:pull/226` \
`$ git checkout pull/226`

Update a local copy of the PR: \
`$ git checkout pull/226` \
`$ git pull https://git.openjdk.org/jextract.git pull/226/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 226`

View PR using the GUI difftool: \
`$ git pr show -t 226`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/226.diff">https://git.openjdk.org/jextract/pull/226.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/226#issuecomment-1994493359)