### PR TITLE
Fix javadoc generation and add check to testing suite

### DIFF
--- a/src/main/java/org/openjdk/jextract/clang/libclang/CXCursor.java
+++ b/src/main/java/org/openjdk/jextract/clang/libclang/CXCursor.java
@@ -259,7 +259,7 @@ public class CXCursor {
     }
 
     /**
-     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction) (if any).
+     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction} (if any).
      * The returned segment has size {@code layout().byteSize()}
      */
     public static MemorySegment reinterpret(MemorySegment addr, Arena arena, Consumer<MemorySegment> cleanup) {
@@ -267,7 +267,7 @@ public class CXCursor {
     }
 
     /**
-     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction) (if any).
+     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction} (if any).
      * The returned segment has size {@code elementCount * layout().byteSize()}
      */
     public static MemorySegment reinterpret(MemorySegment addr, long elementCount, Arena arena, Consumer<MemorySegment> cleanup) {

--- a/src/main/java/org/openjdk/jextract/clang/libclang/CXSourceLocation.java
+++ b/src/main/java/org/openjdk/jextract/clang/libclang/CXSourceLocation.java
@@ -214,7 +214,7 @@ public class CXSourceLocation {
     }
 
     /**
-     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction) (if any).
+     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction} (if any).
      * The returned segment has size {@code layout().byteSize()}
      */
     public static MemorySegment reinterpret(MemorySegment addr, Arena arena, Consumer<MemorySegment> cleanup) {
@@ -222,7 +222,7 @@ public class CXSourceLocation {
     }
 
     /**
-     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction) (if any).
+     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction} (if any).
      * The returned segment has size {@code elementCount * layout().byteSize()}
      */
     public static MemorySegment reinterpret(MemorySegment addr, long elementCount, Arena arena, Consumer<MemorySegment> cleanup) {

--- a/src/main/java/org/openjdk/jextract/clang/libclang/CXSourceRange.java
+++ b/src/main/java/org/openjdk/jextract/clang/libclang/CXSourceRange.java
@@ -259,7 +259,7 @@ public class CXSourceRange {
     }
 
     /**
-     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction) (if any).
+     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction} (if any).
      * The returned segment has size {@code layout().byteSize()}
      */
     public static MemorySegment reinterpret(MemorySegment addr, Arena arena, Consumer<MemorySegment> cleanup) {
@@ -267,7 +267,7 @@ public class CXSourceRange {
     }
 
     /**
-     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction) (if any).
+     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction} (if any).
      * The returned segment has size {@code elementCount * layout().byteSize()}
      */
     public static MemorySegment reinterpret(MemorySegment addr, long elementCount, Arena arena, Consumer<MemorySegment> cleanup) {

--- a/src/main/java/org/openjdk/jextract/clang/libclang/CXString.java
+++ b/src/main/java/org/openjdk/jextract/clang/libclang/CXString.java
@@ -181,7 +181,7 @@ public class CXString {
     }
 
     /**
-     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction) (if any).
+     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction} (if any).
      * The returned segment has size {@code layout().byteSize()}
      */
     public static MemorySegment reinterpret(MemorySegment addr, Arena arena, Consumer<MemorySegment> cleanup) {
@@ -189,7 +189,7 @@ public class CXString {
     }
 
     /**
-     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction) (if any).
+     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction} (if any).
      * The returned segment has size {@code elementCount * layout().byteSize()}
      */
     public static MemorySegment reinterpret(MemorySegment addr, long elementCount, Arena arena, Consumer<MemorySegment> cleanup) {

--- a/src/main/java/org/openjdk/jextract/clang/libclang/CXToken.java
+++ b/src/main/java/org/openjdk/jextract/clang/libclang/CXToken.java
@@ -213,7 +213,7 @@ public class CXToken {
     }
 
     /**
-     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction) (if any).
+     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction} (if any).
      * The returned segment has size {@code layout().byteSize()}
      */
     public static MemorySegment reinterpret(MemorySegment addr, Arena arena, Consumer<MemorySegment> cleanup) {
@@ -221,7 +221,7 @@ public class CXToken {
     }
 
     /**
-     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction) (if any).
+     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction} (if any).
      * The returned segment has size {@code elementCount * layout().byteSize()}
      */
     public static MemorySegment reinterpret(MemorySegment addr, long elementCount, Arena arena, Consumer<MemorySegment> cleanup) {

--- a/src/main/java/org/openjdk/jextract/clang/libclang/CXType.java
+++ b/src/main/java/org/openjdk/jextract/clang/libclang/CXType.java
@@ -214,7 +214,7 @@ public class CXType {
     }
 
     /**
-     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction) (if any).
+     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction} (if any).
      * The returned segment has size {@code layout().byteSize()}
      */
     public static MemorySegment reinterpret(MemorySegment addr, Arena arena, Consumer<MemorySegment> cleanup) {
@@ -222,7 +222,7 @@ public class CXType {
     }
 
     /**
-     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction) (if any).
+     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction} (if any).
      * The returned segment has size {@code elementCount * layout().byteSize()}
      */
     public static MemorySegment reinterpret(MemorySegment addr, long elementCount, Arena arena, Consumer<MemorySegment> cleanup) {

--- a/src/main/java/org/openjdk/jextract/clang/libclang/CXUnsavedFile.java
+++ b/src/main/java/org/openjdk/jextract/clang/libclang/CXUnsavedFile.java
@@ -226,7 +226,7 @@ public class CXUnsavedFile {
     }
 
     /**
-     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction) (if any).
+     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction} (if any).
      * The returned segment has size {@code layout().byteSize()}
      */
     public static MemorySegment reinterpret(MemorySegment addr, Arena arena, Consumer<MemorySegment> cleanup) {
@@ -234,7 +234,7 @@ public class CXUnsavedFile {
     }
 
     /**
-     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction) (if any).
+     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction} (if any).
      * The returned segment has size {@code elementCount * layout().byteSize()}
      */
     public static MemorySegment reinterpret(MemorySegment addr, long elementCount, Arena arena, Consumer<MemorySegment> cleanup) {

--- a/src/main/java/org/openjdk/jextract/impl/StructBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/StructBuilder.java
@@ -352,7 +352,7 @@ final class StructBuilder extends ClassSourceBuilder implements OutputFactory.Bu
         appendIndentedLines("""
 
             /**
-             * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction) (if any).
+             * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction} (if any).
              * The returned segment has size {@code layout().byteSize()}
              */
             public static MemorySegment reinterpret(MemorySegment addr, Arena arena, Consumer<MemorySegment> cleanup) {
@@ -360,7 +360,7 @@ final class StructBuilder extends ClassSourceBuilder implements OutputFactory.Bu
             }
 
             /**
-             * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction) (if any).
+             * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction} (if any).
              * The returned segment has size {@code elementCount * layout().byteSize()}
              */
             public static MemorySegment reinterpret(MemorySegment addr, long elementCount, Arena arena, Consumer<MemorySegment> cleanup) {

--- a/test/lib/testlib/TestUtils.java
+++ b/test/lib/testlib/TestUtils.java
@@ -38,6 +38,8 @@ public class TestUtils {
 
     private static final ToolProvider JAVAC_TOOL = ToolProvider.findFirst("javac")
         .orElseThrow(() ->  new RuntimeException("javac tool not found"));
+    private static final ToolProvider JAVADOC_TOOL = ToolProvider.findFirst("javadoc")
+        .orElseThrow(() ->  new RuntimeException("javadoc tool not found"));
 
     public static Loader classLoader(Path... paths) {
         try {
@@ -77,6 +79,18 @@ public class TestUtils {
             if (result != 0) {
                 System.err.println(writer);
                 throw new RuntimeException("javac returns non-zero value");
+            }
+        } catch (Throwable t) {
+            throw new AssertionError(t);
+        }
+        try {
+            System.err.println("javadoc sources @ " + sourcePath.toAbsolutePath());
+            List<String> commands = new ArrayList<>();
+            commands.addAll(files);
+            int result = JAVADOC_TOOL.run(pw, pw, commands.toArray(new String[0]));
+            if (result != 0) {
+                System.err.println(writer);
+                throw new RuntimeException("javadoc returns non-zero value");
             }
         } catch (Throwable t) {
             throw new AssertionError(t);


### PR DESCRIPTION
Motivation: There is bad javadoc being generated. This fixes that and also adds a check to the testing suite to make sure it does not happen again.

Notes: I branched off of jdk22 branch since I would like such fixes to make their way into the jdk22 branch. Please let me know if there is a different base or head I should use.
