### PR TITLE
7903704: Expose addresses of native functions

### DIFF
--- a/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
@@ -156,9 +156,9 @@ class HeaderFileBuilder extends ClassSourceBuilder {
                 private static class \{holderClass} {
                     public static final FunctionDescriptor DESC = \{functionDescriptorString(1, decl.type())};
 
-                    public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(
-                                \{runtimeHelperName()}.findOrThrow("\{nativeName}"),
-                                DESC);
+                    public static final MemorySegment ADDR = \{runtimeHelperName()}.findOrThrow("\{nativeName}");
+
+                    public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(ADDR, DESC);
                 }
                 """);
             appendBlankLine();
@@ -175,6 +175,14 @@ class HeaderFileBuilder extends ClassSourceBuilder {
                     return \{holderClass}.HANDLE;
                 }
                 """);
+            appendBlankLine();
+            emitDocComment(decl, "Address for:");
+            appendLines(STR."""
+                public static MemorySegment \{javaName}$address() {
+                    return \{holderClass}.ADDR;
+                }
+                """);
+            appendBlankLine();
             emitDocComment(decl);
             appendLines(STR."""
             public static \{retType} \{javaName}(\{paramExprs(declType, finalParamNames, isVarArg)}) {
@@ -223,6 +231,13 @@ class HeaderFileBuilder extends ClassSourceBuilder {
                 """);
             decrAlign();
             appendLines(STR."""
+
+                    /**
+                     * {@return the address}
+                     */
+                    public static MemorySegment address() {
+                        return ADDR;
+                    }
 
                     /**
                      * {@return the specialized method handle}

--- a/test/jtreg/TestSplit.java
+++ b/test/jtreg/TestSplit.java
@@ -31,6 +31,7 @@ import static org.testng.Assert.*;
 /*
  * @test
  * @library /lib
+ * @build testlib.TestUtils
  * @run testng/othervm -Djextract.decls.per.header=1 TestSplit
  */
 public class TestSplit extends JextractToolRunner {

--- a/test/jtreg/TestSplit.java
+++ b/test/jtreg/TestSplit.java
@@ -31,7 +31,7 @@ import static org.testng.Assert.*;
 /*
  * @test
  * @library /lib
- * @build testlib.TestUtils
+ * @build testlib.JextractToolRunner testlib.TestUtils
  * @run testng/othervm -Djextract.decls.per.header=1 TestSplit
  */
 public class TestSplit extends JextractToolRunner {

--- a/test/jtreg/generator/allocCallback/TestAllocCallback.java
+++ b/test/jtreg/generator/allocCallback/TestAllocCallback.java
@@ -33,6 +33,7 @@ import static org.testng.Assert.assertEquals;
  * @bug 7903239
  * @summary ofAddress factory of function pointer type is wrong for struct returns
  * @library /lib
+ * @build testlib.TestUtils
  * @run main/othervm JtregJextract -l AllocCallback --use-system-load-library -t test.jextract.allocCallback alloc_callback.h
  * @build TestAllocCallback
  * @run testng/othervm --enable-native-access=ALL-UNNAMED TestAllocCallback

--- a/test/jtreg/generator/arrayAccess/TestArrayAccess.java
+++ b/test/jtreg/generator/arrayAccess/TestArrayAccess.java
@@ -35,6 +35,7 @@ import static test.jextract.arrayaccess.array_access_h.*;
 /*
  * @test
  * @library /lib
+ * @build testlib.TestUtils
  * @run main/othervm JtregJextract -l ArrayAccess --use-system-load-library -t test.jextract.arrayaccess array_access.h
  * @build TestArrayAccess
  * @run testng/othervm --enable-native-access=ALL-UNNAMED TestArrayAccess

--- a/test/jtreg/generator/clinitCycles/TestGlobal.java
+++ b/test/jtreg/generator/clinitCycles/TestGlobal.java
@@ -31,6 +31,7 @@ import java.lang.foreign.ValueLayout;
 /*
  * @test
  * @library /lib
+ * @build testlib.TestUtils
  * @run main/othervm JtregJextract -t test.jextract.clinit --library ClinitGlobal --use-system-load-library -Djextract.decls.per.header=1 clinit_global.h
  * @build TestGlobal
  * @run testng/othervm --enable-native-access=ALL-UNNAMED TestGlobal

--- a/test/jtreg/generator/clinitCycles/TestStruct.java
+++ b/test/jtreg/generator/clinitCycles/TestStruct.java
@@ -31,6 +31,7 @@ import static org.testng.Assert.*;
 /*
  * @test
  * @library /lib
+ * @build testlib.TestUtils
  * @run main/othervm JtregJextract -t test.jextract.clinit -Djextract.decls.per.header=1 clinit_struct.h
  * @build TestStruct
  * @run testng/othervm --enable-native-access=ALL-UNNAMED TestStruct

--- a/test/jtreg/generator/clinitCycles/TestTypedef.java
+++ b/test/jtreg/generator/clinitCycles/TestTypedef.java
@@ -31,6 +31,7 @@ import java.lang.foreign.ValueLayout;
 /*
  * @test
  * @library /lib
+ * @build testlib.TestUtils
  * @run main/othervm JtregJextract -t test.jextract.clinit -Djextract.decls.per.header=1 clinit_typedef.h
  * @build TestTypedef
  * @run testng/othervm --enable-native-access=ALL-UNNAMED TestTypedef

--- a/test/jtreg/generator/dedup/TestDedup.java
+++ b/test/jtreg/generator/dedup/TestDedup.java
@@ -32,6 +32,7 @@ import java.lang.foreign.GroupLayout;
 /*
  * @test
  * @library /lib
+ * @build testlib.TestUtils
  * @run main/othervm JtregJextract -t test.jextract.dedup macro_fields.h
  * @build TestDedup
  * @run testng/othervm --enable-native-access=ALL-UNNAMED TestDedup

--- a/test/jtreg/generator/funcPointerInvokers/TestFuncPointerInvokers.java
+++ b/test/jtreg/generator/funcPointerInvokers/TestFuncPointerInvokers.java
@@ -34,7 +34,8 @@ import test.jextract.funcpointers.*;
 
 /*
  * @test
-  * @library /lib
+ * @library /lib
+ * @build testlib.TestUtils
  * @run main/othervm JtregJextract -l Func --use-system-load-library -t test.jextract.funcpointers func.h
  * @build TestFuncPointerInvokers
  * @run testng/othervm --enable-native-access=ALL-UNNAMED TestFuncPointerInvokers

--- a/test/jtreg/generator/nestedInsideAnon/TestNestedInsideAnon.java
+++ b/test/jtreg/generator/nestedInsideAnon/TestNestedInsideAnon.java
@@ -31,6 +31,7 @@ import static org.testng.Assert.*;
 /*
  * @test
  * @library /lib
+ * @build testlib.TestUtils
  * @run main/othervm JtregJextract -t test.jextract.nested.anon nestedInsideAnon.h
  * @build TestNestedInsideAnon
  * @run testng/othervm --enable-native-access=ALL-UNNAMED TestNestedInsideAnon

--- a/test/jtreg/generator/nestedStructTypedef/TestNestedStructTypedef.java
+++ b/test/jtreg/generator/nestedStructTypedef/TestNestedStructTypedef.java
@@ -32,6 +32,7 @@ import java.lang.foreign.GroupLayout;
 /*
  * @test
  * @library /lib
+ * @build testlib.TestUtils
  * @run main/othervm JtregJextract -t test.jextract.nested.typedef nestedStructTypedef.h
  * @build TestNestedStructTypedef
  * @run testng/othervm --enable-native-access=ALL-UNNAMED TestNestedStructTypedef

--- a/test/jtreg/generator/nestedTypes/TestNestedTypes.java
+++ b/test/jtreg/generator/nestedTypes/TestNestedTypes.java
@@ -34,6 +34,7 @@ import test.jextract.nestedtypes.*;
 /*
  * @test
  * @library /lib
+ * @build testlib.TestUtils
  * @run main/othervm JtregJextract -t test.jextract.nestedtypes nested_types.h
  * @build TestNestedTypes
  * @run testng/othervm --enable-native-access=ALL-UNNAMED TestNestedTypes

--- a/test/jtreg/generator/nestedTypes/TestNestedTypesNames.java
+++ b/test/jtreg/generator/nestedTypes/TestNestedTypesNames.java
@@ -33,6 +33,7 @@ import static org.testng.Assert.assertTrue;
 /*
  * @test
  * @library /lib
+ * @build testlib.TestUtils
  * @run main/othervm JtregJextract -t test.jextract.nestedtypes.names nested_types_names.h
  * @build TestNestedTypesNames
  * @run testng/othervm --enable-native-access=ALL-UNNAMED TestNestedTypesNames

--- a/test/jtreg/generator/nestedTypes/TestNestedTypesUnsupported.java
+++ b/test/jtreg/generator/nestedTypes/TestNestedTypesUnsupported.java
@@ -34,6 +34,7 @@ import static org.testng.Assert.assertTrue;
 /*
  * @test
  * @library /lib
+ * @build testlib.TestUtils
  * @run main/othervm JtregJextract -t test.jextract.nestedtypes.unsupported nested_types_unsupported.h
  * @build TestNestedTypesUnsupported
  * @run testng/othervm --enable-native-access=ALL-UNNAMED TestNestedTypesUnsupported

--- a/test/jtreg/generator/outOfOrder/TestOutOfOrderStruct.java
+++ b/test/jtreg/generator/outOfOrder/TestOutOfOrderStruct.java
@@ -31,6 +31,7 @@ import static org.testng.Assert.*;
 /*
  * @test
  * @library /lib
+ * @build testlib.TestUtils
  * @run main/othervm JtregJextract -t test.jextract.out.struct out_of_order_struct.h
  * @build TestOutOfOrderStruct
  * @run testng/othervm --enable-native-access=ALL-UNNAMED TestOutOfOrderStruct

--- a/test/jtreg/generator/outOfOrder/TestOutOfOrderTypedef.java
+++ b/test/jtreg/generator/outOfOrder/TestOutOfOrderTypedef.java
@@ -31,6 +31,7 @@ import static org.testng.Assert.*;
 /*
  * @test
  * @library /lib
+ * @build testlib.TestUtils
  * @run main/othervm JtregJextract -t test.jextract.out.typedef out_of_order_typedef.h
  * @build TestOutOfOrderTypedef
  * @run testng/othervm --enable-native-access=ALL-UNNAMED TestOutOfOrderTypedef

--- a/test/jtreg/generator/packed/TestPackedStructs.java
+++ b/test/jtreg/generator/packed/TestPackedStructs.java
@@ -33,6 +33,7 @@ import test.jextract.packedstructs.*;
 /*
  * @test
  * @library /lib
+ * @build testlib.TestUtils
  * @run main/othervm JtregJextract -t test.jextract.packedstructs packedstructs.h
  * @build TestPackedStructs
  * @run testng/othervm --enable-native-access=ALL-UNNAMED TestPackedStructs

--- a/test/jtreg/generator/passaddr/TestPassAddr.java
+++ b/test/jtreg/generator/passaddr/TestPassAddr.java
@@ -1,0 +1,41 @@
+/* Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import org.testng.annotations.Test;
+import static test.jextract.passaddr.passaddr_h.*;
+
+/*
+ * @test
+ * @library /lib
+ * @build testlib.TestUtils
+ * @run main/othervm JtregJextract -l passaddr --use-system-load-library -t test.jextract.passaddr passaddr.h
+ * @build TestPassAddr
+ * @run testng/othervm --enable-native-access=ALL-UNNAMED TestPassAddr
+ */
+public class TestPassAddr {
+
+    @Test
+    public void testPackedStructs() {
+        a(b$address());
+        a_variadic(b_variadic.address());
+    }
+}

--- a/test/jtreg/generator/passaddr/libpassaddr.c
+++ b/test/jtreg/generator/passaddr/libpassaddr.c
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include "passaddr.h"
+
+EXPORT void b(void) {}
+EXPORT void a(cb_t cb) {
+    cb();
+}
+
+EXPORT void b_variadic(int x, ...) {}
+EXPORT void a_variadic(cb_var_t cb) {
+    cb(3, 1, 2, 3);
+}

--- a/test/jtreg/generator/passaddr/passaddr.h
+++ b/test/jtreg/generator/passaddr/passaddr.h
@@ -31,6 +31,6 @@ typedef void (*cb_t)(void);
 EXPORT void b(void);
 EXPORT void a(cb_t cb);
 
-typedef void (*cb_var_t)(void);
+typedef void (*cb_var_t)(int x, ...);
 EXPORT void b_variadic(int x, ...);
 EXPORT void a_variadic(cb_var_t cb);

--- a/test/jtreg/generator/passaddr/passaddr.h
+++ b/test/jtreg/generator/passaddr/passaddr.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#ifdef _WIN64
+#define EXPORT __declspec(dllexport)
+#else
+#define EXPORT
+#endif
+
+typedef void (*cb_t)(void);
+EXPORT void b(void);
+EXPORT void a(cb_t cb);
+
+typedef void (*cb_var_t)(void);
+EXPORT void b_variadic(int x, ...);
+EXPORT void a_variadic(cb_var_t cb);

--- a/test/jtreg/generator/reinterpret/TestReinterpret.java
+++ b/test/jtreg/generator/reinterpret/TestReinterpret.java
@@ -35,6 +35,7 @@ import test.jextract.reinterpret.*;
  * @bug 8253102 7903626
  * @summary jextract should emit reinterpret utility method on struct classes
  * @library /lib
+ * @build testlib.TestUtils
  * @run main/othervm JtregJextract -l Reinterpret --use-system-load-library -t test.jextract.reinterpret reinterpret.h
  * @build TestReinterpret
  * @run testng/othervm --enable-native-access=ALL-UNNAMED TestReinterpret

--- a/test/jtreg/generator/structAccessors/TestGlobalStructAccess.java
+++ b/test/jtreg/generator/structAccessors/TestGlobalStructAccess.java
@@ -33,6 +33,7 @@ import static test.jextract.globalaccess.globalStructAccess_h.*;
 /*
  * @test
  * @library /lib
+ * @build testlib.TestUtils
  * @run main/othervm JtregJextract -l StructGlobal --use-system-load-library -t test.jextract.globalaccess globalStructAccess.h
  * @build TestGlobalStructAccess
  * @run testng/othervm --enable-native-access=ALL-UNNAMED TestGlobalStructAccess

--- a/test/jtreg/generator/structAccessors/TestNestedStructAccess.java
+++ b/test/jtreg/generator/structAccessors/TestNestedStructAccess.java
@@ -32,7 +32,8 @@ import static org.testng.Assert.assertEquals;
 
 /*
  * @test
-  * @library /lib
+ * @library /lib
+ * @build testlib.TestUtils
  * @run main/othervm JtregJextract -t test.jextract.nestedaccess nestedStructAccess.h
  * @build TestNestedStructAccess
  * @run testng/othervm --enable-native-access=ALL-UNNAMED TestNestedStructAccess

--- a/test/jtreg/generator/test7903347/LibTest7903347Test.java
+++ b/test/jtreg/generator/test7903347/LibTest7903347Test.java
@@ -29,6 +29,7 @@ import static test.jextract.test7903347.test7903347_h.*;
  * @bug 7903347
  * @summary add long name option for all single letter options and expand help on default values for various options
  * @library /lib
+ * @build testlib.TestUtils
  * @run main/othervm JtregJextract --library Test7903347 --use-system-load-library -t test.jextract.test7903347 test7903347.h
  * @build LibTest7903347Test
  * @run testng/othervm --enable-native-access=ALL-UNNAMED LibTest7903347Test

--- a/test/jtreg/generator/test8239918/LibTest8239918Test.java
+++ b/test/jtreg/generator/test8239918/LibTest8239918Test.java
@@ -30,6 +30,7 @@ import static test.jextract.test8239918.test8239918_h.*;
  * @bug 8239918
  * @summary jextract generates uncompilable code for no argument C function
  * @library /lib
+ * @build testlib.TestUtils
  * @run main/othervm JtregJextract -l Test8239918 --use-system-load-library -t test.jextract.test8239918 test8239918.h
  * @build LibTest8239918Test
  * @run testng/othervm --enable-native-access=ALL-UNNAMED LibTest8239918Test

--- a/test/jtreg/generator/test8240373/Lib8240373Test.java
+++ b/test/jtreg/generator/test8240373/Lib8240373Test.java
@@ -30,6 +30,7 @@ import static test.jextract.test8240373.test8240373_h.*;
  * @bug 8240373
  * @summary Jextract assigns type "Void" to enum macros
  * @library /lib
+ * @build testlib.TestUtils
  * @run main/othervm JtregJextract -t test.jextract.test8240373 test8240373.h
  * @build Lib8240373Test
  * @run testng/othervm --enable-native-access=ALL-UNNAMED Lib8240373Test

--- a/test/jtreg/generator/test8244412/LibTest8244412Test.java
+++ b/test/jtreg/generator/test8244412/LibTest8244412Test.java
@@ -35,6 +35,7 @@ import static test.jextract.test8244412.test8244412_h.*;
 /*
  * @test
  * @library /lib
+ * @build testlib.TestUtils
  * @bug 8244412
  * @summary jextract should generate static utils class for primitive typedefs
  * @run main/othervm JtregJextract -t test.jextract.test8244412 test8244412.h

--- a/test/jtreg/generator/test8244938/Test8244938.java
+++ b/test/jtreg/generator/test8244938/Test8244938.java
@@ -33,6 +33,7 @@ import test.jextract.test8244938.*;
  * @bug 8244938
  * @summary Crash in foreign ABI CallArranger class when a test native function returns a nested struct
  * @library /lib
+ * @build testlib.TestUtils
  * @run main/othervm JtregJextract -l Test8244938 --use-system-load-library -t test.jextract.test8244938 test8244938.h
  * @build Test8244938
  * @run testng/othervm --enable-native-access=ALL-UNNAMED Test8244938

--- a/test/jtreg/generator/test8245003/Test8245003.java
+++ b/test/jtreg/generator/test8245003/Test8245003.java
@@ -34,6 +34,7 @@ import static java.lang.foreign.Linker.*;
  * @bug 8245003
  * @summary jextract does not generate accessor for MemorySegement typed values
  * @library /lib
+ * @build testlib.TestUtils
  * @run main/othervm JtregJextract -l Test8245003 --use-system-load-library -t test.jextract.test8245003 test8245003.h
  * @build Test8245003
  * @run testng/othervm --enable-native-access=ALL-UNNAMED Test8245003

--- a/test/jtreg/generator/test8246341/LibTest8246341Test.java
+++ b/test/jtreg/generator/test8246341/LibTest8246341Test.java
@@ -34,6 +34,7 @@ import static test.jextract.test8246341.test8246341_h.*;
  * @bug 8246341
  * @summary jextract should generate Cpointer utilities class
  * @library /lib
+ * @build testlib.TestUtils
  * @run main/othervm JtregJextract -l Test8246341 --use-system-load-library -t test.jextract.test8246341 test8246341.h
  * @build LibTest8246341Test
  * @run testng/othervm --enable-native-access=ALL-UNNAMED LibTest8246341Test

--- a/test/jtreg/generator/test8246400/LibTest8246400Test.java
+++ b/test/jtreg/generator/test8246400/LibTest8246400Test.java
@@ -34,6 +34,7 @@ import static test.jextract.test8246400.test8246400_h.*;
  * @bug 8246400
  * @summary jextract should generate a utility to manage mutliple MemorySegments
  * @library /lib
+ * @build testlib.TestUtils
  * @run main/othervm JtregJextract -l Test8246400 --use-system-load-library -t test.jextract.test8246400 test8246400.h
  * @build LibTest8246400Test
  * @run testng/othervm --enable-native-access=ALL-UNNAMED  LibTest8246400Test

--- a/test/jtreg/generator/test8249757/LibTest8249757Test.java
+++ b/test/jtreg/generator/test8249757/LibTest8249757Test.java
@@ -28,6 +28,7 @@ import static test.jextract.test8249757.test8249757_h.*;
 /*
  * @test
  * @library /lib
+ * @build testlib.TestUtils
  * @bug 8249757
  * @summary jextract should expose a way to load library from a given absolute path
  * @run main/othervm JtregJextract -l Test8249757 --use-system-load-library -t test.jextract.test8249757 test8249757.h

--- a/test/jtreg/generator/test8252121/Test8252121.java
+++ b/test/jtreg/generator/test8252121/Test8252121.java
@@ -36,6 +36,7 @@ import static test.jextract.arrayparam.arrayparam_h.*;
  * @bug 8252121
  * @summary jextract generated code fails with ABI for typedefed array type parameters
  * @library /lib
+ * @build testlib.TestUtils
  * @run main/othervm JtregJextract -t test.jextract.arrayparam -l Arrayparam --use-system-load-library arrayparam.h
  * @build Test8252121
  * @run testng/othervm --enable-native-access=ALL-UNNAMED Test8252121

--- a/test/jtreg/generator/test8252465/LibTest8252465Test.java
+++ b/test/jtreg/generator/test8252465/LibTest8252465Test.java
@@ -34,6 +34,7 @@ import test.jextract.test8252465.*;
  * @bug 8252465
  * @summary jextract generates wrong layout and varhandle when different structs have same named field
  * @library /lib
+ * @build testlib.TestUtils
  * @run main/othervm JtregJextract -t test.jextract.test8252465 test8252465.h
  * @build LibTest8252465Test
  * @run testng/othervm -Dforeign.restricted=permit LibTest8252465Test

--- a/test/jtreg/generator/test8253390/LibTest8253390Test.java
+++ b/test/jtreg/generator/test8253390/LibTest8253390Test.java
@@ -28,6 +28,7 @@ import static test.jextract.test8253390.test8253390_h.*;
 /*
  * @test
  * @library /lib
+ * @build testlib.TestUtils
  * @bug 8253390
  * @summary jextract should quote string literals
  * @run main/othervm JtregJextract -t test.jextract.test8253390 test8253390.h

--- a/test/jtreg/generator/test8254983/LibTest8254983Test.java
+++ b/test/jtreg/generator/test8254983/LibTest8254983Test.java
@@ -32,6 +32,7 @@ import test.jextract.test8254983.*;
 /*
  * @test
  * @library /lib
+ * @build testlib.TestUtils
  * @bug 8254983
  * @summary jextract fails to hande layout paths nested structs/union
  * @run main/othervm JtregJextract -t test.jextract.test8254983 test8254983.h

--- a/test/jtreg/generator/test8257892/LibUnsupportedTest.java
+++ b/test/jtreg/generator/test8257892/LibUnsupportedTest.java
@@ -39,6 +39,7 @@ import test.jextract.unsupported.*;
 /*
  * @test
  * @library /lib
+ * @build testlib.TestUtils
  * @run main/othervm JtregJextract -l Unsupported --use-system-load-library -t test.jextract.unsupported unsupported.h
  * @build LibUnsupportedTest
  * @run testng/othervm --enable-native-access=ALL-UNNAMED LibUnsupportedTest

--- a/test/jtreg/generator/test8258605/LibTest8258605Test.java
+++ b/test/jtreg/generator/test8258605/LibTest8258605Test.java
@@ -34,6 +34,7 @@ import static test.jextract.test8258605.funcParam_h.*;
  * @bug 8258605
  * @summary regression: jextract can not handle function prototypes as function arguments
  * @library /lib
+ * @build testlib.TestUtils
  * @run main/othervm JtregJextract -l FuncParam --use-system-load-library -t test.jextract.test8258605 funcParam.h
  * @build LibTest8258605Test
  * @run testng/othervm --enable-native-access=ALL-UNNAMED LibTest8258605Test

--- a/test/jtreg/generator/test8261511/Test8261511.java
+++ b/test/jtreg/generator/test8261511/Test8261511.java
@@ -33,6 +33,7 @@ import static test.jextract.test8261511.test8261511_h.*;
  * @bug 8261511
  * @summary jextract does not generate accessor for MemorySegement typed values
  * @library /lib
+ * @build testlib.TestUtils
  * @run main/othervm JtregJextract -l Test8261511 --use-system-load-library -t test.jextract.test8261511 test8261511.h
  * @build Test8261511
  * @run testng/othervm --enable-native-access=ALL-UNNAMED Test8261511

--- a/test/jtreg/generator/test8281764/Test8281764.java
+++ b/test/jtreg/generator/test8281764/Test8281764.java
@@ -30,6 +30,7 @@ import test.jextract.test8281764.*;
  * @bug 8281764
  * @summary jextract does not generate parameter names for function pointer typedefs
  * @library /lib
+ * @build testlib.TestUtils
  * @run main/othervm JtregJextract -l Test8281764 --use-system-load-library -t test.jextract.test8281764 test8281764.h
  * @build Test8281764
  * @run testng/othervm --enable-native-access=ALL-UNNAMED Test8281764

--- a/test/jtreg/generator/test8282235/Test8282235.java
+++ b/test/jtreg/generator/test8282235/Test8282235.java
@@ -30,6 +30,7 @@ import test.jextract.test8282235.*;
  * @bug 8282235
  * @summary jextract crashes when a Java keyword is used in as a function pointer typedef parameter name
  * @library /lib
+ * @build testlib.TestUtils
  * @run main/othervm JtregJextract -l Test8282235 --use-system-load-library -t test.jextract.test8282235 test8282235.h
  * @build Test8282235
  * @run testng/othervm --enable-native-access=ALL-UNNAMED Test8282235

--- a/test/jtreg/generator/testFunctionPointer/LibFuncPtrTest.java
+++ b/test/jtreg/generator/testFunctionPointer/LibFuncPtrTest.java
@@ -31,6 +31,7 @@ import test.jextract.fp.*;
 /*
  * @test
  * @library /lib
+ * @build testlib.TestUtils
  * @run main/othervm JtregJextract -l FuncPtr --use-system-load-library -t test.jextract.fp funcPtr.h
  * @build LibFuncPtrTest
  * @run testng/othervm LibFuncPtrTest

--- a/test/jtreg/generator/testGlobalRedefinition/TestGlobalRedefinition.java
+++ b/test/jtreg/generator/testGlobalRedefinition/TestGlobalRedefinition.java
@@ -32,6 +32,7 @@ import static test.jextract.redef.redef_h.*;
 /*
  * @test
  * @library /lib
+ * @build testlib.TestUtils
  * @run main/othervm JtregJextract -t test.jextract.redef redef.h
  * @build TestGlobalRedefinition
  * @run testng/othervm -Dforeign.restricted=permit TestGlobalRedefinition

--- a/test/jtreg/generator/testLinkageErrors/TestLinkageErrors.java
+++ b/test/jtreg/generator/testLinkageErrors/TestLinkageErrors.java
@@ -32,6 +32,7 @@ import static test.jextract.testLinkageErrors.testLinkageErrors_h.*;
  * @bug 8259473
  * @summary jextract generated code should throw exception for unfound native symbols from calls, variable access, set immediately
  * @library /lib
+ * @build testlib.TestUtils
  * @run main/othervm JtregJextract -t test.jextract.testLinkageErrors testLinkageErrors.h
  * @build TestLinkageErrors
  * @run testng/othervm --enable-native-access=ALL-UNNAMED TestLinkageErrors

--- a/test/jtreg/generator/testPrintf/TestPrintf.java
+++ b/test/jtreg/generator/testPrintf/TestPrintf.java
@@ -36,8 +36,8 @@ import static test.jextract.printf.printf_h.*;
 
 /*
  * @test
- *
  * @library /lib
+ * @build testlib.TestUtils
  * @run main/othervm JtregJextract -t test.jextract.printf -l Printf --use-system-load-library printf.h
  * @build TestPrintf
  * @run testng/othervm --enable-native-access=ALL-UNNAMED TestPrintf

--- a/test/jtreg/generator/testStruct/LibStructTest.java
+++ b/test/jtreg/generator/testStruct/LibStructTest.java
@@ -36,6 +36,7 @@ import test.jextract.struct.*;
 /*
  * @test
  * @library /lib
+ * @build testlib.TestUtils
  * @run main/othervm JtregJextract -l Struct --use-system-load-library -t test.jextract.struct struct.h
  * @build LibStructTest
  * @run testng/othervm --enable-native-access=ALL-UNNAMED LibStructTest

--- a/test/testng/TEST.properties
+++ b/test/testng/TEST.properties
@@ -1,1 +1,2 @@
 lib.dirs = /lib
+lib.build = testlib.TestUtils

--- a/test/testng/TEST.properties
+++ b/test/testng/TEST.properties
@@ -1,2 +1,2 @@
 lib.dirs = /lib
-lib.build = testlib.TestUtils
+lib.build = testlib.JextractApiTestBase testlib.JextractToolRunner testlib.TestUtils


### PR DESCRIPTION
Add accessors for the address of a native function. This follows the jextract principle of exposing all the information that it has.

The address is useful in cases where a user needs to pass the address of a native function to be used as a callback by another (higher-order) native function.

Note: while working on this I noticed that the `TestUtils` file was not being rebuilt when dependent tests were running. Many tests depend on this file to compile generated source code for instance. I've added the needed `@build` tags, and `lib.build` property (the latter only works for the tests under `TestNG.dirs`).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Issue
 * [CODETOOLS-7903704](https://bugs.openjdk.org/browse/CODETOOLS-7903704): Expose addresses of native functions (**Enhancement** - P3)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**) ⚠️ Review applies to [c50d8574](https://git.openjdk.org/jextract/pull/228/files/c50d8574c185395e6062dd48cb316a4f20c5a729)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/228/head:pull/228` \
`$ git checkout pull/228`

Update a local copy of the PR: \
`$ git checkout pull/228` \
`$ git pull https://git.openjdk.org/jextract.git pull/228/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 228`

View PR using the GUI difftool: \
`$ git pr show -t 228`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/228.diff">https://git.openjdk.org/jextract/pull/228.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/228#issuecomment-2032326470)