### PR TITLE
Fix simple warnings

### DIFF
--- a/src/main/java/org/openjdk/jextract/Declaration.java
+++ b/src/main/java/org/openjdk/jextract/Declaration.java
@@ -72,7 +72,7 @@ public interface Declaration {
      * @return {@code true} if the specified object is equal to this Declaration
      */
     @Override
-	boolean equals(Object o);
+    boolean equals(Object o);
 
     /**
      * Returns the hash code value for this Declaration.
@@ -80,7 +80,7 @@ public interface Declaration {
      * @return the hash code value for this Declaration.
      */
     @Override
-	int hashCode();
+    int hashCode();
 
     /**
      * {@return the attributes associated with this declaration}

--- a/src/main/java/org/openjdk/jextract/Declaration.java
+++ b/src/main/java/org/openjdk/jextract/Declaration.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ *  Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  *  This code is free software; you can redistribute it and/or modify it

--- a/src/main/java/org/openjdk/jextract/Declaration.java
+++ b/src/main/java/org/openjdk/jextract/Declaration.java
@@ -71,14 +71,16 @@ public interface Declaration {
      * @param o the object to be compared for equality with this Declaration
      * @return {@code true} if the specified object is equal to this Declaration
      */
-    boolean equals(Object o);
+    @Override
+	boolean equals(Object o);
 
     /**
      * Returns the hash code value for this Declaration.
      *
      * @return the hash code value for this Declaration.
      */
-    int hashCode();
+    @Override
+	int hashCode();
 
     /**
      * {@return the attributes associated with this declaration}

--- a/src/main/java/org/openjdk/jextract/JextractTool.java
+++ b/src/main/java/org/openjdk/jextract/JextractTool.java
@@ -317,7 +317,7 @@ public final class JextractTool {
                        if (argValue.charAt(0) == '-') {
                            throw new OptionException(spec.help());
                        }
-                       values = options.getOrDefault(spec.name(), new ArrayList<String>());
+                       values = options.getOrDefault(spec.name(), new ArrayList<>());
                        values.add(argValue);
                    } else {
                        // no argument value associated with this option.

--- a/src/main/java/org/openjdk/jextract/JextractTool.java
+++ b/src/main/java/org/openjdk/jextract/JextractTool.java
@@ -104,6 +104,7 @@ public final class JextractTool {
     public static Declaration.Scoped parse(List<Path> headers, String... parserOptions) {
         return parseInternal(Logger.DEFAULT, headers, parserOptions);
     }
+
     private static Declaration.Scoped parseInternal(Logger logger, List<Path> headers, String... parserOptions) {
         Path source = headers.size() > 1? generateTmpSource(headers) : headers.iterator().next();
         return new Parser(logger)

--- a/src/main/java/org/openjdk/jextract/Type.java
+++ b/src/main/java/org/openjdk/jextract/Type.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ *  Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  *  This code is free software; you can redistribute it and/or modify it

--- a/src/main/java/org/openjdk/jextract/Type.java
+++ b/src/main/java/org/openjdk/jextract/Type.java
@@ -67,14 +67,16 @@ public interface Type {
      * @param o the object to be compared for equality with this Type
      * @return {@code true} if the specified object is equal to this Type
      */
-    boolean equals(Object o);
+    @Override
+	boolean equals(Object o);
 
     /**
      * Returns the hash code value for this Type.
      *
      * @return the hash code value for this Type.
      */
-    int hashCode();
+    @Override
+	int hashCode();
 
     /**
      * A primitive type.

--- a/src/main/java/org/openjdk/jextract/Type.java
+++ b/src/main/java/org/openjdk/jextract/Type.java
@@ -68,7 +68,7 @@ public interface Type {
      * @return {@code true} if the specified object is equal to this Type
      */
     @Override
-	boolean equals(Object o);
+    boolean equals(Object o);
 
     /**
      * Returns the hash code value for this Type.
@@ -76,7 +76,7 @@ public interface Type {
      * @return the hash code value for this Type.
      */
     @Override
-	int hashCode();
+    int hashCode();
 
     /**
      * A primitive type.

--- a/src/main/java/org/openjdk/jextract/clang/EvalResult.java
+++ b/src/main/java/org/openjdk/jextract/clang/EvalResult.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ *  Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  *  This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,6 @@
 
 package org.openjdk.jextract.clang;
 
-import java.lang.foreign.MemorySegment;
 import java.lang.foreign.MemorySegment;
 import org.openjdk.jextract.clang.libclang.Index_h;
 

--- a/src/main/java/org/openjdk/jextract/clang/Index.java
+++ b/src/main/java/org/openjdk/jextract/clang/Index.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ *  Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  *  This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,6 @@ package org.openjdk.jextract.clang;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
-import java.lang.foreign.SegmentAllocator;
 import org.openjdk.jextract.clang.libclang.Index_h;
 
 import java.nio.file.Path;

--- a/src/main/java/org/openjdk/jextract/clang/LibClang.java
+++ b/src/main/java/org/openjdk/jextract/clang/LibClang.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ *  Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  *  This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
  *  questions.
  *
  */
+
 package org.openjdk.jextract.clang;
 
 import java.lang.foreign.Arena;
@@ -51,14 +52,14 @@ public class LibClang {
 
     static {
         if (!CRASH_RECOVERY) {
-            //this is an hack - needed because clang_toggleCrashRecovery only takes effect _after_ the
+            //this is a hack - needed because clang_toggleCrashRecovery only takes effect _after_ the
             //first call to createIndex.
             try {
                 Linker linker = Linker.nativeLinker();
                 String putenv = IS_WINDOWS ? "_putenv" : "putenv";
                 MethodHandle PUT_ENV = linker.downcallHandle(linker.defaultLookup().find(putenv).get(),
                                 FunctionDescriptor.of(C_INT, C_POINTER));
-                int res = (int) PUT_ENV.invokeExact((MemorySegment)disableCrashRecovery);
+                int res = (int) PUT_ENV.invokeExact(disableCrashRecovery);
             } catch (Throwable ex) {
                 throw new ExceptionInInitializerError(ex);
             }

--- a/src/main/java/org/openjdk/jextract/clang/SourceLocation.java
+++ b/src/main/java/org/openjdk/jextract/clang/SourceLocation.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ *  Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  *  This code is free software; you can redistribute it and/or modify it
@@ -52,7 +52,6 @@ public class SourceLocation extends ClangDisposable.Owned {
                  MemorySegment line, MemorySegment column, MemorySegment offset);
     }
 
-    @SuppressWarnings("unchecked")
     private Location getLocation(LocationFactory fn) {
         try (var arena = Arena.ofConfined()) {
              MemorySegment file = arena.allocate(C_POINTER);

--- a/src/main/java/org/openjdk/jextract/clang/TranslationUnit.java
+++ b/src/main/java/org/openjdk/jextract/clang/TranslationUnit.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ *  Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  *  This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@ package org.openjdk.jextract.clang;
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.MemoryLayout;
-import java.lang.foreign.SegmentAllocator;
 import org.openjdk.jextract.clang.libclang.CXToken;
 import org.openjdk.jextract.clang.libclang.Index_h;
 import org.openjdk.jextract.clang.libclang.CXUnsavedFile;

--- a/src/main/java/org/openjdk/jextract/impl/CommandLine.java
+++ b/src/main/java/org/openjdk/jextract/impl/CommandLine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,7 +33,6 @@ import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 /**

--- a/src/main/java/org/openjdk/jextract/impl/DeclarationImpl.java
+++ b/src/main/java/org/openjdk/jextract/impl/DeclarationImpl.java
@@ -50,12 +50,12 @@ public abstract class DeclarationImpl implements Declaration {
     }
 
     @Override
-	public String toString() {
+    public String toString() {
         return new PrettyPrinter().print(this);
     }
 
     @Override
-	public String name() {
+    public String name() {
         return name;
     }
 

--- a/src/main/java/org/openjdk/jextract/impl/DeclarationImpl.java
+++ b/src/main/java/org/openjdk/jextract/impl/DeclarationImpl.java
@@ -49,11 +49,13 @@ public abstract class DeclarationImpl implements Declaration {
         this.pos = pos;
     }
 
-    public String toString() {
+    @Override
+	public String toString() {
         return new PrettyPrinter().print(this);
     }
 
-    public String name() {
+    @Override
+	public String name() {
         return name;
     }
 

--- a/src/main/java/org/openjdk/jextract/impl/DuplicateFilter.java
+++ b/src/main/java/org/openjdk/jextract/impl/DuplicateFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,9 +27,7 @@ package org.openjdk.jextract.impl;
 import org.openjdk.jextract.Declaration;
 import org.openjdk.jextract.impl.DeclarationImpl.Skip;
 
-import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 /*

--- a/src/main/java/org/openjdk/jextract/impl/IncludeFilter.java
+++ b/src/main/java/org/openjdk/jextract/impl/IncludeFilter.java
@@ -25,8 +25,6 @@
 package org.openjdk.jextract.impl;
 
 import org.openjdk.jextract.Declaration;
-import org.openjdk.jextract.Type;
-import org.openjdk.jextract.Type.Delegated;
 import org.openjdk.jextract.impl.DeclarationImpl.Skip;
 
 /*

--- a/src/main/java/org/openjdk/jextract/impl/IncludeHelper.java
+++ b/src/main/java/org/openjdk/jextract/impl/IncludeHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,6 @@ import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.Comparator;
 import java.util.EnumMap;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/org/openjdk/jextract/impl/MacroParserImpl.java
+++ b/src/main/java/org/openjdk/jextract/impl/MacroParserImpl.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ *  Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  *  This code is free software; you can redistribute it and/or modify it
@@ -289,7 +289,7 @@ class MacroParserImpl implements AutoCloseable {
             void update() {
                 macrosByMangledName.remove(mangledName());
             }
-        };
+        }
 
         void enterMacro(String name, String[] tokens, Position position) {
             Unparsed unparsed = new Unparsed(name, tokens, position);

--- a/src/main/java/org/openjdk/jextract/impl/TypeImpl.java
+++ b/src/main/java/org/openjdk/jextract/impl/TypeImpl.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ *  Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  *  This code is free software; you can redistribute it and/or modify it
@@ -72,7 +72,7 @@ public abstract class TypeImpl implements Type {
         public boolean isErroneous() {
             return true;
         }
-    };
+    }
 
     public static final class PrimitiveImpl extends TypeImpl implements Type.Primitive {
 

--- a/src/main/java/org/openjdk/jextract/impl/UnsupportedFilter.java
+++ b/src/main/java/org/openjdk/jextract/impl/UnsupportedFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,10 +36,7 @@ import org.openjdk.jextract.Type;
 import org.openjdk.jextract.Type.Declared;
 import org.openjdk.jextract.impl.DeclarationImpl.AnonymousStruct;
 import org.openjdk.jextract.impl.DeclarationImpl.ClangSizeOf;
-import org.openjdk.jextract.impl.DeclarationImpl.JavaName;
 import org.openjdk.jextract.impl.DeclarationImpl.Skip;
-
-import java.io.PrintWriter;
 
 /*
  * This visitor marks a number of unsupported construct so that they are skipped by code generation.

--- a/src/main/java/org/openjdk/jextract/impl/Utils.java
+++ b/src/main/java/org/openjdk/jextract/impl/Utils.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ *  Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  *  This code is free software; you can redistribute it and/or modify it
@@ -222,7 +222,7 @@ class Utils {
             case Type.Function _ -> MemorySegment.class;
             default -> throw new UnsupportedOperationException(type.toString());
         };
-    };
+    }
 
     public static Class<?> carrierFor(Type.Primitive p) {
         return switch (p.kind()) {
@@ -237,7 +237,7 @@ class Utils {
             case Double -> double.class;
             case LongDouble -> {
                 if (TypeImpl.IS_WINDOWS) {
-                    yield (Class<?>) double.class;
+                    yield double.class;
                 } else {
                     throw new UnsupportedOperationException(p.toString());
                 }


### PR DESCRIPTION
Fixes for warnings:

* Missing `@Override` annotations
* Unnecessary code (casts and semicolons)
* Unused imports

There are more complicated warnings that should be looked at separately like resource leaks, potential null access, and unused variables.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/229/head:pull/229` \
`$ git checkout pull/229`

Update a local copy of the PR: \
`$ git checkout pull/229` \
`$ git pull https://git.openjdk.org/jextract.git pull/229/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 229`

View PR using the GUI difftool: \
`$ git pr show -t 229`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/229.diff">https://git.openjdk.org/jextract/pull/229.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/229#issuecomment-2041526107)