### PR TITLE
Fix compilation failure after #229

### DIFF
--- a/src/main/java/org/openjdk/jextract/impl/Utils.java
+++ b/src/main/java/org/openjdk/jextract/impl/Utils.java
@@ -237,7 +237,7 @@ class Utils {
             case Double -> double.class;
             case LongDouble -> {
                 if (TypeImpl.IS_WINDOWS) {
-                    yield double.class;
+                    yield (Class<?>) double.class;
                 } else {
                     throw new UnsupportedOperationException(p.toString());
                 }


### PR DESCRIPTION
Changes in https://github.com/openjdk/jextract/pull/229 result in a compilation failure.

A cast that looks redundant was removed, but is actually needed for the code to compile.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Reviewers
 * [Nir Lisker](https://openjdk.org/census#nlisker) (@nlisker - no project role)
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/230/head:pull/230` \
`$ git checkout pull/230`

Update a local copy of the PR: \
`$ git checkout pull/230` \
`$ git pull https://git.openjdk.org/jextract.git pull/230/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 230`

View PR using the GUI difftool: \
`$ git pr show -t 230`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/230.diff">https://git.openjdk.org/jextract/pull/230.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/230#issuecomment-2041608389)