### PR TITLE
7903697: jextract doesn't use name in asm label attribute

### DIFF
--- a/test/jtreg/generator/aliases/TestAliasAdd.java
+++ b/test/jtreg/generator/aliases/TestAliasAdd.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import static test.jextract.alias_add.libAsmSymbol_h.*;
+
+import org.testng.annotations.Test;
+import static org.testng.Assert.assertEquals;
+
+/*
+ * @test
+ * @requires os.family != "windows"
+ * @library /lib
+ * @build testlib.TestUtils
+ * @run main/othervm JtregJextract -l AsmSymbol -DADD --use-system-load-library -t test.jextract.alias_add libAsmSymbol.h
+ * @build TestAliasAdd
+ * @run testng/othervm --enable-native-access=ALL-UNNAMED TestAliasAdd
+ */
+public class TestAliasAdd {
+
+    @Test
+    public void checkGlobalVar() {
+        assertEquals(1, foo());
+    }
+
+    @Test
+    public void checkGlobalFunction() {
+        assertEquals(3, func(1, 2));
+    }
+}

--- a/test/jtreg/generator/aliases/TestAliasMul.java
+++ b/test/jtreg/generator/aliases/TestAliasMul.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import static test.jextract.alias_mul.libAsmSymbol_h.*;
+
+import org.testng.annotations.Test;
+import static org.testng.Assert.assertEquals;
+
+/*
+ * @test
+ * @requires os.family != "windows"
+ * @library /lib
+ * @build testlib.TestUtils
+ * @run main/othervm JtregJextract -l AsmSymbol --use-system-load-library -t test.jextract.alias_mul libAsmSymbol.h
+ * @build TestAliasMul
+ * @run testng/othervm --enable-native-access=ALL-UNNAMED TestAliasMul
+ */
+public class TestAliasMul {
+
+    @Test
+    public void checkGlobalVar() {
+        assertEquals(2, foo());
+    }
+
+    @Test
+    public void checkGlobalFunction() {
+        assertEquals(2, func(1, 2));
+    }
+}

--- a/test/jtreg/generator/aliases/libAsmSymbol.c
+++ b/test/jtreg/generator/aliases/libAsmSymbol.c
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2019, 2024 Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+
+#include "libAsmSymbol.h"
+
+EXPORT int fooA = 1;
+EXPORT int funcA (int x, int y) {
+    return x + y;
+}
+
+EXPORT int fooB = 2;
+EXPORT int funcB (int x, int y) {
+    return x * y;
+}

--- a/test/jtreg/generator/aliases/libAsmSymbol.h
+++ b/test/jtreg/generator/aliases/libAsmSymbol.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2019, 2024 Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#ifdef _WIN64
+  #ifdef IMPL
+    #define EXPORT __declspec(dllexport)
+  #else
+    #define EXPORT __declspec(dllimport)
+  #endif // IMPL
+#else
+#define EXPORT
+#endif //_WIN64
+
+#if __APPLE__
+#define ALIAS(sym) __asm("_" #sym)
+#else
+#define ALIAS(sym) __asm__(#sym)
+#endif // __APPLE__
+
+#ifdef ADD
+
+EXPORT extern int foo ALIAS(fooA);
+EXPORT int func (int x, int y) ALIAS(funcA);
+
+#else
+
+EXPORT extern int foo ALIAS(fooB);
+EXPORT int func (int x, int y) ALIAS(funcB);
+
+#endif // ADD

--- a/test/jtreg/generator/aliases/libAsmSymbol.h
+++ b/test/jtreg/generator/aliases/libAsmSymbol.h
@@ -22,14 +22,10 @@
  */
 
 #ifdef _WIN64
-  #ifdef IMPL
-    #define EXPORT __declspec(dllexport)
-  #else
-    #define EXPORT __declspec(dllimport)
-  #endif // IMPL
+#define EXPORT __declspec(dllexport)
 #else
 #define EXPORT
-#endif //_WIN64
+#endif
 
 #if __APPLE__
 #define ALIAS(sym) __asm("_" #sym)


### PR DESCRIPTION
This PR restores a functionality that was available in a (much) older version of jextract.

Basically, some library symbols can have a C name that differs from the symbol found in the shared library. This is typically done using an attribute (AsmLabelAttr). We already have code to parse declaration attributes, but when we switched to the new FFM-based jextract, we didn't update code generation to use the aliased name for the symbol lookup, if one was available.

I've resurrected the old test to check this functionality, with some changes: the original test also tested Windows support, but that seems less important, given that Windows doesn't really have an equivalent feature/attribute.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Issue
 * [CODETOOLS-7903697](https://bugs.openjdk.org/browse/CODETOOLS-7903697): jextract doesn't use name in asm label attribute (**Bug** - P2)


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - Committer) ⚠️ Review applies to [7d07c827](https://git.openjdk.org/jextract/pull/232/files/7d07c82752a9d434cb69ee9bf6889f07d8c39e5c)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/232/head:pull/232` \
`$ git checkout pull/232`

Update a local copy of the PR: \
`$ git checkout pull/232` \
`$ git pull https://git.openjdk.org/jextract.git pull/232/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 232`

View PR using the GUI difftool: \
`$ git pr show -t 232`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/232.diff">https://git.openjdk.org/jextract/pull/232.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/232#issuecomment-2045808636)