### PR TITLE
Use compiler switch to filter out `__asm` statements on Windows

### DIFF
--- a/test/jtreg/generator/aliases/libAsmSymbol.c
+++ b/test/jtreg/generator/aliases/libAsmSymbol.c
@@ -24,12 +24,12 @@
 
 #include "libAsmSymbol.h"
 
-EXPORT int fooA = 1;
-EXPORT int funcA (int x, int y) {
+int fooA = 1;
+int funcA (int x, int y) {
     return x + y;
 }
 
-EXPORT int fooB = 2;
-EXPORT int funcB (int x, int y) {
+int fooB = 2;
+int funcB (int x, int y) {
     return x * y;
 }

--- a/test/jtreg/generator/aliases/libAsmSymbol.h
+++ b/test/jtreg/generator/aliases/libAsmSymbol.h
@@ -21,11 +21,7 @@
  * questions.
  */
 
-#ifdef _WIN64
-#define EXPORT __declspec(dllexport)
-#else
-#define EXPORT
-#endif
+#ifndef _WIN64
 
 #if __APPLE__
 #define ALIAS(sym) __asm("_" #sym)
@@ -35,12 +31,14 @@
 
 #ifdef ADD
 
-EXPORT extern int foo ALIAS(fooA);
-EXPORT int func (int x, int y) ALIAS(funcA);
+extern int foo ALIAS(fooA);
+int func (int x, int y) ALIAS(funcA);
 
 #else
 
-EXPORT extern int foo ALIAS(fooB);
-EXPORT int func (int x, int y) ALIAS(funcB);
+extern int foo ALIAS(fooB);
+int func (int x, int y) ALIAS(funcB);
 
 #endif // ADD
+
+#endif // _WIN64


### PR DESCRIPTION
A newly added test uses `__asm` statements which are not supported by MSVC. I failed to catch this during the review of that patch, and this result in a compilation failure on Windows in the most recent version of the code.

The test that needs this native code doesn't run on Windows any way, so I've removed all the Windows-isms from the native code, and instead just disabled compilation of the problematic code on Windows using a compiler switch.

Alternatively, we could modify the `CMakeLists.txt` file to disable building this particular library on Windows, if that's preferred.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/234/head:pull/234` \
`$ git checkout pull/234`

Update a local copy of the PR: \
`$ git checkout pull/234` \
`$ git pull https://git.openjdk.org/jextract.git pull/234/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 234`

View PR using the GUI difftool: \
`$ git pr show -t 234`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/234.diff">https://git.openjdk.org/jextract/pull/234.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/234#issuecomment-2048089109)