### PR TITLE
Add guide section about array types

### DIFF
--- a/doc/GUIDE.md
+++ b/doc/GUIDE.md
@@ -16,7 +16,7 @@ so that a client can instead immediately start using the native libraries they a
 interested in.
 
 This guide shows how to run the jextract tool, and how to use the Java code that it generates.
-The samples under the [`samples`](samples) direcotry are also a good source of examples.
+The samples under the [`samples`](../samples) direcotry are also a good source of examples.
 
 Note that at this time, jextract (and FFM) only supports C header files. If you have a
 library written in another language, see the section on [other languages](#other-languages).

--- a/doc/GUIDE.md
+++ b/doc/GUIDE.md
@@ -640,7 +640,7 @@ Jextract generates:
   type is [`SequenceLayout`].
 2. a `$dimensions` meta-data accessor, which returns the _dimensions_ of the array type.
   This method returns a `long[]` where each element represents the length of a dimension
-  of the array type. For instance, in the example `FOO_ARRAY` has a two dimension, whose
+  of the array type. For instance, in the example `FOO_ARRAY` has two dimensions, whose
   lengths are `3` and `5`, so the `FOO_ARRAY$dimensions` method will return a `long[]`
   with two elements whose values are `3` and `5` in that order.
 3. a getter and setter pair for the array variable. Note that the getter replaces the usual

--- a/doc/GUIDE.md
+++ b/doc/GUIDE.md
@@ -624,31 +624,31 @@ Jextract generates a few extra methods that are useful for working with arrays:
 ```java
 // mylib_h.java
 
-public static SequenceLayout FOO_ARRAY$layout() { ... } // 1
-public static long[] FOO_ARRAY$dimensions() { ... } // 2
+public static MemorySegment FOO_ARRAY() { ... } // 1
+public static void FOO_ARRAY(MemorySegment varValue) { ... } // 1
 
-public static MemorySegment FOO_ARRAY() { ... } // 3
-public static void FOO_ARRAY(MemorySegment varValue) { ... } // 3
+public static int FOO_ARRAY(long index0, long index1) { ... } // 2
+public static void FOO_ARRAY(long index0, long index1, int varValue) { ... } // 2
 
-public static int FOO_ARRAY(long index0, long index1) { ... } // 4
-public static void FOO_ARRAY(long index0, long index1, int varValue) { ... } // 4
+public static SequenceLayout FOO_ARRAY$layout() { ... } // 3
+public static long[] FOO_ARRAY$dimensions() { ... } // 4
 ```
 
 Jextract generates:
 
-1. a layout accessor, just like we have for a regular variable, but note that the return
-  type is [`SequenceLayout`].
-2. a `$dimensions` meta-data accessor, which returns the _dimensions_ of the array type.
-  This method returns a `long[]` where each element represents the length of a dimension
-  of the array type. For instance, in the example `FOO_ARRAY` has two dimensions, whose
-  lengths are `3` and `5`, so the `FOO_ARRAY$dimensions` method will return a `long[]`
-  with two elements whose values are `3` and `5` in that order.
-3. a getter and setter pair for the array variable. Note that the getter replaces the usual
+1. a getter and setter pair for the array variable. Note that the getter replaces the usual
   `XYZ$segment` method that jextract generates for global variables, as the results of the
   two methods would be identical.
-4. a pair of _indexed_ getter and setter methods. These methods can be used to get or set
+2. a pair of _indexed_ getter and setter methods. These methods can be used to get or set
   a single element of the array. Each leading `long` parameter represents an index of one
   of the dimensions of the array.
+3. a layout accessor, just like we have for a regular variable, but note that the return
+  type is [`SequenceLayout`].
+4. a `$dimensions` meta-data accessor, which returns the _dimensions_ of the array type.
+  This method returns a `long[]` where each element represents the length of a dimension
+  of the array type. For instance, in the example `FOO_ARRAY` has two dimensions - `3` and
+  `5` respectively - so the `FOO_ARRAY$dimensions` method will return a `long[]`
+  with two elements whose values are `3` and `5` in that order.
 
 For struct and union fields, the generate methods are comparable, with an additional
 leading `MemorySegment` parameter for the getters and setters, representing the struct or

--- a/doc/GUIDE.md
+++ b/doc/GUIDE.md
@@ -638,7 +638,7 @@ Jextract generates:
 
 1. a layout accessor, just like we have for a regular variable, but note that the return
   type is [`SequenceLayout`].
-2. a `$dimensions` meta-deta accessor, which returns the _dimensions_ of the array type.
+2. a `$dimensions` meta-data accessor, which returns the _dimensions_ of the array type.
   This method returns a `long[]` where each element represents the length of a dimension
   of the array type. For instance, in the example `FOO_ARRAY` has a two dimension, whose
   lengths are `3` and `5`, so the `FOO_ARRAY$dimensions` method will return a `long[]`


### PR DESCRIPTION
The current guide is missing a section discussing the special handling of array types, for which jextract generates a `$dimensions()` accessor, and indexed getters and setters.

This PR adds a section to the guide discussing this. I've put it at the end of the "Using The Code Generated By Jextract" section. I've put it before the section on nested types though, since it's a little more important I think.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**) ⚠️ Review applies to [635d95f6](https://git.openjdk.org/jextract/pull/236/files/635d95f67062ad2639bf307d7f7a70871b0c9fa6)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/236/head:pull/236` \
`$ git checkout pull/236`

Update a local copy of the PR: \
`$ git checkout pull/236` \
`$ git pull https://git.openjdk.org/jextract.git pull/236/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 236`

View PR using the GUI difftool: \
`$ git pr show -t 236`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/236.diff">https://git.openjdk.org/jextract/pull/236.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/236#issuecomment-2059477274)