### PR TITLE
7903723: Jextract binary should live in a bin folder

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,8 @@ def jmods_dir = "$buildDir/jmods"
 def jextract_jmod_file = "$jmods_dir/org.openjdk.jextract.jmod"
 def jextract_jmod_inputs = "$buildDir/jmod_inputs"
 def jextract_app_dir = "$buildDir/jextract"
+def jextract_runtime_dir = "$jextract_app_dir/runtime"
+def jextract_bin_dir = "$jextract_app_dir/bin"
 def clang_include_dir = "${llvm_home}/lib/clang/${clang_version}/include"
 checkPath(clang_include_dir)
 def os_lib_dir = Os.isFamily(Os.FAMILY_WINDOWS)? "bin" : "lib"
@@ -118,13 +120,14 @@ task createJextractImage(type: Exec) {
 
     doFirst {
         delete(jextract_app_dir)
+        project.mkdir "${jextract_bin_dir}"
     }
 
     executable = "${jdk22_home}/bin/jlink"
     args = [
          "--module-path=$jmods_dir",
          "--add-modules=org.openjdk.jextract",
-         "--output=${jextract_app_dir}/runtime",
+         "--output=${jextract_runtime_dir}",
          "--strip-debug", "--no-man-pages", "--no-header-files",
          "--add-options",
          "${quote_jlink_opts}"
@@ -132,7 +135,7 @@ task createJextractImage(type: Exec) {
 
     doLast {
         // Add launcher scripts
-        Path unixOut = Path.of("${jextract_app_dir}/jextract");
+        Path unixOut = Path.of("${jextract_bin_dir}/jextract");
         Files.copy(Path.of("$projectDir/src/main/jextract"), unixOut);
         if (unixOut.getFileSystem().supportedFileAttributeViews().contains("posix")) {
             Set<PosixFilePermission> perms = Files.getPosixFilePermissions(unixOut);
@@ -142,7 +145,7 @@ task createJextractImage(type: Exec) {
             Files.setPosixFilePermissions(unixOut, perms);
         }
 
-        Files.copy(Path.of("$projectDir/src/main/jextract.bat"), Path.of("${jextract_app_dir}/jextract.bat"))
+        Files.copy(Path.of("$projectDir/src/main/jextract.bat"), Path.of("${jextract_bin_dir}/jextract.bat"))
     }
 }
 
@@ -153,7 +156,7 @@ assemble.dependsOn(createJextractImage)
 task verify(type: Exec) {
     dependsOn createJextractImage
 
-    executable = "${jextract_app_dir}/jextract${os_script_extension}"
+    executable = "${jextract_bin_dir}/jextract${os_script_extension}"
     args = [ "test.h", "--output", "$buildDir/integration_test" ]
 }
 

--- a/src/main/jextract
+++ b/src/main/jextract
@@ -1,3 +1,3 @@
 #!/bin/sh
-DIR=`dirname $0`
-$DIR/runtime/bin/java $JEXTRACT_JAVA_OPTIONS -m org.openjdk.jextract/org.openjdk.jextract.JextractTool "$@"
+ROOT=`dirname $0`/..
+$ROOT/runtime/bin/java $JEXTRACT_JAVA_OPTIONS -m org.openjdk.jextract/org.openjdk.jextract.JextractTool "$@"

--- a/src/main/jextract.bat
+++ b/src/main/jextract.bat
@@ -1,2 +1,2 @@
-@set DIR=%~dp0
-@"%DIR%\runtime\bin\java" %JEXTRACT_JAVA_OPTIONS% -m org.openjdk.jextract/org.openjdk.jextract.JextractTool %*
+@set ROOT=%~dp0..
+@"%ROOT%\runtime\bin\java" %JEXTRACT_JAVA_OPTIONS% -m org.openjdk.jextract/org.openjdk.jextract.JextractTool %*


### PR DESCRIPTION
This PR reintroduces the `bin` folder for jextract launcher scripts.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Issue
 * [CODETOOLS-7903723](https://bugs.openjdk.org/browse/CODETOOLS-7903723): Jextract binary should live in a bin folder (**Enhancement** - P3)


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/242/head:pull/242` \
`$ git checkout pull/242`

Update a local copy of the PR: \
`$ git checkout pull/242` \
`$ git pull https://git.openjdk.org/jextract.git pull/242/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 242`

View PR using the GUI difftool: \
`$ git pr show -t 242`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/242.diff">https://git.openjdk.org/jextract/pull/242.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/242#issuecomment-2107581004)