### PR TITLE
Remove duplicate copies of libclang on Linux 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,7 +73,7 @@ task copyLibClang(type: Sync) {
 
     // make sure we only pick up the "real" shared library file from LLVM installation
     // (e.g. exclude symlinks on Linux)
-    def clang_path_include = Os.isFamily(Os.FAMILY_UNIX) ?
+    def clang_path_include = (Os.isFamily(Os.FAMILY_UNIX) && !Os.isFamily(Os.FAMILY_MAC)) ?
             "libclang.so.${clang_version}" : "*clang*"
 
     from("${libclang_dir}") {

--- a/build.gradle
+++ b/build.gradle
@@ -71,11 +71,18 @@ jar {
 task copyLibClang(type: Sync) {
     into("$buildDir/jmod_inputs")
 
+    // make sure we only pick up the "real" shared library file from LLVM installation
+    // (e.g. exclude symlinks on Linux)
+    def clang_path_include = Os.isFamily(Os.FAMILY_UNIX) ?
+            "libclang.so.${clang_version}" : "*clang*"
+
     from("${libclang_dir}") {
-        include("*clang.*")
+        include(clang_path_include)
         include("libLLVM.*")
         exclude("clang.exe")
         into("libs")
+        // make sure we drop shared library version name (Linux only)
+        rename("libclang.so.${clang_version}", "libclang.so")
     }
 
     from("$clang_include_dir") {

--- a/make/Build.gmk
+++ b/make/Build.gmk
@@ -73,7 +73,8 @@ $(BUILD_MODULES_DIR): $(BUILD_CLASSES_DIR)
 	$(CP) "$(LIBCLANG_LIB_DIR)/$(LIBCLANG_COPY_PATH)" "$(JEXTRACT_JMOD_LIBS_DIR)"
 	$(MKDIR) -p "$(JEXTRACT_JMOD_CONF_DIR)/jextract"
 	$(CP) "$(LIBCLANG_INCLUDE_DIR)/"*.h "$(JEXTRACT_JMOD_CONF_DIR)/jextract/"
-	$(MV) "$(JEXTRACT_JMOD_LIBS_DIR)/libclang.so.$(LIBCLANG_VERSION)" "$(JEXTRACT_JMOD_LIBS_DIR)/libclang.so"
+	[ -f $(JEXTRACT_JMOD_LIBS_DIR)/libclang.so.$(LIBCLANG_VERSION) ] && \
+	  $(MV) "$(JEXTRACT_JMOD_LIBS_DIR)/libclang.so.$(LIBCLANG_VERSION)" "$(JEXTRACT_JMOD_LIBS_DIR)/libclang.so"
 
 	# create jextract jmod file
 	$(FIXPATH) $(PANAMA_JAVA_HOME)/bin/jmod \

--- a/make/Build.gmk
+++ b/make/Build.gmk
@@ -58,15 +58,22 @@ $(BUILD_CLASSES_DIR):
 	$(CP) -r src/main/java/META-INF $(BUILD_CLASSES_DIR)
 	$(CP) -r src/main/resources/org/openjdk/jextract/impl/resources $(BUILD_CLASSES_DIR)/org/openjdk/jextract/impl
 
+ifeq ($(PLATFORM_OS), linux)
+  LIBCLANG_COPY_PATH := "libclang.so.$(LIBCLANG_VERSION)"
+else
+  LIBCLANG_COPY_PATH := "*clang.*"
+endif
+
 $(BUILD_MODULES_DIR): $(BUILD_CLASSES_DIR)
 	$(MKDIR) -p $(BUILD_MODULES_DIR)
 	$(MKDIR) -p $(JEXTRACT_JMOD_LIBS_DIR)
 	$(MKDIR) -p $(JEXTRACT_JMOD_CONF_DIR)
 
 	# Copy libclang library and header files
-	$(CP) "$(LIBCLANG_LIB_DIR)/"*clang.* "$(JEXTRACT_JMOD_LIBS_DIR)"
+	$(CP) "$(LIBCLANG_LIB_DIR)/$(LIBCLANG_COPY_PATH)" "$(JEXTRACT_JMOD_LIBS_DIR)"
 	$(MKDIR) -p "$(JEXTRACT_JMOD_CONF_DIR)/jextract"
 	$(CP) "$(LIBCLANG_INCLUDE_DIR)/"*.h "$(JEXTRACT_JMOD_CONF_DIR)/jextract/"
+	$(MV) "$(JEXTRACT_JMOD_LIBS_DIR)/libclang.so.$(LIBCLANG_VERSION)" "$(JEXTRACT_JMOD_LIBS_DIR)/libclang.so"
 
 	# create jextract jmod file
 	$(FIXPATH) $(PANAMA_JAVA_HOME)/bin/jmod \

--- a/make/Build.gmk
+++ b/make/Build.gmk
@@ -73,7 +73,7 @@ $(BUILD_MODULES_DIR): $(BUILD_CLASSES_DIR)
 	$(CP) "$(LIBCLANG_LIB_DIR)/$(LIBCLANG_COPY_PATH)" "$(JEXTRACT_JMOD_LIBS_DIR)"
 	$(MKDIR) -p "$(JEXTRACT_JMOD_CONF_DIR)/jextract"
 	$(CP) "$(LIBCLANG_INCLUDE_DIR)/"*.h "$(JEXTRACT_JMOD_CONF_DIR)/jextract/"
-	[ -f $(JEXTRACT_JMOD_LIBS_DIR)/libclang.so.$(LIBCLANG_VERSION) ] && \
+	[ ! -f $(JEXTRACT_JMOD_LIBS_DIR)/libclang.so.$(LIBCLANG_VERSION) ] || \
 	  $(MV) "$(JEXTRACT_JMOD_LIBS_DIR)/libclang.so.$(LIBCLANG_VERSION)" "$(JEXTRACT_JMOD_LIBS_DIR)/libclang.so"
 
 	# create jextract jmod file

--- a/make/Common.gmk
+++ b/make/Common.gmk
@@ -107,6 +107,7 @@ MKDIR := mkdir
 AWK := awk
 EXPR := expr
 CP := cp
+MV := mv
 CD := cd
 TAR := tar
 PRINTF := printf


### PR DESCRIPTION
On Linux, libclang.so is found in three forms:

* `libclang.so.13.0.0`, this is the real library
* `libclang.so.13`, this is a symlink that points to the above library
* `libclang.so`, this is a symlink that points to the above symlink

Because of this, and because Gradle lacks ability to distinguish between real filenames and symlinks, we end up (on Linux) with multiple versions of libclang, which significantly impact on the size of the final jextract artifact.

The solution is to add some special logic on Linux where:

* only `libclang.so.13.0.0` is copied from LLVM
* `libclang.so.13.0.0` is later renamed to `libclang.so`

This PR implement such changes both for gradle and make build (both have been tested locally).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/246/head:pull/246` \
`$ git checkout pull/246`

Update a local copy of the PR: \
`$ git checkout pull/246` \
`$ git pull https://git.openjdk.org/jextract.git pull/246/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 246`

View PR using the GUI difftool: \
`$ git pr show -t 246`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/246.diff">https://git.openjdk.org/jextract/pull/246.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/246#issuecomment-2133572088)