### PR TITLE
Add support for bin folder in makefile

### DIFF
--- a/make/Build.gmk
+++ b/make/Build.gmk
@@ -84,8 +84,9 @@ $(JEXTRACT_IMAGE_DIR): $(BUILD_MODULES_DIR)
 	    --module-path "$(BUILD_MODULES_DIR)" \
 	    --add-modules org.openjdk.jextract \
 	    --add-options "\"--enable-native-access=org.openjdk.jextract\" \"--enable-preview\""
-	$(CP) src/main/jextract "$(JEXTRACT_IMAGE_DIR)"
-	$(CP) src/main/jextract.bat "$(JEXTRACT_IMAGE_DIR)"
+	$(MKDIR) $(JEXTRACT_IMAGE_DIR)/bin
+	$(CP) src/main/jextract "$(JEXTRACT_IMAGE_DIR)/bin"
+	$(CP) src/main/jextract.bat "$(JEXTRACT_IMAGE_DIR)/bin"
 
 $(JEXTRACT_IMAGE_TEST_JDK_DIR): $(JEXTRACT_IMAGE_DIR)
         # jlink the modules to create a custom runtime image for jextract testing

--- a/make/Build.gmk
+++ b/make/Build.gmk
@@ -87,6 +87,7 @@ $(JEXTRACT_IMAGE_DIR): $(BUILD_MODULES_DIR)
 	$(MKDIR) $(JEXTRACT_IMAGE_DIR)/bin
 	$(CP) src/main/jextract "$(JEXTRACT_IMAGE_DIR)/bin"
 	$(CP) src/main/jextract.bat "$(JEXTRACT_IMAGE_DIR)/bin"
+	$(CHMOD) +x "$(JEXTRACT_IMAGE_DIR)/bin/jextract"
 
 $(JEXTRACT_IMAGE_TEST_JDK_DIR): $(JEXTRACT_IMAGE_DIR)
         # jlink the modules to create a custom runtime image for jextract testing

--- a/make/Common.gmk
+++ b/make/Common.gmk
@@ -108,6 +108,7 @@ AWK := awk
 EXPR := expr
 CP := cp
 CD := cd
+CHMOD := chmod
 TAR := tar
 PRINTF := printf
 


### PR DESCRIPTION
A previous PR changed the gradle build to emit launcher scripts in a separate "bin" folder. However, that PR did not make any changes to the makefiles used to produce the binary bundles. This PR rectifies that.

Tested locally.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - Committer) ⚠️ Review applies to [8c98876d](https://git.openjdk.org/jextract/pull/247/files/8c98876dad658b479632c356f0964e1793c344db)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/247/head:pull/247` \
`$ git checkout pull/247`

Update a local copy of the PR: \
`$ git checkout pull/247` \
`$ git pull https://git.openjdk.org/jextract.git pull/247/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 247`

View PR using the GUI difftool: \
`$ git pr show -t 247`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/247.diff">https://git.openjdk.org/jextract/pull/247.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/247#issuecomment-2133584910)