### PR TITLE
7903758: jextract can avoid temporary file creation for single simple header case

### DIFF
--- a/src/main/resources/org/openjdk/jextract/impl/resources/Messages.properties
+++ b/src/main/resources/org/openjdk/jextract/impl/resources/Messages.properties
@@ -24,7 +24,7 @@
 # error message
 argfile.read.error=reading @argfile failed: {0}
 cannot.read.header.file=cannot read header file: {0}
-not.a.file=not a file: {0}
+not.a.file=file not found: {0}
 l.option.value.invalid=invalid library specifier for -l option: {0}
 l.option.value.absolute.path=when using --use-system-load-library, option value for -l option should be a name or an absolute path: {0}
 class.name.missing.for.multiple.headers=multiple headers specified without --header-class-name


### PR DESCRIPTION
jextract creates a temporary file to support multiple headers and special header syntax <foo.h>. But, temporary file creation can be avoided for single, simple header file/path case.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Issue
 * [CODETOOLS-7903758](https://bugs.openjdk.org/browse/CODETOOLS-7903758): jextract can avoid temporary file creation for single simple header case (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/250/head:pull/250` \
`$ git checkout pull/250`

Update a local copy of the PR: \
`$ git checkout pull/250` \
`$ git pull https://git.openjdk.org/jextract.git pull/250/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 250`

View PR using the GUI difftool: \
`$ git pr show -t 250`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/250.diff">https://git.openjdk.org/jextract/pull/250.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/250#issuecomment-2180730011)