### PR TITLE
7903777: jextract layout for enum with big constant values is wrong

### DIFF
--- a/src/main/java/org/openjdk/jextract/impl/ClassSourceBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/ClassSourceBuilder.java
@@ -32,6 +32,7 @@ import org.openjdk.jextract.Type.Delegated;
 import org.openjdk.jextract.Type.Function;
 import org.openjdk.jextract.Type.Primitive;
 import org.openjdk.jextract.impl.DeclarationImpl.ClangAlignOf;
+import org.openjdk.jextract.impl.DeclarationImpl.ClangEnumType;
 import org.openjdk.jextract.impl.DeclarationImpl.DeclarationString;
 import org.openjdk.jextract.impl.DeclarationImpl.JavaName;
 
@@ -199,7 +200,7 @@ abstract class ClassSourceBuilder {
     String layoutString(Type type, long align) {
         return switch (type) {
             case Primitive p -> primitiveLayoutString(p, align);
-            case Declared d when Utils.isEnum(d) -> layoutString(DeclarationImpl.ClangEnumType.get(d.tree()).get(), align);
+            case Declared d when Utils.isEnum(d) -> layoutString(ClangEnumType.get(d.tree()).get(), align);
             case Declared d when Utils.isStructOrUnion(d) -> alignIfNeeded(JavaName.getFullNameOrThrow(d.tree()) + ".layout()", ClangAlignOf.getOrThrow(d.tree()) / 8, align);
             case Delegated d when d.kind() == Delegated.Kind.POINTER -> alignIfNeeded(runtimeHelperName() + ".C_POINTER", 8, align);
             case Delegated d -> layoutString(d.type(), align);

--- a/src/main/java/org/openjdk/jextract/impl/ClassSourceBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/ClassSourceBuilder.java
@@ -25,7 +25,6 @@
 package org.openjdk.jextract.impl;
 
 import org.openjdk.jextract.Declaration;
-import org.openjdk.jextract.Declaration.Constant;
 import org.openjdk.jextract.Type;
 import org.openjdk.jextract.Type.Array;
 import org.openjdk.jextract.Type.Declared;
@@ -200,7 +199,7 @@ abstract class ClassSourceBuilder {
     String layoutString(Type type, long align) {
         return switch (type) {
             case Primitive p -> primitiveLayoutString(p, align);
-            case Declared d when Utils.isEnum(d) -> layoutString(((Constant)d.tree().members().get(0)).type(), align);
+            case Declared d when Utils.isEnum(d) -> layoutString(DeclarationImpl.ClangEnumType.get(d.tree()).get(), align);
             case Declared d when Utils.isStructOrUnion(d) -> alignIfNeeded(JavaName.getFullNameOrThrow(d.tree()) + ".layout()", ClangAlignOf.getOrThrow(d.tree()) / 8, align);
             case Delegated d when d.kind() == Delegated.Kind.POINTER -> alignIfNeeded(runtimeHelperName() + ".C_POINTER", 8, align);
             case Delegated d -> layoutString(d.type(), align);

--- a/src/main/java/org/openjdk/jextract/impl/DeclarationImpl.java
+++ b/src/main/java/org/openjdk/jextract/impl/DeclarationImpl.java
@@ -349,14 +349,28 @@ public abstract class DeclarationImpl implements Declaration {
     /**
      * An attribute to mark enum constants, with a link to the name of their parent enum.
      */
-    record EnumConstant(String get) {
+    record EnumConstant(String enumName) {
         public static void with(Constant constant, String enumName) {
             constant.addAttribute(new EnumConstant(enumName));
         }
 
         public static Optional<String> get(Constant constant) {
             return constant.getAttribute(EnumConstant.class)
-                    .map(EnumConstant::get);
+                    .map(EnumConstant::enumName);
+        }
+    }
+
+    /**
+     * An attribute used to store the type of an enum declaration, as seen by clang.
+     */
+    record ClangEnumType(Type type) {
+        public static void with(Declaration.Scoped enumDecl, Type type) {
+            enumDecl.addAttribute(new ClangEnumType(type));
+        }
+
+        public static Optional<Type> get(Declaration.Scoped enumDecl) {
+            return enumDecl.getAttribute(ClangEnumType.class)
+                    .map(ClangEnumType::type);
         }
     }
 

--- a/src/main/java/org/openjdk/jextract/impl/TreeMaker.java
+++ b/src/main/java/org/openjdk/jextract/impl/TreeMaker.java
@@ -375,7 +375,9 @@ class TreeMaker {
                     decls.add(enumConstantDecl);
                 }
             });
-            return Declaration.enum_(CursorPosition.of(c), c.spelling(), decls.toArray(new Declaration[0]));
+            Declaration.Scoped enumDecl = Declaration.enum_(CursorPosition.of(c), c.spelling(), decls.toArray(new Declaration[0]));
+            DeclarationImpl.ClangEnumType.with(enumDecl, toType(c.getEnumDeclIntegerType()));
+            return enumDecl;
         } else {
             //if there's a real definition somewhere else, skip this redundant declaration
             return null;
@@ -479,6 +481,10 @@ class TreeMaker {
 
     Type toType(Cursor c) {
         return TypeMaker.makeType(c.type(), this);
+    }
+
+    Type toType(org.openjdk.jextract.clang.Type t) {
+        return TypeMaker.makeType(t, this);
     }
 
     private void checkCursor(Cursor c, CursorKind k) {

--- a/src/main/java/org/openjdk/jextract/impl/Utils.java
+++ b/src/main/java/org/openjdk/jextract/impl/Utils.java
@@ -252,7 +252,7 @@ class Utils {
                 yield CARRIERS_TO_LAYOUT_CARRIERS.get(clazz);
             }
             case Type.Declared declared when isStructOrUnion(declared) -> GroupLayout.class;
-            case Type.Declared declared when isEnum(declared) -> layoutCarrierFor(((Constant)declared.tree().members().get(0)).type());
+            case Type.Declared declared when isEnum(declared) -> layoutCarrierFor(ClangEnumType.get(declared.tree()).get());
             default -> throw new UnsupportedOperationException(t.toString());
         };
     }

--- a/src/main/java/org/openjdk/jextract/impl/Utils.java
+++ b/src/main/java/org/openjdk/jextract/impl/Utils.java
@@ -28,16 +28,13 @@ package org.openjdk.jextract.impl;
 
 import org.openjdk.jextract.Declaration;
 import org.openjdk.jextract.Declaration.Constant;
-import org.openjdk.jextract.Declaration.Scoped;
-import org.openjdk.jextract.Declaration.Typedef;
-import org.openjdk.jextract.JavaSourceFile;
 import org.openjdk.jextract.Type;
-import org.openjdk.jextract.Type.Declared;
 import org.openjdk.jextract.Type.Delegated;
 import org.openjdk.jextract.Type.Delegated.Kind;
 import org.openjdk.jextract.Type.Function;
 import org.openjdk.jextract.clang.Cursor;
 import org.openjdk.jextract.clang.CursorKind;
+import org.openjdk.jextract.impl.DeclarationImpl.ClangEnumType;
 import org.openjdk.jextract.impl.DeclarationImpl.NestedDeclarations;
 
 import java.lang.foreign.AddressLayout;
@@ -157,8 +154,7 @@ class Utils {
 
     static boolean isPrimitive(Type type) {
         return switch (type) {
-            case Type.Declared declared when declared.tree().kind() == Declaration.Scoped.Kind.ENUM ->
-                isPrimitive(((Declaration.Constant)declared.tree().members().get(0)).type());
+            case Type.Declared declared when declared.tree().kind() == Declaration.Scoped.Kind.ENUM -> true;
             case Type.Delegated delegated when delegated.kind() != Kind.POINTER -> isPrimitive(delegated.type());
             case Type.Primitive _ -> true;
             default -> false;
@@ -214,7 +210,7 @@ class Utils {
             case Type.Array _ -> MemorySegment.class;
             case Type.Primitive p -> Utils.carrierFor(p);
             case Type.Declared declared -> declared.tree().kind() == Declaration.Scoped.Kind.ENUM ?
-                    carrierFor(((Declaration.Constant) declared.tree().members().get(0)).type()) :
+                    carrierFor(ClangEnumType.get(declared.tree()).get()) :
                     MemorySegment.class;
             case Type.Delegated delegated -> delegated.kind() == Type.Delegated.Kind.POINTER ?
                     MemorySegment.class :

--- a/test/jtreg/generator/bigEnum/TestBigEnum.java
+++ b/test/jtreg/generator/bigEnum/TestBigEnum.java
@@ -1,0 +1,48 @@
+/* Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import org.testng.annotations.Test;
+import test.jextract.bigenum.*;
+
+import java.lang.foreign.GroupLayout;
+import java.lang.foreign.ValueLayout;
+
+import static org.testng.Assert.*;
+
+/*
+ * @test
+ * @requires (os.arch == "amd64" | os.arch == "x86_64") & os.family == "linux"
+ * @library /lib
+ * @build testlib.TestUtils
+ * @run main/othervm JtregJextract -t test.jextract.bigenum bigEnum.h
+ * @build TestBigEnum
+ * @run testng/othervm --enable-native-access=ALL-UNNAMED TestBigEnum
+ */
+public class TestBigEnum {
+
+    @Test
+    public void testBigEnum() {
+        GroupLayout structLayout = structType.layout();
+        assertEquals(structLayout.memberLayouts().get(0).withoutName(), ValueLayout.JAVA_LONG);
+        assertEquals(structLayout.byteSize(), 16);
+    }
+}

--- a/test/jtreg/generator/bigEnum/bigEnum.h
+++ b/test/jtreg/generator/bigEnum/bigEnum.h
@@ -1,0 +1,12 @@
+typedef enum
+{
+    EnumDef_Undefined = -1,
+    EnumDef_Big = 0x80000000
+
+} EnumDef;
+
+typedef struct structType
+{
+	EnumDef someEnum;
+	long long bigNumber;
+} value;

--- a/test/jtreg/generator/bigEnum/bigEnum.h
+++ b/test/jtreg/generator/bigEnum/bigEnum.h
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
 typedef enum
 {
     EnumDef_Undefined = -1,

--- a/test/jtreg/generator/bigEnum/bigEnum.h
+++ b/test/jtreg/generator/bigEnum/bigEnum.h
@@ -7,6 +7,6 @@ typedef enum
 
 typedef struct structType
 {
-	EnumDef someEnum;
-	long long bigNumber;
+    EnumDef someEnum;
+    long long bigNumber;
 } value;


### PR DESCRIPTION
This PR fixes the code that generates enum layouts. Currently, the layout of an enum type is determined by looking at the type of the first enum constant.
In some platforms, this strategy does not work, as an enum can have constants of **different** types.

The solution is to ask clang what the integral type of the enum declaration is, and store that as an attribute in the enum declaration. Then, we should simply retrieve that type when generating layouts that depend on the enum.

I've added a platform-dependent test, since this functionality is only really available on Linux/gcc (on Windows, enum constants are all truncated to 32 bits, it seems).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Issue
 * [CODETOOLS-7903777](https://bugs.openjdk.org/browse/CODETOOLS-7903777): jextract layout for enum with big constant values is wrong (**Bug** - P3)


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/252/head:pull/252` \
`$ git checkout pull/252`

Update a local copy of the PR: \
`$ git checkout pull/252` \
`$ git pull https://git.openjdk.org/jextract.git pull/252/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 252`

View PR using the GUI difftool: \
`$ git pr show -t 252`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/252.diff">https://git.openjdk.org/jextract/pull/252.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/252#issuecomment-2230955659)