### PR TITLE
7903776: jextract generates uncompilable code when C identifier with the name from "java.lang" classes is used

### DIFF
--- a/src/main/java/org/openjdk/jextract/impl/NameMangler.java
+++ b/src/main/java/org/openjdk/jextract/impl/NameMangler.java
@@ -35,12 +35,14 @@ import org.openjdk.jextract.impl.DeclarationImpl.AnonymousStruct;
 import org.openjdk.jextract.impl.DeclarationImpl.JavaFunctionalInterfaceName;
 import org.openjdk.jextract.impl.DeclarationImpl.JavaName;
 
+import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import javax.lang.model.SourceVersion;
 
 /*
@@ -318,6 +320,16 @@ public final class NameMangler implements Declaration.Visitor<Void, Declaration>
         };
     }
 
+
+    // well known java type names that are potentially used
+    // as unqualified name in the jextract generated code.
+    private static final Set<String> WELL_KNOWN_JAVA_TYPES = ConcurrentHashMap.newKeySet();
+    static {
+        WELL_KNOWN_JAVA_TYPES.add("ByteOrder");
+        WELL_KNOWN_JAVA_TYPES.add("MethodHandle");
+        WELL_KNOWN_JAVA_TYPES.add("VarHandle");
+    }
+
     private static boolean isJavaTypeName(String name) {
         // rule out common case of lower-case starting identifier.
         if (name.length() == 0 || Character.isLowerCase(name.charAt(0))) {
@@ -325,23 +337,29 @@ public final class NameMangler implements Declaration.Visitor<Void, Declaration>
         }
 
         // Java types that are used unqualified in the generated code
-        return switch (name) {
-            case "String", "Struct", "MethodHandle",
-                "VarHandle", "ByteOrder",
-                "FunctionDescriptor", "LibraryLookup",
-                "MemoryLayout",
-                "Arena", "NativeArena", "MemorySegment", "ValueLayout"
-                    -> true;
-            default -> {
-                try {
-                    // java.lang package is auto-imported. Check if we've clash
-                    // of the given identifier with any of the java.lang.* types.
-                    Class.forName("java.lang." + name);
-                    yield true;
-                } catch (Exception ignored) {
-                }
-                yield false;
+        if (WELL_KNOWN_JAVA_TYPES.contains(name)) {
+            return true;
+        }
+
+        // may be it is not cached as well-known java type yet.
+        if (checkTypeInPackage("java.lang", name)) {
+            return true;
+        } else if (checkTypeInPackage("java.lang.foreign", name)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    private static boolean checkTypeInPackage(String pkgName, String typeName) {
+        try {
+            int mods = Class.forName(pkgName + "." + typeName).getModifiers();
+            if (Modifier.isPublic(mods)) {
+                WELL_KNOWN_JAVA_TYPES.add(typeName);
+                return true;
             }
-        };
+        } catch (Exception ignored) {
+        }
+        return false;
     }
 }

--- a/test/testng/org/openjdk/jextract/test/toolprovider/TestJavaLangNames.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/TestJavaLangNames.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2024, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package org.openjdk.jextract.test.toolprovider;
+
+import java.nio.file.Path;
+
+import testlib.TestUtils;
+import org.testng.annotations.Test;
+import testlib.JextractToolRunner;
+
+import static org.testng.Assert.assertNotNull;
+
+// 7903776: jextract generates uncompilable code when C identifier with the name
+// from "java.lang" classes is used
+
+public class TestJavaLangNames extends JextractToolRunner {
+    @Test
+    public void testJavaLangNames() {
+        Path javaLangNamesOutput = getOutputFilePath("javaLangNamesgen");
+        Path javaLangNamesH = getInputFilePath("java_lang_names.h");
+        runAndCompile(javaLangNamesOutput, javaLangNamesH.toString());
+        try(TestUtils.Loader loader = TestUtils.classLoader(javaLangNamesOutput)) {
+            Class<?> headerCls = loader.loadClass("java_lang_names_h");
+            assertNotNull(findMethod(headerCls, "Boolean_"));
+            assertNotNull(findMethod(headerCls, "Integer_"));
+            assertNotNull(findMethod(headerCls, "Object_"));
+        } finally {
+            TestUtils.deleteDir(javaLangNamesOutput);
+        }
+    }
+}

--- a/test/testng/org/openjdk/jextract/test/toolprovider/java_lang_names.h
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/java_lang_names.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2024, 2024 Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+typedef enum {
+   Boolean,
+   Integer,
+   Object
+} MyTypes;


### PR DESCRIPTION
Unqualified names are mangled by NameMangler. But it was complete (didn't include "Boolean"). For uniformity & future proof mangling all type names from "java.lang" package.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Issue
 * [CODETOOLS-7903776](https://bugs.openjdk.org/browse/CODETOOLS-7903776): jextract generates uncompilable code when C identifier with the name from "java.lang" classes is used (**Bug** - P4)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/253/head:pull/253` \
`$ git checkout pull/253`

Update a local copy of the PR: \
`$ git checkout pull/253` \
`$ git pull https://git.openjdk.org/jextract.git pull/253/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 253`

View PR using the GUI difftool: \
`$ git pr show -t 253`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/253.diff">https://git.openjdk.org/jextract/pull/253.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/253#issuecomment-2230921781)