### PR TITLE
7903779: unify logger messages to show position whenever possible

### DIFF
--- a/src/main/java/org/openjdk/jextract/JextractTool.java
+++ b/src/main/java/org/openjdk/jextract/JextractTool.java
@@ -503,7 +503,7 @@ public final class JextractTool {
                 toplevel, headerName,
                 options.targetPackage, options.includeHelper, options.libraries, options.useSystemLoadLibrary, logger);
         } catch (ClangException ce) {
-            logger.err("jextract.clang.error", ce.getMessage());
+            logger.print(ce);
             if (JextractTool.DEBUG) {
                 logger.printStackTrace(ce);
             }

--- a/src/main/java/org/openjdk/jextract/impl/ClangException.java
+++ b/src/main/java/org/openjdk/jextract/impl/ClangException.java
@@ -25,18 +25,40 @@
  */
 package org.openjdk.jextract.impl;
 
+import org.openjdk.jextract.Position;
+import org.openjdk.jextract.clang.Diagnostic;
+
 public class ClangException extends RuntimeException {
     private static final long serialVersionUID = 0L;
 
-    public ClangException(String message) {
-        super(message);
+    private final Position position;
+    private final int severity;
+    private final String spelling;
+
+    public ClangException(Position pos, int severity, String spelling) {
+        super(spelling);
+        this.position = pos;
+        this.severity = severity;
+        this.spelling = spelling;
     }
 
-    public ClangException(String message, Throwable cause) {
-        super(message, cause);
+    public Position position() {
+        return position;
     }
 
-    public ClangException(Throwable cause) {
-        super(cause);
+    public int severity() {
+        return severity;
+    }
+
+    public String spelling() {
+        return spelling;
+    }
+
+    public boolean isError() {
+        return severity == Diagnostic.CXDiagnostic_Error;
+    }
+
+    public boolean isFatal() {
+        return severity == Diagnostic.CXDiagnostic_Fatal;
     }
 }

--- a/src/main/java/org/openjdk/jextract/impl/MissingDepChecker.java
+++ b/src/main/java/org/openjdk/jextract/impl/MissingDepChecker.java
@@ -115,7 +115,7 @@ public final class MissingDepChecker implements Declaration.Visitor<Void, Declar
             // to valid code and (b) missing typedefs to existing structs are resolved correctly, as typedefs are never
             // referred to by name in the generated code (because of libclang limitations).
             if (Skip.isPresent(declared.tree())) {
-                logger.err("jextract.bad.include", decl.name(), declared.tree().name());
+                logger.err(decl.pos(), "jextract.bad.include", decl.name(), declared.tree().name());
             }
         } else if (type instanceof Delegated delegated &&
                         delegated.kind() == Delegated.Kind.TYPEDEF) {

--- a/src/main/java/org/openjdk/jextract/impl/Parser.java
+++ b/src/main/java/org/openjdk/jextract/impl/Parser.java
@@ -112,9 +112,9 @@ public class Parser {
         }
     }
 
-    record PositionRecord(Path path, int line, int col) implements Position {}
-
     private Position asPosition(SourceLocation.Location loc) {
+        record PositionRecord(Path path, int line, int col) implements Position {}
+
         return new PositionRecord(loc.path(), loc.line(), loc.column());
     }
 

--- a/src/main/java/org/openjdk/jextract/impl/Parser.java
+++ b/src/main/java/org/openjdk/jextract/impl/Parser.java
@@ -26,6 +26,7 @@
 package org.openjdk.jextract.impl;
 
 import org.openjdk.jextract.Declaration;
+import org.openjdk.jextract.Position;
 import org.openjdk.jextract.clang.Cursor;
 import org.openjdk.jextract.clang.CursorKind;
 import org.openjdk.jextract.clang.Diagnostic;
@@ -99,13 +100,22 @@ public class Parser {
              TranslationUnit tu = index.parse(name, content,
                 d -> {
                     if (d.severity() > Diagnostic.CXDiagnostic_Warning) {
-                        throw new ClangException(d.toString());
+                        throw new ClangException(
+                            asPosition(d.location().getSpellingLocation()),
+                            d.severity(),
+                            d.spelling());
                     }
                 },
             true, args.toArray(new String[0])) ;
             MacroParserImpl macroParser = MacroParserImpl.make(treeMaker, logger, tu, args)) {
             return collectDeclarations(tu, macroParser);
         }
+    }
+
+    record PositionRecord(Path path, int line, int col) implements Position {}
+
+    private Position asPosition(SourceLocation.Location loc) {
+        return new PositionRecord(loc.path(), loc.line(), loc.column());
     }
 
     private boolean isMacro(Cursor c) {

--- a/src/main/resources/org/openjdk/jextract/impl/resources/Messages.properties
+++ b/src/main/resources/org/openjdk/jextract/impl/resources/Messages.properties
@@ -96,9 +96,6 @@ Use --help for a list of possible options
 expected.atleast.one.header=\
   Expected at least one header file
 
-jextract.clang.error=\
-{0}
-
 jextract.crash=\
 Unexpected exception {0} occurred
 

--- a/test/testng/org/openjdk/jextract/test/toolprovider/includeDeps/TestBadIncludes.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/includeDeps/TestBadIncludes.java
@@ -50,7 +50,7 @@ public class TestBadIncludes extends JextractToolRunner {
 
     @Test(dataProvider = "cases")
     public void testBadIncludes(String badDeclName, String missingDepName) {
-        result.checkContainsOutput("ERROR: " + badDeclName + " depends on " + missingDepName);
+        result.checkContainsOutput("error: " + badDeclName + " depends on " + missingDepName);
     }
 
     @DataProvider

--- a/test/testng/org/openjdk/jextract/test/toolprovider/includeDeps/TestNestedBadIncludes.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/includeDeps/TestNestedBadIncludes.java
@@ -53,7 +53,7 @@ public class TestNestedBadIncludes extends JextractToolRunner {
 
     @Test(dataProvider = "cases")
     public void testBadIncludes(String includeOption, String badDeclName, String missingDepName) {
-        result.checkContainsOutput("ERROR: " + badDeclName + " depends on " + missingDepName);
+        result.checkContainsOutput("error: " + badDeclName + " depends on " + missingDepName);
     }
 
     @DataProvider

--- a/test/testng/org/openjdk/jextract/test/toolprovider/unsupported/TestUnsupportedTypes.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/unsupported/TestUnsupportedTypes.java
@@ -42,7 +42,7 @@ public class TestUnsupportedTypes extends JextractToolRunner {
 
     @Test(dataProvider = "cases")
     public void testUnsupportedTypes(String skippedName, String reason) {
-        result.checkContainsOutput("WARNING: Skipping " + skippedName + " (" + reason);
+        result.checkContainsOutput("warning: Skipping " + skippedName + " (" + reason);
     }
 
     private static final String REASON_UNSUPPORTED_TYPE = "type";


### PR DESCRIPTION
* logger.warn/.err/.info Position accepting overloads.
* Error message format is: &lt;position&gt;:"fatal"|"error"|"warning"|"info"|:&lt;message&gt; (consistent with clang).
* ClangException has position, severity and spelling. ClangExceptions are printed using logger.print.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Issue
 * [CODETOOLS-7903779](https://bugs.openjdk.org/browse/CODETOOLS-7903779): unify logger messages to show position whenever possible (**Bug** - P4)


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - Committer) ⚠️ Review applies to [3fe7c65e](https://git.openjdk.org/jextract/pull/254/files/3fe7c65ebfaac32ee9ef96f8d0278c5a9a86310a)
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**) ⚠️ Review applies to [3fe7c65e](https://git.openjdk.org/jextract/pull/254/files/3fe7c65ebfaac32ee9ef96f8d0278c5a9a86310a)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/254/head:pull/254` \
`$ git checkout pull/254`

Update a local copy of the PR: \
`$ git checkout pull/254` \
`$ git pull https://git.openjdk.org/jextract.git pull/254/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 254`

View PR using the GUI difftool: \
`$ git pr show -t 254`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/254.diff">https://git.openjdk.org/jextract/pull/254.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/254#issuecomment-2250215432)