### PR TITLE
Fix issue with missing JSON classes in make build

### DIFF
--- a/make/Build.gmk
+++ b/make/Build.gmk
@@ -44,17 +44,16 @@ NATIVE_TEST_SOURCES := $(shell find $(TOPDIR)/test -name "lib*.c")
 
 $(foreach file,$(NATIVE_TEST_SOURCES),$(eval $(call BuildNativeLibrary,$(file),$(JEXTRACT_IMAGE_NATIVE_TEST_DIR),$(BUILD_TEST_SUPPORT_DIR),BUILD_NATIVE_TEST_LIBRARIES)))
 
-JAVA_SOURCES = $(shell find $(TOPDIR)/src/main/java -name *.java)
-
 $(BUILD_CLASSES_DIR):
 	$(MKDIR) -p $(BUILD_CLASSES_DIR)/org/openjdk/jextract/impl
 	$(FIXPATH) $(PANAMA_JAVA_HOME)/bin/javac \
 	    --release=22 \
 	    --enable-preview \
 	    -d "$(BUILD_CLASSES_DIR)" \
-	    $(JAVA_SOURCES)
-	$(CP) -r src/main/java/META-INF $(BUILD_CLASSES_DIR)
-	$(CP) -r src/main/resources/org/openjdk/jextract/impl/resources $(BUILD_CLASSES_DIR)/org/openjdk/jextract/impl
+	    --module-source-path org.openjdk.jextract=$(TOPDIR)/src/main/java \
+	    -m org.openjdk.jextract
+	$(CP) -r src/main/java/META-INF $(BUILD_CLASSES_DIR)/org.openjdk.jextract
+	$(CP) -r src/main/resources/org/openjdk/jextract/impl/resources $(BUILD_CLASSES_DIR)/org.openjdk.jextract/org/openjdk/jextract/impl
 
 ifeq ($(PLATFORM_OS), linux)
   LIBCLANG_COPY_PATH := "libclang.so.$(LIBCLANG_VERSION)"
@@ -78,7 +77,7 @@ $(BUILD_MODULES_DIR): $(BUILD_CLASSES_DIR)
 	$(FIXPATH) $(PANAMA_JAVA_HOME)/bin/jmod \
 	    create \
 	    --module-version=22 \
-	    --class-path=$(BUILD_CLASSES_DIR) \
+	    --class-path=$(BUILD_CLASSES_DIR)/org.openjdk.jextract \
 	    --libs=$(JEXTRACT_JMOD_LIBS_DIR) \
 	    --conf=$(JEXTRACT_JMOD_CONF_DIR) \
 	    $(BUILD_MODULES_DIR)/org.openjdk.jextract.jmod

--- a/make/Build.gmk
+++ b/make/Build.gmk
@@ -44,18 +44,15 @@ NATIVE_TEST_SOURCES := $(shell find $(TOPDIR)/test -name "lib*.c")
 
 $(foreach file,$(NATIVE_TEST_SOURCES),$(eval $(call BuildNativeLibrary,$(file),$(JEXTRACT_IMAGE_NATIVE_TEST_DIR),$(BUILD_TEST_SUPPORT_DIR),BUILD_NATIVE_TEST_LIBRARIES)))
 
+JAVA_SOURCES = $(shell find $(TOPDIR)/src/main/java -name *.java)
+
 $(BUILD_CLASSES_DIR):
 	$(MKDIR) -p $(BUILD_CLASSES_DIR)/org/openjdk/jextract/impl
 	$(FIXPATH) $(PANAMA_JAVA_HOME)/bin/javac \
 	    --release=22 \
 	    --enable-preview \
 	    -d "$(BUILD_CLASSES_DIR)" \
-	    src/main/java/module-info.java \
-	    src/main/java/org/openjdk/jextract/*.java \
-	    src/main/java/org/openjdk/jextract/impl/*.java \
-	    src/main/java/org/openjdk/jextract/clang/*.java \
-	    src/main/java/org/openjdk/jextract/clang/libclang/*.java \
-		src/main/java/org/openjdk/jextract/json/parser/*.java
+	    $(JAVA_SOURCES)
 	$(CP) -r src/main/java/META-INF $(BUILD_CLASSES_DIR)
 	$(CP) -r src/main/resources/org/openjdk/jextract/impl/resources $(BUILD_CLASSES_DIR)/org/openjdk/jextract/impl
 

--- a/make/Build.gmk
+++ b/make/Build.gmk
@@ -54,7 +54,8 @@ $(BUILD_CLASSES_DIR):
 	    src/main/java/org/openjdk/jextract/*.java \
 	    src/main/java/org/openjdk/jextract/impl/*.java \
 	    src/main/java/org/openjdk/jextract/clang/*.java \
-	    src/main/java/org/openjdk/jextract/clang/libclang/*.java
+	    src/main/java/org/openjdk/jextract/clang/libclang/*.java \
+		src/main/java/org/openjdk/jextract/json/parser/*.java
 	$(CP) -r src/main/java/META-INF $(BUILD_CLASSES_DIR)
 	$(CP) -r src/main/resources/org/openjdk/jextract/impl/resources $(BUILD_CLASSES_DIR)/org/openjdk/jextract/impl
 

--- a/make/RunTestsPrebuilt.gmk
+++ b/make/RunTestsPrebuilt.gmk
@@ -69,6 +69,8 @@ define SetupRunJtregTest
 	    -verbose:summary,fail,error \
 	    -nativepath:$$(JEXTRACT_NATIVE_TEST_DIR) \
 	    -vmoption:--enable-native-access=ALL-UNNAMED,org.openjdk.jextract \
+		-javacoption:--add-exports=org.openjdk.jextract/org.openjdk.jextract.json.parser=ALL-UNNAMED \
+		-javaoption:--add-exports=org.openjdk.jextract/org.openjdk.jextract.json.parser=ALL-UNNAMED \
 	    $2 \
 	    && $$(ECHO) $$$$? > $$($1_EXITCODE) \
             || $$(ECHO) $$$$? > $$($1_EXITCODE)


### PR DESCRIPTION
Currently, the `make` build is broken, since we added a new package, but the make build doesn't build the source files in that package. 

This patch adds compilation of the new sources, and adds the missing `--add-exports` flags when running tests. Instead of listing each package in the javac command, I've switched to module source path-based compilation. So, if we ever change the packages in the future, we should run into the same problem again.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)
 * [Athijegannathan Sundararajan](https://openjdk.org/census#sundar) (@sundararajana - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/259/head:pull/259` \
`$ git checkout pull/259`

Update a local copy of the PR: \
`$ git checkout pull/259` \
`$ git pull https://git.openjdk.org/jextract.git pull/259/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 259`

View PR using the GUI difftool: \
`$ git pr show -t 259`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/259.diff">https://git.openjdk.org/jextract/pull/259.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/259#issuecomment-2334776107)