### PR TITLE
Copy powershell script in make build as well

### DIFF
--- a/make/Build.gmk
+++ b/make/Build.gmk
@@ -92,6 +92,7 @@ $(JEXTRACT_IMAGE_DIR): $(BUILD_MODULES_DIR)
 	$(MKDIR) $(JEXTRACT_IMAGE_DIR)/bin
 	$(CP) src/main/jextract "$(JEXTRACT_IMAGE_DIR)/bin"
 	$(CP) src/main/jextract.bat "$(JEXTRACT_IMAGE_DIR)/bin"
+	$(CP) src/main/jextract.ps1 "$(JEXTRACT_IMAGE_DIR)/bin"
 	$(CHMOD) +x "$(JEXTRACT_IMAGE_DIR)/bin/jextract"
 
 $(JEXTRACT_IMAGE_TEST_JDK_DIR): $(JEXTRACT_IMAGE_DIR)


### PR DESCRIPTION
I noticed that the powershell script we added is only being copied to the output directory as part of the gradle build. This PR makes it so we also copy it in the make build.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/260/head:pull/260` \
`$ git checkout pull/260`

Update a local copy of the PR: \
`$ git checkout pull/260` \
`$ git pull https://git.openjdk.org/jextract.git pull/260/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 260`

View PR using the GUI difftool: \
`$ git pr show -t 260`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/260.diff">https://git.openjdk.org/jextract/pull/260.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/260#issuecomment-2340876335)