### PR TITLE
7903878: jextract should derive struct field offsets from struct layouts

### DIFF
--- a/src/main/java/org/openjdk/jextract/impl/StructBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/StructBuilder.java
@@ -390,9 +390,9 @@ final class StructBuilder extends ClassSourceBuilder implements OutputFactory.Bu
     private String emitOffsetFieldDecl(Declaration.Variable field, String javaName) {
         String offsetFieldName = javaName + "$OFFSET";
         appendIndentedLines(String.format("""
-            private static final long %1$s = %2$d;
+            private static final long %1$s = $LAYOUT.byteOffset(%2$s);
             """,
-            offsetFieldName, ClangOffsetOf.getOrThrow(field) / 8));
+            offsetFieldName, fieldElementPaths(field.name())));
         appendBlankLine();
         emitFieldDocComment(field, "Offset for field:");
         appendIndentedLines("""


### PR DESCRIPTION
Please read the JBS issue for more details.

Currently jextract emits hardwired offsets, it would be better if the offsets could be computed dynamically from the struct layouts.

Passes all tests, unsure if this patch requires new tests.
Note: I used `fieldElementPaths(field.name())))` instead of the `javaName` to deal with nested structs.


It seems like GitHub actions are broken for Ubuntu? will look into this next week if necessary.