### PR TITLE
Touch up gradle build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -212,16 +212,17 @@ task cmakeBuild(type: Exec) {
     ]
 }
 
-void createJtregTask(String name, boolean coverage, String os_lib_dir) {
+// alias that can be easily referenced from a run configuration
+tasks.register("testDeps") {
+    dependsOn createRuntimeImageForTest,cmakeBuild
+}
+
+void createJtregTask(String name, String jacocoAgent, String os_lib_dir) {
     tasks.register(name, JavaExec) {
-        dependsOn createRuntimeImageForTest,cmakeBuild
+        dependsOn testDeps
 
         if (findProperty("jtreg_home") == null) {
             throw new GradleException("jtreg_home is not defined")
-        }
-        // e.g.: <jacoco repo>/org.jacoco.agent/target/classes/jacocoagent.jar
-        if (coverage && findProperty("jacoco_agent") == null) {
-            throw new GradleException("jacoco_agent is not defined")
         }
 
         workingDir = "$buildDir"
@@ -239,8 +240,7 @@ void createJtregTask(String name, boolean coverage, String os_lib_dir) {
                 "-retain:fail,error",
         ]
 
-        if (coverage) {
-            String jacocoAgent = findProperty("jacoco_agent")
+        if (jacocoAgent != null) {
             String coverageFile = "$buildDir/jacoco-run/jextract.exec"
             String includes = "org.openjdk.jextract.*"
             args += "-javaoption:-javaagent:$jacocoAgent=destfile=$coverageFile,includes=$includes"
@@ -250,8 +250,12 @@ void createJtregTask(String name, boolean coverage, String os_lib_dir) {
     }
 }
 
-createJtregTask("jtreg", false, os_lib_dir)
-createJtregTask("jtregWithCoverage", true, os_lib_dir)
+createJtregTask("jtreg", null, os_lib_dir)
+// e.g.: <jacoco repo>/org.jacoco.agent/target/classes/jacocoagent.jar
+String jacocoAgent = findProperty("jacoco_agent")
+if (jacocoAgent != null) {
+    createJtregTask("jtregWithCoverage", jacocoAgent, os_lib_dir)
+}
 
 tasks.register("coverage", JavaExec) {
     dependsOn jtregWithCoverage


### PR DESCRIPTION
I'm setting up the jextract repo on a new machine, and ran into a couple of small build issues that this PR addresses:

1.) intellij will try to collect all tasks defined by the gradle build, but this is currently failing if you don't have the jacoco agent configured, since that's needed to 'configure' one of the test tasks. The fix I added is to only lazily register the test task for coverage instead.

2.) If you want to debug a jtreg test through Intellij, it's nice to be able to build the test image and native test libraries as a pre-run step. I've added a new task called `testDeps` which does both of these things, and can be easily referenced from a run configuration.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/263/head:pull/263` \
`$ git checkout pull/263`

Update a local copy of the PR: \
`$ git checkout pull/263` \
`$ git pull https://git.openjdk.org/jextract.git pull/263/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 263`

View PR using the GUI difftool: \
`$ git pr show -t 263`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/263.diff">https://git.openjdk.org/jextract/pull/263.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/263#issuecomment-2539516513)
</details>
