### PR TITLE
7903735: Remove redundant method in generated code

### DIFF
--- a/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
@@ -365,8 +365,7 @@ class HeaderFileBuilder extends ClassSourceBuilder {
             }
 
             static MemorySegment findOrThrow(String symbol) {
-                return SYMBOL_LOOKUP.find(symbol)
-                    .orElseThrow(() -> new UnsatisfiedLinkError("unresolved symbol: " + symbol));
+                return SYMBOL_LOOKUP.findOrThrow(symbol);
             }
 
             static MethodHandle upcallHandle(Class<?> fi, String name, FunctionDescriptor fdesc) {


### PR DESCRIPTION
Was looking at older issues and saw an opportunity for a refractor.
I don't see a dependent PR feature for this repo but this is meant to be merged after https://github.com/openjdk/jextract/pull/265

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Issue
 * [CODETOOLS-7903735](https://bugs.openjdk.org/browse/CODETOOLS-7903735): Remove redundant method in generated code (**Enhancement** - P4)


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - Committer) ⚠️ Review applies to [aea49d45](https://git.openjdk.org/jextract/pull/266/files/aea49d4547cf4365869665ec5f5cab3fe3444a08)
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**) ⚠️ Review applies to [aea49d45](https://git.openjdk.org/jextract/pull/266/files/aea49d4547cf4365869665ec5f5cab3fe3444a08)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/266/head:pull/266` \
`$ git checkout pull/266`

Update a local copy of the PR: \
`$ git checkout pull/266` \
`$ git pull https://git.openjdk.org/jextract.git pull/266/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 266`

View PR using the GUI difftool: \
`$ git pr show -t 266`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/266.diff">https://git.openjdk.org/jextract/pull/266.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/266#issuecomment-2549315960)
</details>
