### PR TITLE
7903731: Jextract should support macOS frameworks

### DIFF
--- a/doc/GUIDE.md
+++ b/doc/GUIDE.md
@@ -988,6 +988,14 @@ A complete list of all the supported command line options is given below:
 | `--include-[function,constant,struct,union,typedef,var]<String>` | Include a symbol of the given name and kind in the generated bindings. When one of these options is specified, any symbol that is not matched by any specified filters is omitted from the generated bindings. |
 | `--version`                                                  | print version information and exit |
 
+**macOS platform options (available only when running on macOS):**
+
+| Option                       | Meaning                                                                                                                                                                                                                                 |
+|:-----------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `--mac-framework-dir <dir>`  | specify the framework directory dir include files <br/>defaults to the current Mac OS X SDK dir<br/> This removes the need of having a compile_flags.txt with the required `-framework XYZ` options in the folder where jextract is ran |
+| `-f, framework <framekwork>` | specify the name of the library, path will be expanded to that of the framework folder                                                                                                                                                  |
+
+
 Jextract accepts one or more header files. When multiple header files are specified,
 the `--header-class-name` option is mandatory. Header files can be specified in two different ways:
 

--- a/samples/opengl/compile_flags.txt
+++ b/samples/opengl/compile_flags.txt
@@ -1,1 +1,0 @@
--F/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks

--- a/samples/opengl/compilesource.sh
+++ b/samples/opengl/compilesource.sh
@@ -1,5 +1,5 @@
-jextract -t opengl -l :/System/Library/Frameworks/GLUT.framework/GLUT \
-  -l :/System/Library/Frameworks/OpenGL.framework/OpenGL \
+jextract -t opengl -f GLUT \
+  -f OpenGL \
   "<GLUT/glut.h>"
 
 javac --source=22 -d . opengl/*.java

--- a/src/main/java/org/openjdk/jextract/impl/Utils.java
+++ b/src/main/java/org/openjdk/jextract/impl/Utils.java
@@ -27,7 +27,6 @@
 package org.openjdk.jextract.impl;
 
 import org.openjdk.jextract.Declaration;
-import org.openjdk.jextract.Declaration.Constant;
 import org.openjdk.jextract.Type;
 import org.openjdk.jextract.Type.Delegated;
 import org.openjdk.jextract.Type.Delegated.Kind;
@@ -47,6 +46,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * General utility functions

--- a/src/main/resources/org/openjdk/jextract/impl/resources/Messages.properties
+++ b/src/main/resources/org/openjdk/jextract/impl/resources/Messages.properties
@@ -1,21 +1,21 @@
 #
-#  Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+#  Copyright (c) 2020, 2024 Oracle and/or its affiliates. All rights reserved.
 #  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
-# 
+#
 #  This code is free software; you can redistribute it and/or modify it
 #  under the terms of the GNU General Public License version 2 only, as
 #  published by the Free Software Foundation.
-# 
+#
 #  This code is distributed in the hope that it will be useful, but WITHOUT
 #  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
 #  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
 #  version 2 for more details (a copy is included in the LICENSE file that
 #  accompanied this code).
-# 
+#
 #  You should have received a copy of the GNU General Public License version
 #  2 along with this work; if not, write to the Free Software Foundation,
 #  Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
-# 
+#
 #  Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
 #  or visit www.oracle.com if you need additional information or have any
 #  questions.
@@ -26,7 +26,9 @@ argfile.read.error=reading @argfile failed: {0}
 cannot.read.header.file=cannot read header file: {0}
 not.a.file=not a file: {0}
 l.option.value.invalid=invalid library specifier for -l option: {0}
+f.option.value.invalid=invalid library specifier for -f option: {0}
 l.option.value.absolute.path=when using --use-system-load-library, option value for -l option should be a name or an absolute path: {0}
+f.option.value.absolute.path=when using --use-system-load-library, option value for -f option should be a name or an absolute path: {0}
 class.name.missing.for.multiple.headers=multiple headers specified without --header-class-name
 
 # help messages for options
@@ -47,6 +49,8 @@ help.output=specify the directory to place generated files
 help.source=generate java sources
 help.t=target package for specified header files
 help.version=print version information and exit
+help.mac.framework=specify the path of the framework include files
+help.framework.library.path=specify name of framework library, jextract will infer public frameworks dir
 help.non.option=header file
 jextract.usage=\
 Usage: jextract <options> <header file> [<header file>] [...]                                   \n\
@@ -82,6 +86,12 @@ Option                             Description                                  
 -t, --target-package <package>     target package name for the generated classes. If this option\n\
 \                                   is not specified, then unnamed package is used.             \n\
 --version                          print version information and exit                           \n
+
+jextract.usage.mac=\
+Platform dependent options for running jextract                                                 \n\
+--mac-framework-dir <dir>          specify the framework directory                              \n\
+-f <framekwork>                    specify framework library. -f libGL is equivalent to         \n\
+\                                      -l :/System/Library/Frameworks/libGL.framework/libGL         \n
 
 jextract.version=\
 jextract {0}\n\


### PR DESCRIPTION
Read the JBS issue for more detail.

This patch adds two new mac specific options, to make it easier to use frameworks and remove the need of a `compile_flags.txt` file. An exception is thrown if those options are used from an other platform, the error message is inspired from `jpackage`