### PR TITLE
7903926: jtreg/generator/testLinkageErrors/TestLinkageErrors.java failed with "expected [true] but found [false]"

### DIFF
--- a/test/jtreg/generator/testLinkageErrors/TestLinkageErrors.java
+++ b/test/jtreg/generator/testLinkageErrors/TestLinkageErrors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,7 +47,7 @@ public class TestLinkageErrors {
             while (t.getCause() != null) {
                 t = t.getCause();
             }
-            assertTrue(t.getMessage().contains("unresolved symbol: " + symbol));
+            assertTrue(t.getMessage().contains("Symbol not found: " + symbol));
         }
     }
 


### PR DESCRIPTION
Please review this patch to stop a test failure after a53f5c0 because the error message changed.

Passes tier 1 on all platforms.

TIA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Issue
 * [CODETOOLS-7903926](https://bugs.openjdk.org/browse/CODETOOLS-7903926): jtreg/generator/testLinkageErrors/TestLinkageErrors.java failed with "expected [true] but found [false]" (**Bug** - P3)


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/270/head:pull/270` \
`$ git checkout pull/270`

Update a local copy of the PR: \
`$ git checkout pull/270` \
`$ git pull https://git.openjdk.org/jextract.git pull/270/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 270`

View PR using the GUI difftool: \
`$ git pr show -t 270`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/270.diff">https://git.openjdk.org/jextract/pull/270.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/270#issuecomment-2574739835)
</details>
