### PR TITLE
7903928: update build.gradle to use JDK 23

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -180,4 +180,4 @@ jobs:
     - name: 'Run tests'
       shell: sh
       run: |
-        sh ./gradlew -Pjdk22_home=${{ matrix.DEPS_ROOT }}/jdk-toolchain -Pllvm_home=${{ matrix.DEPS_ROOT }}/llvm/image -Pjtreg_home=./deps/jtreg/build/images/jtreg jtreg
+        sh ./gradlew -Pjdk23_home=${{ matrix.DEPS_ROOT }}/jdk-toolchain -Pllvm_home=${{ matrix.DEPS_ROOT }}/llvm/image -Pjtreg_home=./deps/jtreg/build/images/jtreg jtreg

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -167,7 +167,7 @@ jobs:
     - name: 'Build Jextract'
       shell: sh
       run: |
-        sh ./gradlew -Pjdk22_home=${{ matrix.DEPS_ROOT }}/jdk-toolchain -Pllvm_home=${{ matrix.DEPS_ROOT }}/llvm/image clean verify        
+        sh ./gradlew -Pjdk23_home=${{ matrix.DEPS_ROOT }}/jdk-toolchain -Pllvm_home=${{ matrix.DEPS_ROOT }}/llvm/image clean verify
 
     - name: 'Get cached JTReg'
       uses: actions/cache@v4

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ def static checkPath(String p) {
 }
 
 def llvm_home = project.property("llvm_home")
+def jdk_home = project.property("jdk23_home")
 checkPath(llvm_home)
 checkPath("${llvm_home}/lib/clang")
 def clang_versions = new File("${llvm_home}/lib/clang/").list();
@@ -39,7 +40,7 @@ if (clang_versions.length == 0) {
 def clang_version = clang_versions[0]
 
 def buildDir = layout.buildDirectory.get()
-def jextract_version = "22"
+def jextract_version = "23"
 def jmods_dir = "$buildDir/jmods"
 def jextract_jmod_file = "$jmods_dir/org.openjdk.jextract.jmod"
 def jextract_jmod_inputs = "$buildDir/jmod_inputs"
@@ -59,9 +60,9 @@ repositories {
 }
 
 compileJava {
-    options.release = 22
+    options.release = 23
     options.fork = true
-    options.forkOptions.executable = "${jdk22_home}/bin/javac${os_exe_suffix}"
+    options.forkOptions.executable = "${jdk_home}/bin/javac${os_exe_suffix}"
 }
 
 jar {
@@ -104,7 +105,7 @@ task createJextractJmod(type: Exec) {
         delete(jextract_jmod_file)
     }
 
-    executable = "${jdk22_home}/bin/jmod"
+    executable = "${jdk_home}/bin/jmod"
     args = [
           "create",
           "--module-version=$jextract_version",
@@ -131,7 +132,7 @@ task createJextractImage(type: Exec) {
         project.mkdir "${jextract_bin_dir}"
     }
 
-    executable = "${jdk22_home}/bin/jlink"
+    executable = "${jdk_home}/bin/jlink"
     args = [
          "--module-path=$jmods_dir",
          "--add-modules=org.openjdk.jextract",
@@ -183,9 +184,9 @@ task createRuntimeImageForTest(type: Exec) {
         delete(out_dir)
     }
 
-    executable = "${jdk22_home}/bin/jlink"
+    executable = "${jdk_home}/bin/jlink"
     args = [
-         "--module-path=$jmods_dir" + File.pathSeparator + "$jdk22_home/jmods",
+         "--module-path=$jmods_dir" + File.pathSeparator + "$jdk_home/jmods",
          "--add-modules=ALL-MODULE-PATH",
          "--output=$out_dir",
     ]

--- a/samples/python3/compilesource.sh
+++ b/samples/python3/compilesource.sh
@@ -3,6 +3,7 @@ if [[ -z "${ANACONDA3_HOME}" ]]; then
 fi
 
 jextract --output src \
+  -D_Float16=short \
   -l :${ANACONDA3_HOME}/lib/libpython3.11.dylib \
   -I ${ANACONDA3_HOME}/include/python3.11 \
   -t org.python \


### PR DESCRIPTION
We've updated native makefile to use JDK 23 (
https://github.com/openjdk/jextract/commit/0b89a462146940a2ec90e34eeb5df3d46d8980d2 )

While build.gradle works & expects jdk 23, it still refers to JDK var as "jdk22_home" and passes --release to be 22. Also jextract version is "22".

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Issue
 * [CODETOOLS-7903928](https://bugs.openjdk.org/browse/CODETOOLS-7903928): update build.gradle to use JDK 23 (**Bug** - P3) ⚠️ Issue is already resolved. Consider making this a "backport pull request" by setting the PR title to `Backport <hash>` with the hash of the original commit. See [Backports](https://wiki.openjdk.org/display/SKARA/Backports).


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/271/head:pull/271` \
`$ git checkout pull/271`

Update a local copy of the PR: \
`$ git checkout pull/271` \
`$ git pull https://git.openjdk.org/jextract.git pull/271/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 271`

View PR using the GUI difftool: \
`$ git pr show -t 271`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/271.diff">https://git.openjdk.org/jextract/pull/271.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/271#issuecomment-2579302793)
</details>
