### PR TITLE
7903932: Make private static classes final and have a private constructor

### DIFF
--- a/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
@@ -177,7 +177,9 @@ class HeaderFileBuilder extends ClassSourceBuilder {
             String holderClass = newHolderClassName(javaName);
             appendLines("""
 
-                private static class %1$s {
+                private static final class %1$s {
+                
+                    private %1$s(){ }
                     public static final FunctionDescriptor DESC = %2$s;
 
                     public static final MemorySegment ADDR = %3$s.findOrThrow("%4$s");
@@ -513,7 +515,9 @@ class HeaderFileBuilder extends ClassSourceBuilder {
             String dimsString = dimensions.stream().map(Object::toString)
                     .collect(Collectors.joining(", "));
             appendIndentedLines("""
-                private static class %1$s {
+                private static final class %1$s {
+                
+                    private %1$s(){ }
                     public static final %2$s LAYOUT = %3$s;
                     public static final MemorySegment SEGMENT = %4$s.findOrThrow("%5$s").reinterpret(LAYOUT.byteSize());
                 %6$s
@@ -523,7 +527,9 @@ class HeaderFileBuilder extends ClassSourceBuilder {
                     lookupName(var), accessHandle, dimsString);
         } else {
             appendIndentedLines("""
-                private static class %1$s {
+                private static final class %1$s {
+                   
+                    private %1$s(){ }
                     public static final %2$s LAYOUT = %3$s;
                     public static final MemorySegment SEGMENT = %4$s.findOrThrow("%5$s").reinterpret(LAYOUT.byteSize());
                 }

--- a/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
@@ -178,8 +178,9 @@ class HeaderFileBuilder extends ClassSourceBuilder {
             appendLines("""
 
                 private static final class %1$s {
-                
+
                     private %1$s(){ }
+
                     public static final FunctionDescriptor DESC = %2$s;
 
                     public static final MemorySegment ADDR = %3$s.findOrThrow("%4$s");
@@ -516,8 +517,9 @@ class HeaderFileBuilder extends ClassSourceBuilder {
                     .collect(Collectors.joining(", "));
             appendIndentedLines("""
                 private static final class %1$s {
-                
+
                     private %1$s(){ }
+
                     public static final %2$s LAYOUT = %3$s;
                     public static final MemorySegment SEGMENT = %4$s.findOrThrow("%5$s").reinterpret(LAYOUT.byteSize());
                 %6$s
@@ -528,8 +530,9 @@ class HeaderFileBuilder extends ClassSourceBuilder {
         } else {
             appendIndentedLines("""
                 private static final class %1$s {
-                   
+
                     private %1$s(){ }
+
                     public static final %2$s LAYOUT = %3$s;
                     public static final MemorySegment SEGMENT = %4$s.findOrThrow("%5$s").reinterpret(LAYOUT.byteSize());
                 }


### PR DESCRIPTION
Please review this patch to make static utility classes final with a private constructor, as they are not meant to be extended.

This is a small refractor of the generated code.

TIA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Issue
 * [CODETOOLS-7903932](https://bugs.openjdk.org/browse/CODETOOLS-7903932): Make private static classes final and have a private constructor (**Enhancement** - P4)


### Reviewers
 * [Per Minborg](https://openjdk.org/census#pminborg) (@minborg - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/274/head:pull/274` \
`$ git checkout pull/274`

Update a local copy of the PR: \
`$ git checkout pull/274` \
`$ git pull https://git.openjdk.org/jextract.git pull/274/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 274`

View PR using the GUI difftool: \
`$ git pr show -t 274`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/274.diff">https://git.openjdk.org/jextract/pull/274.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/274#issuecomment-2597656309)
</details>
