### PR TITLE
7903984: Inline upcallHandle method to reduce shared code across multiple generations

### DIFF
--- a/src/main/java/org/openjdk/jextract/impl/ClassSourceBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/ClassSourceBuilder.java
@@ -160,6 +160,15 @@ abstract class ClassSourceBuilder {
             """, className);
     }
 
+    final void emitPrivateConstructor() {
+        appendIndentedLines("""
+
+            private %1$s() {
+                // Should not be called directly
+            }
+            """, className);
+    }
+
     final void emitDocComment(Declaration decl) {
         emitDocComment(decl, "");
     }

--- a/src/main/java/org/openjdk/jextract/impl/FunctionalInterfaceBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/FunctionalInterfaceBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -82,8 +82,16 @@ final class FunctionalInterfaceBuilder extends ClassSourceBuilder {
 
     private void emitFunctionalFactory(String fiName) {
         appendIndentedLines("""
+            
+            static MethodHandle upcallHandle(Class<?> fi, String name, FunctionDescriptor fdesc) {
+                try {
+                    return MethodHandles.lookup().findVirtual(fi, name, fdesc.toMethodType());
+                } catch (ReflectiveOperationException ex) {
+                    throw new AssertionError(ex);
+                }
+            }
 
-            private static final MethodHandle UP$MH = %1$s.upcallHandle(%2$s.%3$s.class, "apply", $DESC);
+            private static final MethodHandle UP$MH = upcallHandle(%2$s.%3$s.class, "apply", $DESC);
 
             /**
              * Allocates a new upcall stub, whose implementation is defined by {@code fi}.

--- a/src/main/java/org/openjdk/jextract/impl/FunctionalInterfaceBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/FunctionalInterfaceBuilder.java
@@ -82,7 +82,7 @@ final class FunctionalInterfaceBuilder extends ClassSourceBuilder {
 
     private void emitFunctionalFactory(String fiName) {
         appendIndentedLines("""
-            
+
             static MethodHandle upcallHandle(Class<?> fi, String name, FunctionDescriptor fdesc) {
                 try {
                     return MethodHandles.lookup().findVirtual(fi, name, fdesc.toMethodType());

--- a/src/main/java/org/openjdk/jextract/impl/FunctionalInterfaceBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/FunctionalInterfaceBuilder.java
@@ -83,15 +83,15 @@ final class FunctionalInterfaceBuilder extends ClassSourceBuilder {
     private void emitFunctionalFactory(String fiName) {
         appendIndentedLines("""
 
-            static MethodHandle upcallHandle(Class<?> fi, String name, FunctionDescriptor fdesc) {
+            static MethodHandle upcallHandle() {
                 try {
-                    return MethodHandles.lookup().findVirtual(fi, name, fdesc.toMethodType());
+                    return MethodHandles.lookup().findVirtual(%2$s.%3$s.class, "apply", $DESC.toMethodType());
                 } catch (ReflectiveOperationException ex) {
                     throw new AssertionError(ex);
                 }
             }
 
-            private static final MethodHandle UP$MH = upcallHandle(%2$s.%3$s.class, "apply", $DESC);
+            private static final MethodHandle UP$MH = upcallHandle();
 
             /**
              * Allocates a new upcall stub, whose implementation is defined by {@code fi}.

--- a/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
@@ -368,14 +368,6 @@ class HeaderFileBuilder extends ClassSourceBuilder {
                 return SYMBOL_LOOKUP.findOrThrow(symbol);
             }
 
-            static MethodHandle upcallHandle(Class<?> fi, String name, FunctionDescriptor fdesc) {
-                try {
-                    return MethodHandles.lookup().findVirtual(fi, name, fdesc.toMethodType());
-                } catch (ReflectiveOperationException ex) {
-                    throw new AssertionError(ex);
-                }
-            }
-
             static MemoryLayout align(MemoryLayout layout, long align) {
                 return switch (layout) {
                     case PaddingLayout p -> p;

--- a/test/testng/org/openjdk/jextract/test/toolprovider/TestClassGeneration.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/TestClassGeneration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -192,7 +192,7 @@ public class TestClassGeneration extends JextractToolRunner {
     @Test(dataProvider = "functionalInterfaces")
     public void testFunctionalInterface(String name, MethodType type) {
         Class<?> fpClass = loader.loadClass("com.acme." + name);
-        checkDefaultConstructor(fpClass);
+        checkPrivateConstructor(fpClass);
         Class<?> fiClass = findNestedClass(fpClass, "Function");
         assertNotNull(fiClass);
         checkMethod(fiClass, "apply", type);
@@ -226,6 +226,15 @@ public class TestClassGeneration extends JextractToolRunner {
             assertEquals(c.getModifiers(), 0, "Unexpected constructor modifiers");
         } catch (ReflectiveOperationException ex) {
             fail("Default constructor not found!");
+        }
+    }
+
+    private void checkPrivateConstructor(Class<?> cls) {
+        try {
+            Constructor<?> c = cls.getDeclaredConstructor();
+            assertEquals(c.getModifiers(), Modifier.PRIVATE, "Unexpected constructor modifiers");
+        } catch (ReflectiveOperationException ex) {
+            fail("Private constructor not found!");
         }
     }
 }


### PR DESCRIPTION
Please review this patch to inline the upcallHandle method, reducing the amount of shared items across multiple jextract generations.

Edit: all tests pass in CI, GitHub failure is unrelated 

TIA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Issue
 * [CODETOOLS-7903984](https://bugs.openjdk.org/browse/CODETOOLS-7903984): Inline upcallHandle method to reduce shared code across multiple generations (**Enhancement** - P4)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**) ⚠️ Review applies to [3d387faf](https://git.openjdk.org/jextract/pull/279/files/3d387fafb85cfa5848a04fb3f778ebad46037847)
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - Committer) ⚠️ Review applies to [273f5f22](https://git.openjdk.org/jextract/pull/279/files/273f5f22b4accfe74d806cb9ad430d4c71ae89c2)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/279/head:pull/279` \
`$ git checkout pull/279`

Update a local copy of the PR: \
`$ git checkout pull/279` \
`$ git pull https://git.openjdk.org/jextract.git pull/279/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 279`

View PR using the GUI difftool: \
`$ git pr show -t 279`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/279.diff">https://git.openjdk.org/jextract/pull/279.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/279#issuecomment-2761506259)
</details>
