### PR TITLE
7903983: Remove redundant findOrThrow method

### DIFF
--- a/doc/GUIDE.md
+++ b/doc/GUIDE.md
@@ -988,7 +988,7 @@ A complete list of all the supported command line options is given below:
 | `--include-[function,constant,struct,union,typedef,var]<String>` | Include a symbol of the given name and kind in the generated bindings. When one of these options is specified, any symbol that is not matched by any specified filters is omitted from the generated bindings. |
 | `--version`                                                  | print version information and exit |
 | `-F <dir>` (macOs only)                                          | specify the framework directory include files. Defaults to the current Mac OS X SDK dir.|
-| `-framework <framework>` (macOs only)                            | specify the name of the library, path will be expanded to that of the framework folder.|
+| `--framework <framework>` (macOs only)                           | specify the name of the library, path will be expanded to that of the framework folder.|
 
 
 Jextract accepts one or more header files. When multiple header files are specified,

--- a/samples/opengl/compilesource.sh
+++ b/samples/opengl/compilesource.sh
@@ -1,5 +1,5 @@
-jextract -t opengl -framework GLUT \
-  -framework OpenGL \
+jextract -t opengl --framework GLUT \
+  --framework OpenGL \
   "<GLUT/glut.h>"
 
 javac --source=22 -d . opengl/*.java

--- a/src/main/java/org/openjdk/jextract/JextractTool.java
+++ b/src/main/java/org/openjdk/jextract/JextractTool.java
@@ -370,7 +370,7 @@ public final class JextractTool {
 
         if (isMacOSX) {
             parser.accepts("-F", "help.mac.framework", true);
-            parser.accepts("-framework", "help.framework.library.path", true);
+            parser.accepts("--framework", "help.framework.library.path", true);
         }
 
         OptionSet optionSet;
@@ -536,10 +536,13 @@ public final class JextractTool {
     }
 
     private int parseLibraries(String optionString, OptionSet optionSet, boolean useSystemLoadLibrary, Options.Builder builder) {
-        if (optionSet.has("-" + optionString)) {
-            for (String lib : optionSet.valuesOf("-" + optionString)) {
+        String cmdOption = optionString.length() < 3 ?
+                "-" + optionString :
+                "--" + optionString;
+        if (optionSet.has(cmdOption)) {
+            for (String lib : optionSet.valuesOf(cmdOption)) {
                 try {
-                    String spec = optionString.equals("framework") ?
+                    String spec = cmdOption.equals("--framework") ?
                             resolveFrameworkPath(lib) :
                             lib;
 

--- a/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
@@ -180,12 +180,12 @@ class HeaderFileBuilder extends ClassSourceBuilder {
                 private static class %1$s {
                     public static final FunctionDescriptor DESC = %2$s;
 
-                    public static final MemorySegment ADDR = %3$s.findOrThrow("%4$s");
+                    public static final MemorySegment ADDR = SYMBOL_LOOKUP.findOrThrow("%3$s");
 
                     public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(ADDR, DESC);
                 }
                 """, holderClass, functionDescriptorString(1, decl.type()),
-                    runtimeHelperName(), lookupName(decl));
+                    lookupName(decl));
             appendBlankLine();
             emitDocComment(decl, "Function descriptor for:");
             appendLines("""
@@ -232,19 +232,19 @@ class HeaderFileBuilder extends ClassSourceBuilder {
             appendLines("""
                 public static class %1$s {
                     private static final FunctionDescriptor BASE_DESC = %2$s;
-                    private static final MemorySegment ADDR = %3$s.findOrThrow("%4$s");
+                    private static final MemorySegment ADDR = SYMBOL_LOOKUP.findOrThrow("%3$s");
 
                     private final MethodHandle handle;
                     private final FunctionDescriptor descriptor;
                     private final MethodHandle spreader;
 
-                    private %5$s(MethodHandle handle, FunctionDescriptor descriptor, MethodHandle spreader) {
+                    private %4$s(MethodHandle handle, FunctionDescriptor descriptor, MethodHandle spreader) {
                         this.handle = handle;
                         this.descriptor = descriptor;
                         this.spreader = spreader;
                     }
                 """, invokerClassName, functionDescriptorString(2, decl.type()),
-                    runtimeHelperName(), lookupName(decl), invokerClassName);
+                    lookupName(decl), invokerClassName);
             incrAlign();
             appendBlankLine();
             emitDocComment(decl, "Variadic invoker factory for:");
@@ -362,10 +362,6 @@ class HeaderFileBuilder extends ClassSourceBuilder {
                                .map(Object::toString)
                                .collect(Collectors.joining(", "));
                  System.out.printf("%s(%s)\\n", name, traceArgs);
-            }
-
-            static MemorySegment findOrThrow(String symbol) {
-                return SYMBOL_LOOKUP.findOrThrow(symbol);
             }
 
             static MethodHandle upcallHandle(Class<?> fi, String name, FunctionDescriptor fdesc) {
@@ -515,19 +511,19 @@ class HeaderFileBuilder extends ClassSourceBuilder {
             appendIndentedLines("""
                 private static class %1$s {
                     public static final %2$s LAYOUT = %3$s;
-                    public static final MemorySegment SEGMENT = %4$s.findOrThrow("%5$s").reinterpret(LAYOUT.byteSize());
-                %6$s
-                    public static final long[] DIMS = { %7$s };
+                    public static final MemorySegment SEGMENT = SYMBOL_LOOKUP.findOrThrow("%4$s").reinterpret(LAYOUT.byteSize());
+                %5$s
+                    public static final long[] DIMS = { %6$s };
                 }
-                """, mangledName, layoutType, layoutString(varType), runtimeHelperName(),
-                    lookupName(var), accessHandle, dimsString);
+                """, mangledName, layoutType, layoutString(varType),lookupName(var),
+                    accessHandle, dimsString);
         } else {
             appendIndentedLines("""
                 private static class %1$s {
                     public static final %2$s LAYOUT = %3$s;
-                    public static final MemorySegment SEGMENT = %4$s.findOrThrow("%5$s").reinterpret(LAYOUT.byteSize());
+                    public static final MemorySegment SEGMENT = SYMBOL_LOOKUP.findOrThrow("%4$s").reinterpret(LAYOUT.byteSize());
                 }
-                """, mangledName, layoutType, layoutString(varType), runtimeHelperName(), lookupName(var));
+                """, mangledName, layoutType, layoutString(varType), lookupName(var));
         }
         incrAlign();
         appendBlankLine();

--- a/src/main/resources/org/openjdk/jextract/impl/resources/Messages.properties
+++ b/src/main/resources/org/openjdk/jextract/impl/resources/Messages.properties
@@ -88,7 +88,7 @@ Option                             Description                                  
 \                                                                                               \n\
 macOS platform options for running jextract (available only when running on macOS):             \n\
 -F <dir>            specify the framework directory                                     \n\
--framework <framework>                     specify framework library. -framework libGL is equivalent to         \n\
+--framework <framework>                     specify framework library. --framework libGL is equivalent to         \n\
 \                                      -l :/System/Library/Frameworks/libGL.framework/libGL
 
 jextract.version=\


### PR DESCRIPTION
`SymbolLookup::FindOrThrow` was introduced in JDK 23, making this method in the generated code redundant:
```
  static MemorySegment findOrThrow(String symbol) {
      return SYMBOL_LOOKUP.findOrThrow(symbol);
  }
```
The generated method should have been dropped in https://github.com/openjdk/jextract/commit/a53f5c05e3ee2cca057cadb78b2e381c39f943d7 but I didn't cleanup all uses of it.

A small additional cleanup in PR is that the newly added option for framworks now uses `--` rather than `-`

Edit: all tests pass in CI on all platforms, GitHub failure is unrelated 

TIA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Issue
 * [CODETOOLS-7903983](https://bugs.openjdk.org/browse/CODETOOLS-7903983): Remove redundant findOrThrow method (**Enhancement** - P4)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/280/head:pull/280` \
`$ git checkout pull/280`

Update a local copy of the PR: \
`$ git checkout pull/280` \
`$ git pull https://git.openjdk.org/jextract.git pull/280/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 280`

View PR using the GUI difftool: \
`$ git pr show -t 280`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/280.diff">https://git.openjdk.org/jextract/pull/280.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/280#issuecomment-2761519435)
</details>
