### PR TITLE
7903877: jextract exception handling in downcall wrappers

### DIFF
--- a/src/main/java/org/openjdk/jextract/impl/FunctionalInterfaceBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/FunctionalInterfaceBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -110,6 +110,8 @@ final class FunctionalInterfaceBuilder extends ClassSourceBuilder {
             public static %1$s invoke(MemorySegment funcPtr%2$s%3$s) {
                 try {
                     %4$s DOWN$MH.invokeExact(funcPtr%5$s%6$s);
+                } catch (Error | RuntimeException ex) {
+                    throw ex;
                 } catch (Throwable ex$) {
                     throw new AssertionError("should not reach here", ex$);
                 }

--- a/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
@@ -217,6 +217,8 @@ class HeaderFileBuilder extends ClassSourceBuilder {
                         traceDowncall(%5$s);
                     }
                     %6$smh$.invokeExact(%7$s);
+                } catch (Error | RuntimeException ex) {
+                   throw ex;
                 } catch (Throwable ex$) {
                    throw new AssertionError("should not reach here", ex$);
                 }
@@ -454,6 +456,8 @@ class HeaderFileBuilder extends ClassSourceBuilder {
                 public static MemorySegment %1$s(%2$s) {
                     try {
                         return (MemorySegment)%3$s.HANDLE.invokeExact(%3$s.SEGMENT, 0L, %4$s);
+                    } catch (Error | RuntimeException ex) {
+                        throw ex;
                     } catch (Throwable ex$) {
                         throw new AssertionError("should not reach here", ex$);
                     }

--- a/src/main/java/org/openjdk/jextract/impl/StructBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/StructBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -261,6 +261,8 @@ final class StructBuilder extends ClassSourceBuilder implements OutputFactory.Bu
                 public static MemorySegment %1$s(MemorySegment %2$s, %3$s) {
                     try {
                         return (MemorySegment)%4$s.invokeExact(%2$s, 0L, %5$s);
+                    } catch (Error | RuntimeException ex) {
+                        throw ex;
                     } catch (Throwable ex$) {
                         throw new AssertionError("should not reach here", ex$);
                     }

--- a/test/jtreg/generator/reachableException/TestReachableException.java
+++ b/test/jtreg/generator/reachableException/TestReachableException.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.util.concurrent.*;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import test.jextract.reachableException.*;
+
+/*
+ * @test
+ * @library /lib
+ * @build testlib.TestUtils
+ * @run main/othervm JtregJextract -t test.jextract.reachableException reachableException.h
+ * @build TestReachableException
+ * @run junit/othervm --enable-native-access=ALL-UNNAMED TestReachableException
+ */
+
+public class TestReachableException {
+
+    private Arena confinedArena;
+    private MemorySegment callbackSegment;
+
+    @BeforeEach
+    public void setup() {
+        confinedArena = Arena.ofConfined();
+        callbackSegment = simple_callback.allocate(value ->
+                System.out.println("Value: " + value), confinedArena);
+    }
+
+    @AfterEach
+    public void cleanup() {
+        if (confinedArena != null && confinedArena.scope().isAlive()) {
+            confinedArena.close();
+        }
+    }
+
+    @Test
+    void testWrongThreadAccess() throws Exception {
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try {
+            Future<Throwable> future = executor.submit(() -> {
+                try {
+                    simple_callback.invoke(callbackSegment, 42);
+                    return null;
+                } catch (Throwable t) {
+                    return t;
+                }
+            });
+
+            Throwable thrown = future.get(5, TimeUnit.SECONDS);
+
+            assertNotNull(thrown, "Expected an exception when accessing from wrong thread");
+            assertInstanceOf(WrongThreadException.class, thrown,
+                    "Expected WrongThreadException but got: " + thrown.getClass().getName());
+
+        } finally {
+            executor.shutdown();
+        }
+    }
+
+    @Test
+    void testSameThreadAccess() {
+        assertDoesNotThrow(() -> {
+            simple_callback.invoke(callbackSegment, 42);
+        }, "No exception should be thrown when accessing from the same thread");
+    }
+
+    @Test
+    void testExceptionTypePreservation() throws Exception {
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try {
+            Future<Class<?>> future = executor.submit(() -> {
+                try {
+                    simple_callback.invoke(callbackSegment, 42);
+                    return null;
+                } catch (Throwable t) {
+                    return t.getClass();
+                }
+            });
+
+            Class<?> exceptionClass = future.get(5, TimeUnit.SECONDS);
+            assertEquals(WrongThreadException.class, exceptionClass,
+                    "Exception should be WrongThreadException, not wrapped in AssertionError");
+
+        } finally {
+            executor.shutdown();
+        }
+    }
+}

--- a/test/jtreg/generator/reachableException/reachableException.h
+++ b/test/jtreg/generator/reachableException/reachableException.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+typedef void (*simple_callback)(int value);
+
+void register_callback(simple_callback cb);
+
+void invoke_callback(int value);


### PR DESCRIPTION
Can I please get a review for this patch to improve the exception handling in downcall wrappers, if the exception is reachable then throwing an exception is better than catching an exception and turning them into an `AssertionError`.

TIA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Issue
 * [CODETOOLS-7903877](https://bugs.openjdk.org/browse/CODETOOLS-7903877): jextract exception handling in downcall wrappers (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/281/head:pull/281` \
`$ git checkout pull/281`

Update a local copy of the PR: \
`$ git checkout pull/281` \
`$ git pull https://git.openjdk.org/jextract.git pull/281/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 281`

View PR using the GUI difftool: \
`$ git pr show -t 281`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/281.diff">https://git.openjdk.org/jextract/pull/281.diff</a>

</details>
