### PR TITLE
Gradle cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -129,7 +129,7 @@ tasks.register("createJextractImage", Exec) {
 
     doFirst {
         delete(jextract_app_dir)
-        project.mkdir "${jextract_bin_dir}"
+        Files.createDirectories(Path.of(jextract_bin_dir))
     }
 
     executable = "${jdk_home}/bin/jlink"

--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,7 @@ jar {
     archiveVersion = project.version
 }
 
-task copyLibClang(type: Sync) {
+tasks.register("copyLibClang", Sync) {
     into("$buildDir/jmod_inputs")
 
     // make sure we only pick up the "real" shared library file from LLVM installation
@@ -93,7 +93,7 @@ task copyLibClang(type: Sync) {
     }
 }
 
-task createJextractJmod(type: Exec) {
+tasks.register("createJextractJmod", Exec) {
     dependsOn jar, copyLibClang
 
     // if these inputs or outputs change, gradle will rerun the task
@@ -116,7 +116,7 @@ task createJextractJmod(type: Exec) {
     ]
 }
 
-task createJextractImage(type: Exec) {
+tasks.register("createJextractImage", Exec) {
     dependsOn createJextractJmod
 
     // if these inputs or outputs change, gradle will rerun the task
@@ -163,7 +163,7 @@ task createJextractImage(type: Exec) {
 assemble.dependsOn(createJextractImage)
 
 // very simple integration test for generated jextract
-task verify(type: Exec) {
+tasks.register("verify", Exec) {
     dependsOn createJextractImage
 
     executable = "${jextract_bin_dir}/jextract${os_script_extension}"
@@ -171,7 +171,7 @@ task verify(type: Exec) {
 }
 
 // jlink a JDK image with org.openjdk.jextract for testing
-task createRuntimeImageForTest(type: Exec) {
+tasks.register("createRuntimeImageForTest", Exec) {
     dependsOn createJextractJmod
 
     def out_dir = "$buildDir/jextract-jdk-test-image"
@@ -192,7 +192,7 @@ task createRuntimeImageForTest(type: Exec) {
     ]
 }
 
-task cmakeConfigure(type: Exec) {
+tasks.register("cmakeConfigure", Exec) {
     executable = "cmake"
     args = [
         "-B", "$buildDir/testlib-build",
@@ -203,7 +203,7 @@ task cmakeConfigure(type: Exec) {
     ]
 }
 
-task cmakeBuild(type: Exec) {
+tasks.register("cmakeBuild", Exec) {
     dependsOn cmakeConfigure
 
     executable = "cmake"

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,4 @@
+import org.apache.groovy.nio.extensions.NioExtensions
 import org.apache.tools.ant.taskdefs.condition.Os
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -97,12 +98,12 @@ tasks.register("createJextractJmod", Exec) {
     dependsOn copyLibClang
 
     // if these inputs or outputs change, gradle will rerun the task
-    inputs.file(tasks.named('jar', Jar).flatMap { it.archiveFile})
+    inputs.file(tasks.named('jar', Jar).flatMap { it.archiveFile })
     inputs.dir("$jextract_jmod_inputs")
     outputs.file(jextract_jmod_file)
 
     doFirst {
-        delete(jextract_jmod_file)
+        Files.deleteIfExists(Path.of(jextract_jmod_file))
     }
 
     executable = "${jdk_home}/bin/jmod"
@@ -119,7 +120,11 @@ tasks.register("createJextractJmod", Exec) {
 tasks.register("createJextractImage", Exec) {
     dependsOn createJextractJmod
 
+    def main_sources = "$projectDir/src/main"
     // if these inputs or outputs change, gradle will rerun the task
+    inputs.file("$main_sources/jextract")
+    inputs.file("$main_sources/jextract.bat")
+    inputs.file("$main_sources/jextract.ps1")
     inputs.file("$jextract_jmod_file")
     outputs.dir(jextract_app_dir)
 
@@ -128,7 +133,7 @@ tasks.register("createJextractImage", Exec) {
         '"--enable-native-access=org.openjdk.jextract"'
 
     doFirst {
-        delete(jextract_app_dir)
+        NioExtensions.deleteDir(Path.of(jextract_app_dir))
         Files.createDirectories(Path.of(jextract_bin_dir))
     }
 
@@ -145,7 +150,7 @@ tasks.register("createJextractImage", Exec) {
     doLast {
         // Add launcher scripts
         Path unixOut = Path.of("${jextract_bin_dir}/jextract");
-        Files.copy(Path.of("$projectDir/src/main/jextract"), unixOut);
+        Files.copy(Path.of("$main_sources/jextract"), unixOut);
         if (unixOut.getFileSystem().supportedFileAttributeViews().contains("posix")) {
             Set<PosixFilePermission> perms = Files.getPosixFilePermissions(unixOut);
             perms.add(PosixFilePermission.OWNER_EXECUTE);
@@ -154,8 +159,8 @@ tasks.register("createJextractImage", Exec) {
             Files.setPosixFilePermissions(unixOut, perms);
         }
 
-        Files.copy(Path.of("$projectDir/src/main/jextract.bat"), Path.of("${jextract_bin_dir}/jextract.bat"))
-        Files.copy(Path.of("$projectDir/src/main/jextract.ps1"), Path.of("${jextract_bin_dir}/jextract.ps1"))
+        Files.copy(Path.of("$main_sources/jextract.bat"), Path.of("${jextract_bin_dir}/jextract.bat"))
+        Files.copy(Path.of("$main_sources/jextract.ps1"), Path.of("${jextract_bin_dir}/jextract.ps1"))
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -94,10 +94,10 @@ tasks.register("copyLibClang", Sync) {
 }
 
 tasks.register("createJextractJmod", Exec) {
-    dependsOn jar, copyLibClang
+    dependsOn copyLibClang
 
     // if these inputs or outputs change, gradle will rerun the task
-    inputs.file(jar.archiveFile.get())
+    inputs.file(tasks.named('jar', Jar).flatMap { it.archiveFile})
     inputs.dir("$jextract_jmod_inputs")
     outputs.file(jextract_jmod_file)
 


### PR DESCRIPTION
I've been doing some development, and came across a few warnings during build.

These are, [Project::task](https://docs.gradle.org/current/javadoc/org/gradle/api/Project.html#task(java.lang.String)) is now deprecated, avoiding Project::mkdir, project::delete and Project::getProjectDir as they cannot work under configuration-cache.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/283/head:pull/283` \
`$ git checkout pull/283`

Update a local copy of the PR: \
`$ git checkout pull/283` \
`$ git pull https://git.openjdk.org/jextract.git pull/283/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 283`

View PR using the GUI difftool: \
`$ git pr show -t 283`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/283.diff">https://git.openjdk.org/jextract/pull/283.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/283#issuecomment-3029350359)
</details>
