### PR TITLE
7904051: Jextract should generate symbols in the same class consistently

### DIFF
--- a/src/main/java/org/openjdk/jextract/impl/Parser.java
+++ b/src/main/java/org/openjdk/jextract/impl/Parser.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
+ *  Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  *  This code is free software; you can redistribute it and/or modify it
@@ -38,6 +38,7 @@ import org.openjdk.jextract.clang.TranslationUnit;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -91,6 +92,8 @@ public class Parser {
         });
 
         decls.addAll(macroParser.macroTable.reparseConstants());
+        decls.sort(Comparator.comparing(Declaration::name, String.CASE_INSENSITIVE_ORDER)
+                        .thenComparing(Declaration::name, Comparator.reverseOrder()));
         Declaration.Scoped rv = treeMaker.createHeader(tuCursor, decls);
         return rv;
     }

--- a/test/testng/org/openjdk/jextract/test/toolprovider/docComments/TestDocComments.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/docComments/TestDocComments.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -69,10 +69,10 @@ public class TestDocComments extends JextractToolRunner {
     public void testTypedefs() throws IOException {
         var comments = getDocComments("typedefs.h", "typedefs_h.java");
         assertEquals(comments, List.of(
-            "typedef unsigned long long size_t",
             "typedef int INT_32",
             "typedef int *INT_PTR",
-            "typedef struct Foo *OPAQUE_PTR"));
+            "typedef struct Foo *OPAQUE_PTR",
+            "typedef unsigned long long size_t"));
     }
 
     @Test


### PR DESCRIPTION
Copying the bug description:

> A symbol, depending on the order that clang found it will not necessarily be in the same class every time.
The IDE works against you here, when you navigate to a symbol and it exists in header number 4 for example, it will sometimes automatically import header number 4 so you have to go and change it because you want to get it from the top level class.
>If you don't do that, you build a dependency for your platform into the generated code.
>The symbols not being consistent across platforms can be fixed by sorting the symbols.

Very simple change, done in a way to not break existing code as a simple sort would've changed the names of variables in the generated code.
There was a test case that had to be updated.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Issue
 * [CODETOOLS-7904051](https://bugs.openjdk.org/browse/CODETOOLS-7904051): Jextract should generate symbols in the same class consistently (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/286/head:pull/286` \
`$ git checkout pull/286`

Update a local copy of the PR: \
`$ git checkout pull/286` \
`$ git pull https://git.openjdk.org/jextract.git pull/286/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 286`

View PR using the GUI difftool: \
`$ git pr show -t 286`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/286.diff">https://git.openjdk.org/jextract/pull/286.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/286#issuecomment-3019858391)
</details>
