### PR TITLE
7903947: Access to function pointers  in structs could be streamlined

### DIFF
--- a/src/main/java/org/openjdk/jextract/JextractTool.java
+++ b/src/main/java/org/openjdk/jextract/JextractTool.java
@@ -145,7 +145,7 @@ public final class JextractTool {
         return logger.hasErrors() ?
                 List.of() :
                 List.of(OutputFactory.generateWrapped(transformedDecl, targetPkg, options.libraries, options.useSystemLoadLibrary,
-                        options.sharedClassName));
+                        options.includeHelper, options.sharedClassName));
     }
 
     /**

--- a/src/main/java/org/openjdk/jextract/impl/OutputFactory.java
+++ b/src/main/java/org/openjdk/jextract/impl/OutputFactory.java
@@ -47,10 +47,11 @@ public class OutputFactory implements Declaration.Visitor<Void, Declaration> {
                                                    String pkgName,
                                                    List<Options.Library> libs,
                                                    boolean useSystemLoadLibrary,
+                                                   IncludeHelper includeHelper,
                                                    String sharedClassName) {
         String clsName = JavaName.getOrThrow(decl);
         ToplevelBuilder toplevelBuilder = new ToplevelBuilder(pkgName, clsName,
-                libs, useSystemLoadLibrary, sharedClassName);
+                libs, useSystemLoadLibrary, sharedClassName, includeHelper);
         return new OutputFactory(toplevelBuilder).generate(decl);
     }
 

--- a/src/main/java/org/openjdk/jextract/impl/Utils.java
+++ b/src/main/java/org/openjdk/jextract/impl/Utils.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
+ *  Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  *  This code is free software; you can redistribute it and/or modify it
@@ -150,6 +150,17 @@ class Utils {
             default -> false;
         };
     }
+
+    static boolean isFunctionPointer(Type type) {
+        return switch (type) {
+            case Type.Delegated delegated when delegated.kind() == Delegated.Kind.POINTER ->
+                    delegated.type() instanceof Type.Function;
+            case Type.Delegated delegated when delegated.kind() == Delegated.Kind.TYPEDEF ->
+                    isFunctionPointer(delegated.type());
+            default -> false;
+        };
+    }
+
 
     static boolean isPrimitive(Type type) {
         return switch (type) {

--- a/test/jtreg/generator/functionalDispatch/FunctionalDispatch.java
+++ b/test/jtreg/generator/functionalDispatch/FunctionalDispatch.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * @test
+ * @library /lib
+ * @build testlib.TestUtils
+ * @bug 7903947
+ * @summary test option to streamline access to function pointers
+ * @run main/othervm JtregJextract
+ *      --include-typedef DupStruct,functional
+ *      --include-typedef Funcs,functional
+ *      --include-typedef Simple,functional
+ *      -t test.jextract.functional_dispatch functional_dispatch.h
+ * @build FunctionalDispatch
+ * @run testng/othervm --enable-native-access=ALL-UNNAMED FunctionalDispatch
+ */
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import test.jextract.functional_dispatch.*;
+
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+
+public class FunctionalDispatch {
+    @Test
+    public void testSimpleStruct() {
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment s = Simple.allocate(arena);
+            assertEquals(Simple.value(s), 0);
+            Simple.value(s, 999);
+            assertEquals(Simple.value(s), 999);
+        }
+    }
+
+    @Test
+    public void testFuncsFunctionalDispatch() {
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment f = Funcs.allocate(arena);
+
+            Funcs.zero.Function zeroLam = () -> 7;
+            MemorySegment zeroPtr = Funcs.zero.allocate(zeroLam, arena);
+            Funcs.zero(f, zeroPtr);
+            assertEquals(Funcs.zero(f), 7);
+
+            Funcs.one.Function oneLam = x -> x * 3;
+            MemorySegment onePtr = Funcs.one.allocate(oneLam, arena);
+            Funcs.one(f, onePtr);
+            assertEquals(Funcs.one(f, 5), 15);
+
+            Funcs.sum.Function sumLam = (a, b) -> a + b;
+            MemorySegment sumPtr = Funcs.sum.allocate(sumLam, arena);
+            Funcs.sum(f, sumPtr);
+            assertEquals(Funcs.sum(f, 100L, 23L), 123L);
+
+            Funcs.make_point.Function mpLam = (x, y) -> {
+                MemorySegment p = Funcs.Point.allocate(arena);
+                Funcs.Point.x(p, x);
+                Funcs.Point.y(p, y);
+                return p;
+            };
+            MemorySegment mpPtr = Funcs.make_point.allocate(mpLam, arena);
+            Funcs.make_point(f, mpPtr);
+            MemorySegment p = Funcs.make_point(f, arena, 8, 9);
+            assertEquals(Funcs.Point.x(p), 8);
+            assertEquals(Funcs.Point.y(p), 9);
+        }
+    }
+
+    @Test
+    public void testDupStructFunctional() {
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment ds = DupStruct.allocate(arena);
+
+            DupStruct.dup.Function dupLam = () -> {
+                MemorySegment s = Simple.allocate(arena);
+                Simple.value(s, 555);
+                return s;
+            };
+            MemorySegment dupPtr = DupStruct.dup.allocate(dupLam, arena);
+            DupStruct.dup(ds, dupPtr);
+            MemorySegment result = DupStruct.dup(ds, arena);
+            assertEquals(Simple.value(result), 555);
+        }
+    }
+}

--- a/test/jtreg/generator/functionalDispatch/functional_dispatch.h
+++ b/test/jtreg/generator/functionalDispatch/functional_dispatch.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+ typedef struct {
+    int    (*zero)();
+    int    (*one)(int);
+    long   (*sum)(long, long);
+    struct Point { int x; int y; } (*make_point)(int, int);
+} Funcs;
+
+typedef struct { int value; } Simple;
+
+typedef struct {
+    Simple (*dup)();
+} DupStruct;


### PR DESCRIPTION
Please review this patch to add a new option where you can generate an direct invoker methods. This feature is intended to be used on structs that are just a collection of functions we had like to call.

If this feature is used, we remove the getter to avoid name collisions as we assume this is similar to an interface.

Changes to `GUIDE.md` have been intentionally left out from this initial patch to make reviews easier.

```C
struct Foo {
    struct Bar (*a)(void);
    struct Bar (*b)(int);
};
```

Before 

```java
var foo = alloc_callback_h.foo();

var barA = Foo.a.invoke(Foo.a(foo), arena);
var barB = Foo.b.invoke(Foo.b(foo), arena, 100);
```

After 

```java
var foo = alloc_callback_h.foo();

var barA = Foo.a(foo, arena);
var barB = Foo.b(foo, arena, 100);

```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Issue
 * [CODETOOLS-7903947](https://bugs.openjdk.org/browse/CODETOOLS-7903947): Access to function pointers  in structs could be streamlined (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/287/head:pull/287` \
`$ git checkout pull/287`

Update a local copy of the PR: \
`$ git checkout pull/287` \
`$ git pull https://git.openjdk.org/jextract.git pull/287/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 287`

View PR using the GUI difftool: \
`$ git pr show -t 287`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/287.diff">https://git.openjdk.org/jextract/pull/287.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/287#issuecomment-3107936946)
</details>
