### PR TITLE
7904073: Derive required symbols from client code to minimize generated bindings

### DIFF
--- a/samples/opengl-minimal-bidings/NativeSymbolLister.java
+++ b/samples/opengl-minimal-bidings/NativeSymbolLister.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   - Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   - Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ *   - Neither the name of Oracle nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.*;
+import java.util.*;
+import java.util.stream.Stream;
+import java.lang.classfile.ClassFile;
+import java.lang.classfile.ClassModel;
+import java.lang.classfile.CodeModel;
+import java.lang.classfile.MethodModel;
+import java.lang.classfile.instruction.InvokeInstruction;
+import java.lang.classfile.instruction.FieldInstruction;
+
+/**
+ * Scans a directory of compiled client class files and lists all native
+ * symbols referenced and writes the sorted, unique list of symbols into an output file.
+ * Requires JDK 24+ (java.lang.classfile API).
+ *
+ * Usage:
+ *   java --enable-preview NativeSymbolLister <clientClasses-dir> <output-file>
+ */
+public class NativeSymbolLister {
+    public static void main(String[] args) throws IOException {
+        if (args.length != 2) {
+            System.err.println("Usage: java NativeSymbolLister <clientClasses-dir> <output-file>");
+            System.exit(1);
+        }
+        Path dir = Paths.get(args[0]);
+        Path output = Paths.get(args[1]);
+        if (!Files.isDirectory(dir)) {
+            System.err.println("Not a directory: " + dir);
+            System.exit(1);
+        }
+
+        Set<String> symbols = new TreeSet<>();
+        try (Stream<Path> paths = Files.walk(dir)) {
+            paths.filter(p -> p.toString().endsWith(".class"))
+                    .forEach(p -> {
+                        try {
+                            byte[] bytes = Files.readAllBytes(p);
+                            symbols.addAll(extractSymbols(bytes));
+                        } catch (IOException e) {
+                            System.err.println("Failed to read " + p + ": " + e.getMessage());
+                        }
+                    });
+        }
+
+        try (BufferedWriter writer = Files.newBufferedWriter(output, StandardCharsets.UTF_8)) {
+            for (String sym : symbols) {
+                writer.write(sym);
+                writer.newLine();
+            }
+        }
+
+        System.out.println("Symbols written to " + output + " (" + symbols.size() + " entries)");
+    }
+
+    private static Set<String> extractSymbols(byte[] classBytes) {
+        Set<String> set = new HashSet<>();
+        ClassModel cm = ClassFile.of().parse(classBytes);
+        cm.elementStream()
+                .flatMap(ce -> ce instanceof MethodModel mm
+                        ? mm.elementStream()
+                        .flatMap(me -> me instanceof CodeModel code
+                                ? code.elementStream()
+                                : Stream.empty())
+                        : Stream.empty())
+                .forEach(elem -> {
+                    if (elem instanceof InvokeInstruction inv) {
+                        String name = inv.name().stringValue();
+                        if (!"<init>".equals(name) && !"<clinit>".equals(name)) {
+                            set.add(name);
+                        }
+                    } else if (elem instanceof FieldInstruction fld) {
+                        set.add(fld.name().stringValue());
+                    }
+                });
+        return set;
+    }
+}

--- a/samples/opengl-minimal-bidings/README.md
+++ b/samples/opengl-minimal-bidings/README.md
@@ -1,0 +1,36 @@
+# jextract symbol filtering sample
+
+This sample demonstrates how to analyze compiled client code to discover which native symbols are actually used.  
+The workflow is:
+
+1. Run `jextract` to dump all includes.
+2. Compile and run `NativeSymbolLister` on your client classes to collect referenced symbols.
+3. Filter the includes file.
+4. Re-run `jextract` to generate a much smaller binding set.
+
+## Notes on Windows
+
+This sample requires freeglut as a dependency. On Windows the freeglut package that comes with MinGW is know not to work,
+because clang (which jextract uses under the hood) doesn't seem to understand MinGW builtins found in the MinGW standard library header files.
+
+The sample has been tested against the freeglut MSVC package found here: https://www.transmissionzero.co.uk/software/freeglut-devel/
+
+On top of that, the code in Teapot.java has to be changed to account for different parameter names in the Windows freeglut headers:
+
+```
+diff --git a/opengl/Teapot.java b/opengl/Teapot.java
+index 22d1f44..d5eb786 100644
+--- a/opengl/Teapot.java
++++ b/opengl/Teapot.java
+@@ -79,8 +79,8 @@ public class Teapot {
+             glutInitWindowSize(500, 500);
+             glutCreateWindow(allocator.allocateUtf8String("Hello Panama!"));
+             var teapot = new Teapot(allocator);
+-            var displayStub = glutDisplayFunc$func.allocate(teapot::display, scope);
+-            var idleStub = glutIdleFunc$func.allocate(teapot::onIdle, scope);
++            var displayStub = glutDisplayFunc$callback.allocate(teapot::display, scope);
++            var idleStub = glutIdleFunc$callback.allocate(teapot::onIdle, scope);
+             glutDisplayFunc(displayStub);
+             glutIdleFunc(idleStub);
+             glutMainLoop();
+```

--- a/samples/opengl-minimal-bidings/Teapot.java
+++ b/samples/opengl-minimal-bidings/Teapot.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   - Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   - Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ *   - Neither the name of Oracle nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.SegmentAllocator;
+import opengl.*;
+import static opengl.glut_h.*;
+
+public class Teapot {
+    private float rot = 0;
+
+    Teapot(SegmentAllocator allocator) {
+        // Reset Background
+        glClearColor(0f, 0f, 0f, 0f);
+        // Setup Lighting
+        glShadeModel(GL_SMOOTH());
+        var pos = allocator.allocateFrom(C_FLOAT, new float[] {0.0f, 15.0f, -15.0f, 0});
+        glLightfv(GL_LIGHT0(), GL_POSITION(), pos);
+        var spec = allocator.allocateFrom(C_FLOAT, new float[] {1, 1, 1, 0});
+        glLightfv(GL_LIGHT0(), GL_AMBIENT(), spec);
+        glLightfv(GL_LIGHT0(), GL_DIFFUSE(), spec);
+        glLightfv(GL_LIGHT0(), GL_SPECULAR(), spec);
+        var shini = allocator.allocate(C_FLOAT, 113);
+        glMaterialfv(GL_FRONT(), GL_SHININESS(), shini);
+        glEnable(GL_LIGHTING());
+        glEnable(GL_LIGHT0());
+        glEnable(GL_DEPTH_TEST());
+    }
+
+    void display() {
+        glClear(GL_COLOR_BUFFER_BIT() | GL_DEPTH_BUFFER_BIT());
+        glPushMatrix();
+        glRotatef(-20f, 1f, 1f, 0f);
+        glRotatef(rot, 0f, 1f, 0f);
+        glutSolidTeapot(0.5d);
+        glPopMatrix();
+        glutSwapBuffers();
+    }
+
+    void onIdle() {
+        rot += 0.1;
+        glutPostRedisplay();
+    }
+
+    public static void main(String[] args) {
+        try (var arena = Arena.ofConfined()) {
+            var argc = arena.allocateFrom(C_INT, 0);
+            glutInit(argc, argc);
+            glutInitDisplayMode(GLUT_DOUBLE() | GLUT_RGB() | GLUT_DEPTH());
+            glutInitWindowSize(500, 500);
+            glutCreateWindow(arena.allocateFrom("Hello Panama!"));
+            var teapot = new Teapot(arena);
+            var displayStub = glutDisplayFunc$func.allocate(teapot::display, arena);
+            var idleStub = glutIdleFunc$func.allocate(teapot::onIdle, arena);
+            glutDisplayFunc(displayStub);
+            glutIdleFunc(idleStub);
+            glutMainLoop();
+        }
+    }
+}

--- a/samples/opengl-minimal-bidings/compile_windows.ps1
+++ b/samples/opengl-minimal-bidings/compile_windows.ps1
@@ -1,0 +1,19 @@
+param(
+  [Parameter(Mandatory=$true, HelpMessage="The path to the freeglut installation")]
+  [string]$freeglutPath
+)
+
+jextract `
+  --output src `
+  -I "$freeglutPath\include" `
+  --use-system-load-library `
+  "-l" opengl32 `
+  "-l" glu32 `
+  "-l" freeglut `
+  "-t" "opengl" `
+  '<GL\glut.h>'
+
+# Too many sources for command line. Put them into separate file
+ls -r src/*.java | %{ $_.FullName } | Out-File sources.txt
+javac -d classes '@sources.txt'
+

--- a/samples/opengl-minimal-bidings/compilesource.sh
+++ b/samples/opengl-minimal-bidings/compilesource.sh
@@ -1,0 +1,35 @@
+jextract --dump-includes includes.txt \
+  -t opengl \
+  --framework GLUT \
+  --framework OpenGL \
+  "<GLUT/glut.h>"
+
+jextract -t opengl \
+  --framework GLUT \
+  --framework OpenGL \
+  "<GLUT/glut.h>"
+
+javac --release 24 \
+      -d target/generatedclasses \
+      opengl/*.java
+
+javac --release 24 \
+      -cp target/generatedclasses \
+      -d target/clientClasses \
+      Teapot.java
+
+java --enable-preview \
+      --source 24 \
+      NativeSymbolLister.java \
+      target/clientClasses \
+      used.txt
+
+grep -Ff used.txt includes.txt > includes-filtered.txt
+
+rm -rf target opengl
+
+jextract @includes-filtered.txt -t opengl --framework GLUT \
+  --framework OpenGL \
+  "<GLUT/glut.h>"
+
+javac --source=24 -d . opengl/*.java

--- a/samples/opengl-minimal-bidings/run.sh
+++ b/samples/opengl-minimal-bidings/run.sh
@@ -1,0 +1,1 @@
+java -XstartOnFirstThread --enable-native-access=ALL-UNNAMED Teapot.java $*

--- a/samples/opengl-minimal-bidings/run_windows.ps1
+++ b/samples/opengl-minimal-bidings/run_windows.ps1
@@ -1,0 +1,10 @@
+param(
+  [Parameter(Mandatory=$true, HelpMessage="The path to the freeglut installation")]
+  [string]$freeglutPath
+)
+
+java `
+  -cp classes `
+  --enable-native-access=ALL-UNNAMED `
+  -D"java.library.path=C:\Windows\System32`;$freeglutPath\bin\x64" `
+  Teapot.java


### PR DESCRIPTION
Please review this change to add a small sample that extracts full bindings once, scans the compiled client classes to collect actually referenced symbols, filters the includes list, and re-runs jextract to produce a slim binding set.