### PR TITLE
proof-of-concept: preserve fixed width integer types

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ Alternatively, to build jextract from the latest sources (which include all the 
 > Over time, new branches will be added, each targeting a specific JDK version.
 > </details>
 
-`jextract` can be built using `gradle`, as follows (on Windows, `gradlew.bat` should be used instead).
+`jextract` can be built using `gradlew`, as follows (on Windows, `gradlew.bat` should be used instead).
 
-We currently use gradle version 8.11.1 which is fetched automatically by the gradle wrapper. Please refer to the [compatibility matrix](https://docs.gradle.org/current/userguide/compatibility.html) to see which version of java is needed in `PATH`/`JAVA_HOME` to run gradle. Note that the JDK we use to build (the toolchain JDK) is passed in separately as a property.
+We currently use Gradle version 8.11.1 which is fetched automatically by the Gradle wrapper. Please refer to the [compatibility matrix](https://docs.gradle.org/current/userguide/compatibility.html) to see which version of java is needed in `PATH`/`JAVA_HOME` to run Gradle. Note that the JDK we use to build (the toolchain JDK) is passed in separately as a property.
 
 
 
@@ -36,6 +36,7 @@ We currently use gradle version 8.11.1 which is fetched automatically by the gra
 $ sh ./gradlew -Pjdk_home=<jdk_home_dir> -Pllvm_home=<libclang_dir> clean verify
 ```
 
+Alternatively these properties can be specified in the [`gradle.properties` file](https://docs.gradle.org/current/userguide/build_environment.html#the_gradle_properties_file).
 
 > <details><summary><strong>Using a local installation of LLVM</strong></summary>
 >

--- a/src/main/java/org/openjdk/jextract/clang/Type.java
+++ b/src/main/java/org/openjdk/jextract/clang/Type.java
@@ -138,6 +138,18 @@ public final class Type extends ClangDisposable.Owned {
     }
 
     /**
+     * For a typedef returns the underlying type.
+     */
+    public Type typeDefUnderlyingType() {
+        var cursor = getDeclarationCursor();
+        if (cursor.isInvalid()) {
+            throw new AssertionError("TODO");
+        }
+        var underlyingType = Index_h.clang_getTypedefDeclUnderlyingType(cursor.owner, cursor.segment);
+        return new Type(underlyingType, owner);
+    }
+
+    /**
      * Determine whether a Type has the "const" qualifier set,
      * without looking through typedefs that may have added "const" at a
      * different level.

--- a/src/main/java/org/openjdk/jextract/impl/ClassSourceBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/ClassSourceBuilder.java
@@ -41,6 +41,7 @@ import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodType;
 import java.lang.invoke.VarHandle;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -211,7 +212,7 @@ abstract class ClassSourceBuilder {
             case Declared d when Utils.isEnum(d) -> layoutString(ClangEnumType.get(d.tree()).get(), align);
             case Declared d when Utils.isStructOrUnion(d) -> alignIfNeeded(JavaName.getFullNameOrThrow(d.tree()) + ".layout()", ClangAlignOf.getOrThrow(d.tree()) / 8, align);
             case Delegated d when d.kind() == Delegated.Kind.POINTER -> alignIfNeeded(runtimeHelperName() + ".C_POINTER", 8, align);
-            case Delegated d when d.kind() == Delegated.Kind.TYPEDEF -> typeDefLayoutString(d, align);
+            case Delegated d when d.kind() == Delegated.Kind.TYPEDEF -> typedefLayoutString(d, align);
             case Delegated d -> layoutString(d.type(), align);
             case Function _ -> alignIfNeeded(runtimeHelperName() + ".C_POINTER", 8, align);
             case Array a -> String.format("MemoryLayout.sequenceLayout(%1$d, %2$s)", a.elementCount().orElse(0L), layoutString(a.elementType(), align));
@@ -219,16 +220,18 @@ abstract class ClassSourceBuilder {
         };
     }
 
-    private String typeDefLayoutString(Type.Delegated type, long align) {
+    private String typedefLayoutString(Type.Delegated type, long align) {
         String name = type.name().orElse("");
+        String layoutName = runtimeHelperName() + ".C_" + name.toUpperCase(Locale.ROOT);
         return switch (name) {
             // https://en.cppreference.com/w/c/types/integer.html
-            case "int8_t", "int16_t", "int32_t", "int64_t",
-                 "uint8_t", "uint16_t", "uint32_t", "uint64_t",
-                 // Other types which are common enough and have an entry in FFM `Linker#canonicalLayouts()`
-                 "size_t"
-                // TODO: Use proper names and proper alignment
-                -> alignIfNeeded(runtimeHelperName() + ".DEBUG_" + name, 1, align);
+            case "int8_t", "uint8_t" -> layoutName;
+            case "int16_t", "uint16_t" -> alignIfNeeded(layoutName, 2, align);
+            case "int32_t", "uint32_t" -> alignIfNeeded(layoutName, 4, align);
+            case "int64_t", "uint64_t" -> alignIfNeeded(layoutName, 8, align);
+             // Other types which are common enough and have an entry in FFM `Linker#canonicalLayouts()`
+            case "size_t" -> alignIfNeeded(layoutName, 8, align);
+            // Fall back to the layout for the underlying type
             default -> layoutString(type.type(), align);
         };
     }

--- a/src/main/java/org/openjdk/jextract/impl/ClassSourceBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/ClassSourceBuilder.java
@@ -222,11 +222,9 @@ abstract class ClassSourceBuilder {
     private String typeDefLayoutString(Type.Delegated type, long align) {
         String name = type.name().orElse("");
         return switch (name) {
-            // https://en.cppreference.com/w/cpp/types/integer.html
+            // https://en.cppreference.com/w/c/types/integer.html
             case "int8_t", "int16_t", "int32_t", "int64_t",
                  "uint8_t", "uint16_t", "uint32_t", "uint64_t",
-                 // https://en.cppreference.com/w/cpp/types/floating-point.html
-                 "float16_t", "float32_t", "float64_t", "float128_t", "bfloat16_t",
                  // Other types which are common enough and have an entry in FFM `Linker#canonicalLayouts()`
                  "size_t"
                 // TODO: Use proper names and proper alignment

--- a/src/main/java/org/openjdk/jextract/impl/DeclarationImpl.java
+++ b/src/main/java/org/openjdk/jextract/impl/DeclarationImpl.java
@@ -223,7 +223,11 @@ public abstract class DeclarationImpl implements Declaration {
 
         @Override
         public Type.Function type() {
-            return type;
+            // Use actual types from parameters, since they preserve typedef information
+            // This is needed for example for `malloc` to preserve the parameter type `size_t` and avoid it becoming `long`
+            // TODO: Does that also affect return type? maybe not, for C function `mbstowcs` it properly emits `size_t` as return type
+            // TODO: Maybe this is not safe / correct
+            return Type.function(type.varargs(), type.returnType(), params.stream().map(Variable::type).toArray(Type[]::new));
         }
 
         @Override

--- a/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
@@ -403,6 +403,8 @@ class HeaderFileBuilder extends ClassSourceBuilder {
             public static final ValueLayout.OfByte C_CHAR =(ValueLayout.OfByte)Linker.nativeLinker().canonicalLayouts().get("char");
             public static final ValueLayout.OfShort C_SHORT = (ValueLayout.OfShort) Linker.nativeLinker().canonicalLayouts().get("short");
             public static final ValueLayout.OfInt C_INT = (ValueLayout.OfInt) Linker.nativeLinker().canonicalLayouts().get("int");
+            // For C_LONG use unspecific ValueLayout to make generated code portable; because on Linux it is OfLong but on Windows it is OfInt
+            public static final ValueLayout C_LONG = (ValueLayout) Linker.nativeLinker().canonicalLayouts().get("long");
             public static final ValueLayout.OfLong C_LONG_LONG = (ValueLayout.OfLong) Linker.nativeLinker().canonicalLayouts().get("long long");
             public static final ValueLayout.OfFloat C_FLOAT = (ValueLayout.OfFloat) Linker.nativeLinker().canonicalLayouts().get("float");
             public static final ValueLayout.OfDouble C_DOUBLE = (ValueLayout.OfDouble) Linker.nativeLinker().canonicalLayouts().get("double");
@@ -418,14 +420,11 @@ class HeaderFileBuilder extends ClassSourceBuilder {
             public static final ValueLayout.OfLong C_INT64_T = (ValueLayout.OfLong) Linker.nativeLinker().canonicalLayouts().get("int64_t");
             public static final ValueLayout.OfLong C_UINT64_T = C_INT64_T;
 
+            // For C_SIZE_T use unspecific ValueLayout to make generated code portable; because its layout is platform-specific
             public static final ValueLayout C_SIZE_T = (ValueLayout) Linker.nativeLinker().canonicalLayouts().get("size_t");
             """);
-        // For C_LONG use unspecific ValueLayout to make generated code portable; because on Linux it is OfLong but on Windows it is OfInt
         if (TypeImpl.IS_WINDOWS) {
-            appendIndentedLines("public static final ValueLayout C_LONG = (ValueLayout) Linker.nativeLinker().canonicalLayouts().get(\"long\");");
             appendIndentedLines("public static final ValueLayout.OfDouble C_LONG_DOUBLE = (ValueLayout.OfDouble) Linker.nativeLinker().canonicalLayouts().get(\"double\");");
-        } else {
-            appendIndentedLines("public static final ValueLayout C_LONG = (ValueLayout) Linker.nativeLinker().canonicalLayouts().get(\"long\");");
         }
     }
     private void emitGlobalGetter(String holderClass, String javaName,

--- a/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
@@ -408,12 +408,14 @@ class HeaderFileBuilder extends ClassSourceBuilder {
             public static final ValueLayout.OfDouble C_DOUBLE = (ValueLayout.OfDouble) Linker.nativeLinker().canonicalLayouts().get("double");
             public static final AddressLayout C_POINTER = ((AddressLayout) Linker.nativeLinker().canonicalLayouts().get("void*"))
                     .withTargetLayout(MemoryLayout.sequenceLayout(java.lang.Long.MAX_VALUE, C_CHAR));
+            
+            // TODO: constants for fixed width integer types and other common `..._t` types
             """);
         if (TypeImpl.IS_WINDOWS) {
-            appendIndentedLines("public static final ValueLayout.OfInt C_LONG = (ValueLayout.OfInt) Linker.nativeLinker().canonicalLayouts().get(\"long\");");
+            appendIndentedLines("public static final ValueLayout C_LONG = (ValueLayout) Linker.nativeLinker().canonicalLayouts().get(\"long\");");
             appendIndentedLines("public static final ValueLayout.OfDouble C_LONG_DOUBLE = (ValueLayout.OfDouble) Linker.nativeLinker().canonicalLayouts().get(\"double\");");
         } else {
-            appendIndentedLines("public static final ValueLayout.OfLong C_LONG = (ValueLayout.OfLong) Linker.nativeLinker().canonicalLayouts().get(\"long\");");
+            appendIndentedLines("public static final ValueLayout C_LONG = (ValueLayout) Linker.nativeLinker().canonicalLayouts().get(\"long\");");
         }
     }
     private void emitGlobalGetter(String holderClass, String javaName,

--- a/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/HeaderFileBuilder.java
@@ -408,9 +408,19 @@ class HeaderFileBuilder extends ClassSourceBuilder {
             public static final ValueLayout.OfDouble C_DOUBLE = (ValueLayout.OfDouble) Linker.nativeLinker().canonicalLayouts().get("double");
             public static final AddressLayout C_POINTER = ((AddressLayout) Linker.nativeLinker().canonicalLayouts().get("void*"))
                     .withTargetLayout(MemoryLayout.sequenceLayout(java.lang.Long.MAX_VALUE, C_CHAR));
-            
-            // TODO: constants for fixed width integer types and other common `..._t` types
+
+            public static final ValueLayout.OfByte C_INT8_T = (ValueLayout.OfByte) Linker.nativeLinker().canonicalLayouts().get("int8_t");
+            public static final ValueLayout.OfByte C_UINT8_T = C_INT8_T;
+            public static final ValueLayout.OfShort C_INT16_T = (ValueLayout.OfShort) Linker.nativeLinker().canonicalLayouts().get("int16_t");
+            public static final ValueLayout.OfShort C_UINT16_T = C_INT16_T;
+            public static final ValueLayout.OfInt C_INT32_T = (ValueLayout.OfInt) Linker.nativeLinker().canonicalLayouts().get("int32_t");
+            public static final ValueLayout.OfInt C_UINT32_T = C_INT32_T;
+            public static final ValueLayout.OfLong C_INT64_T = (ValueLayout.OfLong) Linker.nativeLinker().canonicalLayouts().get("int64_t");
+            public static final ValueLayout.OfLong C_UINT64_T = C_INT64_T;
+
+            public static final ValueLayout C_SIZE_T = (ValueLayout) Linker.nativeLinker().canonicalLayouts().get("size_t");
             """);
+        // For C_LONG use unspecific ValueLayout to make generated code portable; because on Linux it is OfLong but on Windows it is OfInt
         if (TypeImpl.IS_WINDOWS) {
             appendIndentedLines("public static final ValueLayout C_LONG = (ValueLayout) Linker.nativeLinker().canonicalLayouts().get(\"long\");");
             appendIndentedLines("public static final ValueLayout.OfDouble C_LONG_DOUBLE = (ValueLayout.OfDouble) Linker.nativeLinker().canonicalLayouts().get(\"double\");");

--- a/src/main/java/org/openjdk/jextract/impl/TypeMaker.java
+++ b/src/main/java/org/openjdk/jextract/impl/TypeMaker.java
@@ -152,7 +152,9 @@ class TypeMaker {
                 }
             }
             case Typedef: {
-                Type __type = makeType(t.canonicalType(), treeMaker);
+                // Don't use `canonicalType()` here since that would lose information about intermediate typedefs,
+                // for example `typedef uint16_t MyType` would otherwise be resolved as `short` and not `uint16_t`
+                Type __type = makeType(t.typeDefUnderlyingType(), treeMaker);
                 return Type.typedef(t.spelling(), __type);
             }
             case Complex: {


### PR DESCRIPTION
For https://mail.openjdk.org/pipermail/jextract-dev/2026-January/002449.html (and previous thread messages)

This proof-of-concept is incomplete, but it demonstrates that (most likely) enough information is available to jextract to preserve the original types, and keep the C library portable.

For example the portable type `int64_t` could be preserved instead of turning it into the non-portable `long`.
When trying this locally with [jtreesitter](https://github.com/tree-sitter/java-tree-sitter)'s jextract setup on Windows it seemed to emit portable code, without using types such as `long` or `long long` anymore. The only exception are C enums, which use `int`, but that appears to be portable (and since [C23 it is also possible to specify a fixed type for an enum](https://en.cppreference.com/w/c/language/enum.html)).

Most likely I will not complete this pull request; its main purpose is to highlight which code changes might be needed to preserve typedef information (but I am not very familiar with this project, so maybe there are missing places, and better ways to solve this).
Hopefully this is useful nonetheless.

Feel free to close this pull request.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/299/head:pull/299` \
`$ git checkout pull/299`

Update a local copy of the PR: \
`$ git checkout pull/299` \
`$ git pull https://git.openjdk.org/jextract.git pull/299/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 299`

View PR using the GUI difftool: \
`$ git pr show -t 299`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/299.diff">https://git.openjdk.org/jextract/pull/299.diff</a>

</details>
