### PR TITLE
7904128: Add a struct reinterpret helper that keeps scope

### DIFF
--- a/doc/GUIDE.md
+++ b/doc/GUIDE.md
@@ -328,10 +328,9 @@ public class Point {
     public static MemorySegment allocateArray(long elementCount,
             SegmentAllocator allocator) { ... } // 4
 
-    public static MemorySegment reinterpret(MemorySegment addr, Arena arena,
-            Consumer<MemorySegment> cleanup) { ... } // 6
     public static MemorySegment reinterpret(MemorySegment addr, long elementCount,
             Arena arena, Consumer<MemorySegment> cleanup) { ... } // 6
+    public static MemorySegment reinterpret(MemorySegment addr, long elementCount) { ... } // 6
 }
 ```
 
@@ -406,17 +405,24 @@ The `reinterpret` method can be used to associate the correct bounds and lifetim
 // Main.java
 
 try (Arena arena = Arena.ofConfined()) {
-    MemorySegment point = Point.reinterpret(new_point(), arena, mylib_h::delete_point);
+    MemorySegment point = Point.reinterpret(new_point(), 1, arena, mylib_h::delete_point);
 
     // ...
 } // 'delete_point` called here
 ```
 
 The `point` segment returned by `reinterpret` has exactly the size of one `Point` (for
-arrays of struct, use the `reinterpret` overload that takes an element count as well). The
-lifetime we associate with the segment is the lifetime denoted by `arena`, and when the
-arena is closed, we want to call `delete_point`, which we can do by passing a method
-reference to `delete_point` as a cleanup action when calling `reinterpret`.
+arrays of struct, pass a larger `elementCount`). The lifetime we associate with the segment
+is the lifetime denoted by `arena`, and when the arena is closed, we want to call
+`delete_point`, which we can do by passing a method reference to `delete_point` as a cleanup
+action when calling `reinterpret`.
+
+If the source segment already has the desired scope and you only need to adjust the bounds, use
+the overload that keeps the existing scope:
+
+```java
+MemorySegment points = Point.reinterpret(existingSegment, elementCount);
+```
 
 The class that jextract generates for unions is identical to the class generated for
 structs.

--- a/src/main/java/org/openjdk/jextract/impl/StructBuilder.java
+++ b/src/main/java/org/openjdk/jextract/impl/StructBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -359,18 +359,18 @@ final class StructBuilder extends ClassSourceBuilder implements OutputFactory.Bu
 
             /**
              * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction} (if any).
-             * The returned segment has size {@code layout().byteSize()}
-             */
-            public static MemorySegment reinterpret(MemorySegment addr, Arena arena, Consumer<MemorySegment> cleanup) {
-                return reinterpret(addr, 1, arena, cleanup);
-            }
-
-            /**
-             * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction} (if any).
              * The returned segment has size {@code elementCount * layout().byteSize()}
              */
             public static MemorySegment reinterpret(MemorySegment addr, long elementCount, Arena arena, Consumer<MemorySegment> cleanup) {
                 return addr.reinterpret(layout().byteSize() * elementCount, arena, cleanup);
+            }
+
+            /**
+             * Reinterprets {@code addr} using the existing scope.
+             * The returned segment has size {@code elementCount * layout().byteSize()}
+             */
+            public static MemorySegment reinterpret(MemorySegment addr, long elementCount) {
+                return addr.reinterpret(layout().byteSize() * elementCount);
             }
             """);
     }

--- a/test/jtreg/generator/reinterpret/TestReinterpret.java
+++ b/test/jtreg/generator/reinterpret/TestReinterpret.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,7 +45,7 @@ public class TestReinterpret {
     public void testSingleStruct() {
         try (Arena arena = Arena.ofConfined()) {
             MemorySegment addr = make(14, 99);
-            MemorySegment seg = Point.reinterpret(addr, arena, reinterpret_h::freePoint);
+            MemorySegment seg = Point.reinterpret(addr, 1, arena, reinterpret_h::freePoint);
             assertEquals(Point.x(seg), 14);
             assertEquals(Point.y(seg), 99);
         }
@@ -62,6 +62,19 @@ public class TestReinterpret {
                 assertEquals(Point.x(point), i);
                 assertEquals(Point.y(point), i + 1);
             }
+        }
+    }
+
+    @Test
+    public void testReinterpretScope() {
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment addr = make(14, 99);
+            MemorySegment seg = Point.reinterpret(addr, 1);
+            assertEquals(Point.x(seg), 14);
+            assertEquals(Point.y(seg), 99);
+
+            MemorySegment array = Point.reinterpret(addr, 2);
+            assertEquals(array.byteSize(), Point.layout().byteSize() * 2);
         }
     }
 }

--- a/test/jtreg/generator/test8257892/LibUnsupportedTest.java
+++ b/test/jtreg/generator/test8257892/LibUnsupportedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -62,7 +62,7 @@ public class LibUnsupportedTest {
     @Test
     public void testGetFoo() {
         try (Arena arena = Arena.ofConfined()) {
-            var seg = Foo.reinterpret(getFoo(), arena, null);
+            var seg = Foo.reinterpret(getFoo(), 1, arena, null);
             Foo.i(seg, 42);
             Foo.c(seg, (byte)'j');
             assertEquals(Foo.i(seg), 42);


### PR DESCRIPTION
Please review this change to add a new reinterpret method that keeps scope, I have removed one of the old methods and only kept one with arena and cleanup, and one without.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Issue
 * [CODETOOLS-7904128](https://bugs.openjdk.org/browse/CODETOOLS-7904128): Add a struct reinterpret helper that keeps scope (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/300/head:pull/300` \
`$ git checkout pull/300`

Update a local copy of the PR: \
`$ git checkout pull/300` \
`$ git pull https://git.openjdk.org/jextract.git pull/300/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 300`

View PR using the GUI difftool: \
`$ git pr show -t 300`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/300.diff">https://git.openjdk.org/jextract/pull/300.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/300#issuecomment-3848490341)
</details>
