### PR TITLE
Print IncludeKinds in consistent order

### DIFF
--- a/src/main/java/org/openjdk/jextract/impl/IncludeHelper.java
+++ b/src/main/java/org/openjdk/jextract/impl/IncludeHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/main/java/org/openjdk/jextract/impl/IncludeHelper.java
+++ b/src/main/java/org/openjdk/jextract/impl/IncludeHelper.java
@@ -142,7 +142,9 @@ public class IncludeHelper {
                 writer.append(lineSep);
                 writer.append("#### Extracted from: " + pathEntries.getKey().toString() + "\n\n");
                 Map<IncludeKind, List<Declaration>> declsByKind = pathEntries.getValue().stream()
-                        .collect(Collectors.groupingBy(IncludeKind::fromDeclaration));
+                        .collect(Collectors.groupingBy(IncludeKind::fromDeclaration,
+                                () -> new EnumMap<>(IncludeKind.class),
+                                Collectors.toList()));
                 int maxLengthOptionCol = pathEntries.getValue().stream().mapToInt(d -> d.name().length()).max().getAsInt();
                 maxLengthOptionCol += 2; // --
                 maxLengthOptionCol += IncludeKind.FUNCTION.optionName().length(); // max option name

--- a/test/testng/org/openjdk/jextract/test/toolprovider/TestFilters.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/TestFilters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/testng/org/openjdk/jextract/test/toolprovider/TestFilters.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/TestFilters.java
@@ -33,8 +33,10 @@ import java.nio.file.Path;
 import java.util.Iterator;
 import java.util.List;
 
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
 public class TestFilters extends JextractToolRunner {
@@ -69,18 +71,18 @@ public class TestFilters extends JextractToolRunner {
             Path filterH = getInputFilePath("filters.h");
             runNoOuput("--dump-includes", includes.toString(), filterH.toString()).checkSuccess();
             List<String> includeLines = Files.readAllLines(includes);
-            outer: for (FilterKind kind : FilterKind.values()) {
-                String filterLine = kind.filterOption + " " + kind.symbolName;
-                Iterator<String> linesIt = includeLines.iterator();
-                while (linesIt.hasNext()) {
-                    String line = linesIt.next();
-                    if (line.startsWith(filterLine)) {
-                        linesIt.remove();
-                        continue outer;
-                    }
-                }
-                fail("Filter line not found: " + filterLine);
-            }
+            List<String> filteredLines = includeLines.stream().filter(line -> line.startsWith("--")).toList();
+            assertEquals(filteredLines.size(), 9);
+            // These will be in consistent order based on type and symbol name.
+            assertTrue(filteredLines.get(0).startsWith("--include-constant BLUE "));
+            assertTrue(filteredLines.get(1).startsWith("--include-constant GREEN "));
+            assertTrue(filteredLines.get(2).startsWith("--include-constant RED "));
+            assertTrue(filteredLines.get(3).startsWith("--include-constant _constant "));
+            assertTrue(filteredLines.get(4).startsWith("--include-var _global "));
+            assertTrue(filteredLines.get(5).startsWith("--include-function _function "));
+            assertTrue(filteredLines.get(6).startsWith("--include-typedef _typedef "));
+            assertTrue(filteredLines.get(7).startsWith("--include-struct _struct "));
+            assertTrue(filteredLines.get(8).startsWith("--include-union _union "));
         } finally {
             TestUtils.deleteDir(filterOutput);
         }


### PR DESCRIPTION
- the current jextract `--dump-includes` output inconsistently orders symbols by include type. (e.g. struct, typedef, function)
- this means that when i rerun jextract dump includes on newer version header files, the output is not in stable order. this causes extraneous and confusing diffs. i believe this is a caused of the fact that Collectors.groupingBy uses some sort of HashMap which is finicky around ordering.
- solution is to use a EnumMap which naturally keeps the ordering of the IncludeKinds
- i was not able to get all of the testing working (even on master) locally, but the salient test `testDumpIncludes` passes.

<!--
Please add the following to the description of the pull request:

1. A brief recap of the status quo, as it relates to the subject of the pull request.
2. A description of why the status quo is problematic.
3. A description of how this pull request addresses this issue.
4. If you ran into issues while making changes in the code that you had to work around,
  please mention these as well, as this helps reviewers understand the changes that have been made.

For 1 and 2 it is also okay to refer to the JBS ticket, if that already contains a comprehensive
problem description.

Please test your pull request before submitting it by running `./gradlew jtreg`. If you're
not able to test locally on your machine, please indicate this in the pull request description,
and indicate which testing has been done instead (or indicate that no testing has been done).

It is possible to run tests through Github actions if you enable them for your fork (this is free).
Github actions can be enabled for your fork from the 'Actions' tab. The tests will then run
automatically after the pull request has been created.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/301/head:pull/301` \
`$ git checkout pull/301`

Update a local copy of the PR: \
`$ git checkout pull/301` \
`$ git pull https://git.openjdk.org/jextract.git pull/301/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 301`

View PR using the GUI difftool: \
`$ git pr show -t 301`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/301.diff">https://git.openjdk.org/jextract/pull/301.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/301#issuecomment-3942202842)
</details>
