### PR TITLE
7904167: Enable -03 optimization in NativeCompilation.gmk

### DIFF
--- a/make/NativeCompilation.gmk
+++ b/make/NativeCompilation.gmk
@@ -82,6 +82,8 @@ else
 
       CC_NAME := gcc
       LINK_NAME := gcc
+      CFLAGS += -O3
+      LDFLAGS += -O3
       ifneq ($(SYSROOT),)
         CFLAGS += --sysroot=$(SYSROOT)
       endif

--- a/test/test-support/CMakeLists.txt
+++ b/test/test-support/CMakeLists.txt
@@ -27,7 +27,7 @@ foreach(TEST_LIB ${TEST_LIBS})
     )
 
     # Link against libm to resolve sqrt() and other math symbols
-    find_library(LIBM, m)
+    find_library(LIBM m)
     if(LIBM)
       target_link_libraries(${LIB_NAME} ${LIBM})
     endif()


### PR DESCRIPTION
Enable -03 in make/NativeCompilation.gmk to align with Gradle [CMake Release](https://github.com/openjdk/jextract/blob/ad6430f83085c87f0f226a47c46c593d87d26376/build.gradle#L200) optimization. 

JBS : [CODETOOLS-7904167](https://bugs.openjdk.org/browse/CODETOOLS-7904167)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Error
&nbsp;⚠️ Pull request body is missing required line: `- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).`

### Issue
 * [CODETOOLS-7904167](https://bugs.openjdk.org/browse/CODETOOLS-7904167): Enable -03 optimization in NativeCompilation.gmk (**Bug** - P4)


### Reviewers
 * [Nizar Benalla](https://openjdk.org/census#nbenalla) (@nizarbenalla - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/302/head:pull/302` \
`$ git checkout pull/302`

Update a local copy of the PR: \
`$ git checkout pull/302` \
`$ git pull https://git.openjdk.org/jextract.git pull/302/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 302`

View PR using the GUI difftool: \
`$ git pr show -t 302`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/302.diff">https://git.openjdk.org/jextract/pull/302.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/302#issuecomment-4082183906)
</details>
