### PR TITLE
7904175: Empty option value can crash jextract

### DIFF
--- a/src/main/java/org/openjdk/jextract/JextractTool.java
+++ b/src/main/java/org/openjdk/jextract/JextractTool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -325,6 +325,10 @@ public final class JextractTool {
                            i++; // consume value from next command line arg
                        } // else -DFOO like case. argValue already set
 
+                       // do not allow empty argument values
+                       if (argValue.isEmpty()) {
+                           throw new OptionException("empty value for option: " + arg);
+                       }
                        // do not allow argument value to start with '-'
                        // this will catch issues like "-l-lclang", "-l -t"
                        if (argValue.charAt(0) == '-') {

--- a/test/testng/org/openjdk/jextract/test/toolprovider/JextractToolProviderTest.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/JextractToolProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,6 +50,15 @@ public class JextractToolProviderTest extends JextractToolRunner {
     @Test
     public void testVersion() {
         runNoOuput("--version").checkSuccess();
+    }
+
+    // error for empty option value
+    @Test
+    public void testEmptyOptionValue() {
+        runNoOuput("-D", "", getInputFilePath("hello.h").toString())
+            .checkFailure(OPTION_ERROR)
+            .checkContainsOutput("empty value for option: -D")
+            .checkContainsOutput("Usage: jextract <options> <header file>");
     }
 
     // error for non-existent args file


### PR DESCRIPTION
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

Passing empty option values to jextract causes it to crash, this patch prevent that to happen.

Please add the following to the description of the pull request:

1. A brief recap of the status quo, as it relates to the subject of the pull request.
2. A description of why the status quo is problematic.
3. A description of how this pull request addresses this issue.
4. If you ran into issues while making changes in the code that you had to work around,
  please mention these as well, as this helps reviewers understand the changes that have been made.

For 1 and 2 it is also okay to refer to the JBS ticket, if that already contains a comprehensive
problem description.

Please test your pull request before submitting it by running `./gradlew jtreg`. If you're
not able to test locally on your machine, please indicate this in the pull request description,
and indicate which testing has been done instead (or indicate that no testing has been done).

It is possible to run tests through Github actions if you enable them for your fork (this is free).
Github actions can be enabled for your fork from the 'Actions' tab. The tests will then run
automatically after the pull request has been created.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (no review required)

### Issue
 * [CODETOOLS-7904175](https://bugs.openjdk.org/browse/CODETOOLS-7904175): Empty option value can crash jextract (**Bug** - P4)


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/303/head:pull/303` \
`$ git checkout pull/303`

Update a local copy of the PR: \
`$ git checkout pull/303` \
`$ git pull https://git.openjdk.org/jextract.git pull/303/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 303`

View PR using the GUI difftool: \
`$ git pr show -t 303`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/303.diff">https://git.openjdk.org/jextract/pull/303.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/303#issuecomment-4162310594)
</details>
