### PR TITLE
Update ONNX Gen AI jextract example

### DIFF
--- a/samples/onnx/OnnxGenerator.java
+++ b/samples/onnx/OnnxGenerator.java
@@ -112,10 +112,12 @@ You are a helpful and accurate assistant.<|end|>
 
     public int prompt(String userPrompt) {
         var inputTokens = call(OgaCreateSequences(ret));
+        int ntokens = 0;
         try {
             call(OgaTokenizerEncode(tokenizer, arena.allocateFrom(PROMPT_TEMPLATE.formatted(userPrompt)), inputTokens));
             call(OgaGenerator_AppendTokenSequences(generator, inputTokens));
             while (!OgaGenerator_IsDone(generator)) {
+                ntokens++;
                 call(OgaGenerator_GenerateNextToken(generator));
                 int nextToken = call(OgaGenerator_GetNextTokens(generator, ret, count)).get(C_INT, 0);
                 String response = call(OgaTokenizerStreamDecode(tokenizerStream, nextToken, ret)).getString(0);

--- a/samples/onnx/OnnxGenerator.java
+++ b/samples/onnx/OnnxGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -45,7 +45,7 @@ public class OnnxGenerator implements AutoCloseable {
 
     static final String PROMPT_TEMPLATE = """
     <|system|>
-You are a helpful assistant.<|end|>
+You are a helpful and accurate assistant.<|end|>
 <|user|>
 %s<|end|>
 <|assistant|>""";
@@ -82,8 +82,12 @@ You are a helpful assistant.<|end|>
             String str;
             System.out.print("> ");
             while ((str = in.readLine()) != null) {
-                gen.prompt(str);
-                System.out.print("> ");
+                if (str.equals("/exit")) {
+                    return;
+                } else {
+                    gen.prompt(str);
+                    System.out.print("> ");
+                }
             }
             in.close();
         }
@@ -108,12 +112,10 @@ You are a helpful assistant.<|end|>
 
     public int prompt(String userPrompt) {
         var inputTokens = call(OgaCreateSequences(ret));
-        int ntokens = 0;
         try {
             call(OgaTokenizerEncode(tokenizer, arena.allocateFrom(PROMPT_TEMPLATE.formatted(userPrompt)), inputTokens));
             call(OgaGenerator_AppendTokenSequences(generator, inputTokens));
             while (!OgaGenerator_IsDone(generator)) {
-                ntokens++;
                 call(OgaGenerator_GenerateNextToken(generator));
                 int nextToken = call(OgaGenerator_GetNextTokens(generator, ret, count)).get(C_INT, 0);
                 String response = call(OgaTokenizerStreamDecode(tokenizerStream, nextToken, ret)).getString(0);

--- a/samples/onnx/README.md
+++ b/samples/onnx/README.md
@@ -1,10 +1,10 @@
 To run Generative AI models with ONNX runtime, make sure to have downloaded a native [`libonnxruntime`](https://github.com/microsoft/onnxruntime/release) and [`libonnxruntime-genai`](https://github.com/microsoft/onnxruntime-genai/releases).
 
-1. The [`libonnxruntime-genai`](https://github.com/microsoft/onnxruntime-genai/releases) binary needs the statically built binaries from [`libonnxruntime`](https://github.com/microsoft/onnxruntime/release), so you need to set `ORT_LIB_PATH` to the directory containing the downloaded [`libonnxruntime`](https://github.com/microsoft/onnxruntime/release), then the ONNX_GEN_AI_HOME to [`libonnxruntime-genai`](https://github.com/microsoft/onnxruntime-genai/releases). 
+1. The [`libonnxruntime-genai`](https://github.com/microsoft/onnxruntime-genai/releases) binary needs the statically built binaries from [`libonnxruntime`](https://github.com/microsoft/onnxruntime/release), so you have to set `ORT_LIB_PATH` to the directory containing the downloaded [`libonnxruntime`](https://github.com/microsoft/onnxruntime/release), then the ONNX_GEN_AI_HOME to [`libonnxruntime-genai`](https://github.com/microsoft/onnxruntime-genai/releases). 
 The native library extension (`.dylib` or `.so` or `.dll`) is platform specific.
 
     ```bash
-    export ORT_LIB_PATH=/path/.../onnxruntime/
+    export ORT_LIB_PATH=/path/.../onnxruntime/lib/libonnxruntime.[dylib|so|dll]
     export ONNX_GENAI_HOME=/path/.../onnxruntime-genai/
     ```
 2. Run `compile.sh`:

--- a/samples/onnx/README.md
+++ b/samples/onnx/README.md
@@ -1,21 +1,11 @@
 To run Generative AI models with ONNX runtime, make sure to have downloaded a native [`libonnxruntime`](https://github.com/microsoft/onnxruntime/release) and [`libonnxruntime-genai`](https://github.com/microsoft/onnxruntime-genai/releases).
-The compatible `libonnxruntime` library must be present in the same folder as `libonnxruntime-genai` library, like in the tree below.
 
-```text
-onnxruntime-genai/
-├── include
-│ ├── ort_genai.h
-│ └── ort_genai_c.h
-└── lib
-    ├── libonnxruntime-genai.dylib
-    └── libonnxruntime.dylib
-```
-
-
-1. Set `ONNX_PATH` to the directory containing the built native libraries. The native library extension (`.dylib` or `.so` or `.dll`) is platform specific.
+1. The [`libonnxruntime-genai`](https://github.com/microsoft/onnxruntime-genai/releases) binary needs the statically built binaries from [`libonnxruntime`](https://github.com/microsoft/onnxruntime/release), so you need to set `ORT_LIB_PATH` to the directory containing the downloaded [`libonnxruntime`](https://github.com/microsoft/onnxruntime/release), then the ONNX_GEN_AI_HOME to [`libonnxruntime-genai`](https://github.com/microsoft/onnxruntime-genai/releases). 
+The native library extension (`.dylib` or `.so` or `.dll`) is platform specific.
 
     ```bash
-    export ONNX_PATH=/path/.../onnxruntime-genai/
+    export ORT_LIB_PATH=/path/.../onnxruntime/
+    export ONNX_GENAI_HOME=/path/.../onnxruntime-genai/
     ```
 2. Run `compile.sh`:
 
@@ -36,3 +26,4 @@ onnxruntime-genai/
     ```bash
     sh ./run.sh
     ```
+   

--- a/samples/onnx/README.md
+++ b/samples/onnx/README.md
@@ -1,21 +1,28 @@
 To run Generative AI models with ONNX runtime, make sure to have downloaded a native [`libonnxruntime`](https://github.com/microsoft/onnxruntime/release) and [`libonnxruntime-genai`](https://github.com/microsoft/onnxruntime-genai/releases).
-The compatible `libonnxruntime` library must be present in the same folder as `libonnxruntime-genai` library. 
+The compatible `libonnxruntime` library must be present in the same folder as `libonnxruntime-genai` library, like in the tree below.
+
+```text
+onnxruntime-genai/
+├── include
+│ ├── ort_genai.h
+│ └── ort_genai_c.h
+└── lib
+    ├── libonnxruntime-genai.dylib
+    └── libonnxruntime.dylib
+```
 
 
-1. Set `ONNX_LIB_PATH` to the directory containing the built native libraries. The native library extension (`.dylib` or `.so` or `.dll`) is platform specific.
-
-   (e.g. where `libonnxruntime-genai.so` or `.dylib` lives):
+1. Set `ONNX_PATH` to the directory containing the built native libraries. The native library extension (`.dylib` or `.so` or `.dll`) is platform specific.
 
     ```bash
-    export ONNX_LIB_PATH=/path/.../onnxruntime-genai/lib/
+    export ONNX_PATH=/path/.../onnxruntime-genai/
     ```
-
-2. Set `ORT_GENAI_INCLUDE_DIR` to your clone of `onnxruntime-genai` before running `compile.sh`:
+2. Run `compile.sh`:
 
     ```bash
-    export ORT_GENAI_INCLUDE_DIR=/path/.../onnxruntime-genai/include
+    ./compile.sh
     ```
-
+   
 3. Download or prepare a valid ONNX model:
 
    ```bash
@@ -24,13 +31,7 @@ The compatible `libonnxruntime` library must be present in the same folder as `l
     export MODEL_PATH=/path/.../Phi-3-mini-4k-instruct-onnx/cpu_and_mobile/cpu-int4-rtn-block-32-acc-level-4/
     ```
 
-4. Run `compile.sh`:
-
-    ```bash
-    ./compile.sh
-    ```
-
-5. Run the example:
+4. Run the example:
 
     ```bash
     sh ./run.sh

--- a/samples/onnx/README.md
+++ b/samples/onnx/README.md
@@ -1,29 +1,22 @@
-1. Clone `onnxruntime-genai` and build Java bindings:
+To run Generative AI models with ONNX runtime, make sure to have downloaded a native [`libonnxruntime`](https://github.com/microsoft/onnxruntime/release) and [`libonnxruntime-genai`](https://github.com/microsoft/onnxruntime-genai/releases).
+The compatible `libonnxruntime` library must be present in the same folder as `libonnxruntime-genai` library. 
 
-    ```bash
-    git clone https://github.com/microsoft/onnxruntime-genai.git
-    cd onnxruntime-genai
-    ./build.sh --build_java --config Release
-   ````
-    or
-   ```bash
-    ./build.sh
-    ```
 
-2. Set `ONNX_LIB_PATH` to the directory containing the built native library
+1. Set `ONNX_LIB_PATH` to the directory containing the built native libraries. The native library extension (`.dylib` or `.so` or `.dll`) is platform specific.
+
    (e.g. where `libonnxruntime-genai.so` or `.dylib` lives):
 
     ```bash
-    export ONNX_LIB_PATH=/.../onnxruntime-genai/build/macOS/RelWithDebInfo/
+    export ONNX_LIB_PATH=/path/.../onnxruntime-genai/lib/
     ```
 
-3. Set `ORT_GENAI_DIR` to your clone of `onnxruntime-genai` before running `compile.sh`:
+2. Set `ORT_GENAI_INCLUDE_DIR` to your clone of `onnxruntime-genai` before running `compile.sh`:
 
     ```bash
-    export ORT_GENAI_DIR=/path/.../onnxruntime-genai/
+    export ORT_GENAI_INCLUDE_DIR=/path/.../onnxruntime-genai/include
     ```
 
-4. Download or prepare a valid ONNX model:
+3. Download or prepare a valid ONNX model:
 
    ```bash
     git clone https://huggingface.co/microsoft/Phi-3-mini-4k-instruct-onnx
@@ -31,13 +24,13 @@
     export MODEL_PATH=/path/.../Phi-3-mini-4k-instruct-onnx/cpu_and_mobile/cpu-int4-rtn-block-32-acc-level-4/
     ```
 
-5. Run `compile.sh`:
+4. Run `compile.sh`:
 
     ```bash
     ./compile.sh
     ```
 
-6. Run the example:
+5. Run the example:
 
     ```bash
     sh ./run.sh

--- a/samples/onnx/compile.sh
+++ b/samples/onnx/compile.sh
@@ -1,6 +1,6 @@
 jextract \
   --target-package oracle.code.onnx.foreign \
   --output src \
-  "$ONNX_PATH/include/ort_genai_c.h"
+  "$ONNX_GENAI_HOME/include/ort_genai_c.h"
 
 javac --release 26 -d . src/oracle/code/onnx/foreign/*.java OnnxGenerator.java

--- a/samples/onnx/compile.sh
+++ b/samples/onnx/compile.sh
@@ -1,6 +1,6 @@
 jextract \
   --target-package oracle.code.onnx.foreign \
   --output src \
-  "$ORT_GENAI_INCLUDE_DIR/ort_genai_c.h"
+  "$ONNX_PATH/include/ort_genai_c.h"
 
 javac --release 26 -d . src/oracle/code/onnx/foreign/*.java OnnxGenerator.java

--- a/samples/onnx/compile.sh
+++ b/samples/onnx/compile.sh
@@ -1,6 +1,6 @@
 jextract \
   --target-package oracle.code.onnx.foreign \
   --output src \
-  "$ORT_GENAI_DIR/src/ort_genai_c.h"
+  "$ORT_GENAI_INCLUDE_DIR/ort_genai_c.h"
 
-javac --release 24 -d . src/oracle/code/onnx/foreign/*.java OnnxGenerator.java
+javac --release 26 -d . src/oracle/code/onnx/foreign/*.java OnnxGenerator.java

--- a/samples/onnx/run.sh
+++ b/samples/onnx/run.sh
@@ -1,5 +1,5 @@
 java \
   --enable-native-access=ALL-UNNAMED \
-  -Djava.library.path="$ONNX_LIB_PATH" \
+  -Djava.library.path="$ONNX_PATH/lib/" \
   OnnxGenerator \
   "$MODEL_PATH"

--- a/samples/onnx/run.sh
+++ b/samples/onnx/run.sh
@@ -1,5 +1,5 @@
 java \
   --enable-native-access=ALL-UNNAMED \
-  -Djava.library.path="$ONNX_PATH/lib/" \
+  -Djava.library.path="$ONNX_GENAI_HOME/lib" \
   OnnxGenerator \
   "$MODEL_PATH"


### PR DESCRIPTION
**1. Status Quo**
The current ONNX Gen AI example requires end users to manually build the native library. A lot of files are needed only to build the native runtime, but not serving a need later on.

**2. Problem**

The native build instructions are subject to change when comes to prerequisites and the build from latest sources can also come with unresolved issues on the native side.

**3. Fix**

This pull request introduces a few changes in the prerequisites:
 * Pre-download compatible releases of `onnxruntime` and `onnxruntime-genai` (the `onnxruntime-genai` is a wrapper over the native `onnxruntime`). Release archives have the structure: 
 ```text
 onnxruntime-genai-0.14.0-osx-arm64/
├── LICENSE
├── README.md
├── SECURITY.md
├── ThirdPartyNotices.txt
├── include
│   ├── ort_genai.h
│   └── ort_genai_c.h
└── lib
    └── libonnxruntime-genai.dylib
 ```

 ```text
onnxruntime-osx-arm64-1.26.0/
├── GIT_COMMIT_ID
├── LICENSE
├── Privacy.md
├── README.md
├── ThirdPartyNotices.txt
├── VERSION_NUMBER
├── include
│   ├── core
│   │   └── providers
│   │       ├── custom_op_context.h
│   │       └── resource.h
│   ├── coreml_provider_factory.h
│   ├── cpu_provider_factory.h
│   ├── onnxruntime_c_api.h
│   ├── onnxruntime_cxx_api.h
│   ├── onnxruntime_cxx_inline.h
│   ├── onnxruntime_env_config_keys.h
│   ├── onnxruntime_ep_c_api.h
│   ├── onnxruntime_ep_device_ep_metadata_keys.h
│   ├── onnxruntime_float16.h
│   ├── onnxruntime_lite_custom_op.h
│   ├── onnxruntime_run_options_config_keys.h
│   ├── onnxruntime_session_options_config_keys.h
│   ├── provider_options.h
│   └── webgpu_provider_factory.h
├── lib
│   ├── cmake
│   │   └── onnxruntime
│   │       ├── onnxruntimeConfig.cmake
│   │       ├── onnxruntimeConfigVersion.cmake
│   │       ├── onnxruntimeTargets-release.cmake
│   │       └── onnxruntimeTargets.cmake
│   ├── libonnxruntime.1.26.0.dylib
│   ├── libonnxruntime.1.26.0.dylib.dSYM
│   │   └── Contents
│   │       ├── Info.plist
│   │       └── Resources
│   │           ├── DWARF
│   │           │   └── libonnxruntime.1.26.0.dylib
│   │           └── Relocations
│   │               └── aarch64
│   │                   └── libonnxruntime.1.26.0.dylib.yml
│   ├── libonnxruntime.1.dylib -> libonnxruntime.1.26.0.dylib
│   ├── libonnxruntime.dylib
│   └── pkgconfig
│       └── libonnxruntime.pc
└── testdata
    └── libcustom_op_library.dylib
 ```
 * The user should set the ORT_LIB_PATH to `libonnxruntime<release>.dylib`. This variable was found here: https://ort.pyke.io/setup/linking.
 * Generate Java bindings for the downloaded `onnxruntime-genai` release using the 
 * Add a way to exit the from LLM conversation in `call` method.

I run tests through Github actions enabled in my fork.

- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Change must be properly reviewed (no review required)

### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/304/head:pull/304` \
`$ git checkout pull/304`

Update a local copy of the PR: \
`$ git checkout pull/304` \
`$ git pull https://git.openjdk.org/jextract.git pull/304/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 304`

View PR using the GUI difftool: \
`$ git pr show -t 304`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/304.diff">https://git.openjdk.org/jextract/pull/304.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/304#issuecomment-4751026699)
</details>
