### PR TITLE
Fix gh actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -135,7 +135,7 @@ jobs:
 
     - name: 'Check cache for LLVM'
       id: get-cached-llvm
-      uses: actions/cache@v4
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ${{ matrix.DEPS_ROOT }}/llvm/image
         key: llvm-${{ env.CLANG_LLVM_VERSION }}-${{ matrix.os }}
@@ -171,7 +171,7 @@ jobs:
         sh ./gradlew -Pjdk_home=${{ matrix.DEPS_ROOT }}/jdk-toolchain -Pllvm_home=${{ matrix.DEPS_ROOT }}/llvm/image clean verify
 
     - name: 'Get cached JTReg'
-      uses: actions/cache@v4
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ./deps/jtreg/build/images/jtreg
         enableCrossOsArchive: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,14 +21,14 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 1
-      - uses: gradle/actions/wrapper-validation@v6
+      - uses: gradle/actions/wrapper-validation@3f131e8634966bd73d06cc69884922b02e6faf92 # v6
 
   build-jtreg:
     runs-on: ubuntu-latest
     steps:
     - name: 'Check cache for JTReg'
       id: get-cached-jtreg
-      uses: actions/cache@v4
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ./deps/jtreg/build/images/jtreg
         key: jtreg-${{ env.JTREG_VERSION }}
@@ -81,14 +81,14 @@ jobs:
 
     - name: 'Check cache for toolchain JDK'
       id: get-cached-toolchain
-      uses: actions/cache@v4
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ${{ matrix.DEPS_ROOT }}/jdk-toolchain
         key: jdk-toolchain-${{ env.TOOLCHAIN_VERSION }}-${{ matrix.os }}
 
     - name: 'Download toolchain JDK'
       id: download-toolchain-jdk
-      uses: oracle-actions/setup-java@v1.5.0
+      uses: oracle-actions/setup-java@fff43251af9936a0e6a4d5d0946e14f1680e9b6b # v1.5.0
       if: ${{ steps.get-cached-toolchain.outputs.cache-hit != 'true' }}
       with:
         website: oracle.com
@@ -122,7 +122,7 @@ jobs:
         ${{ matrix.DEPS_ROOT }}/jdk-toolchain/bin/java --version
 
     - name: 'Setup Gradle Java'
-      uses: oracle-actions/setup-java@v1.5.0
+      uses: oracle-actions/setup-java@fff43251af9936a0e6a4d5d0946e14f1680e9b6b # v1.5.0
       with:
         website: oracle.com
         release: ${{ env.GRADLE_JAVA_VERSION }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 1
-      - uses: gradle/actions/wrapper-validation@v4
+      - uses: gradle/actions/wrapper-validation@v6
 
   build-jtreg:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
   validate-gradle-wrapper:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 1
       - uses: gradle/actions/wrapper-validation@v4
@@ -35,7 +35,7 @@ jobs:
 
     - name: 'Check out JTReg'
       if: ${{ steps.get-cached-jtreg.outputs.cache-hit != 'true' }}
-      uses: actions/checkout@v4.1.1
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         repository: 'openjdk/jtreg'
         ref: 'jtreg-${{ env.JTREG_VERSION }}'
@@ -70,7 +70,7 @@ jobs:
 
     steps:
     - name: 'Check out repository'
-      uses: actions/checkout@v4.1.1
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         fetch-depth: 1
 
@@ -88,10 +88,10 @@ jobs:
 
     - name: 'Download toolchain JDK'
       id: download-toolchain-jdk
-      uses: oracle-actions/setup-java@v1.3.4
+      uses: oracle-actions/setup-java@v1.5.0
       if: ${{ steps.get-cached-toolchain.outputs.cache-hit != 'true' }}
       with:
-        website: jdk.java.net
+        website: oracle.com
         release: ${{ env.TOOLCHAIN_VERSION }}
         install: false
 
@@ -122,8 +122,9 @@ jobs:
         ${{ matrix.DEPS_ROOT }}/jdk-toolchain/bin/java --version
 
     - name: 'Setup Gradle Java'
-      uses: oracle-actions/setup-java@v1.3.4
+      uses: oracle-actions/setup-java@v1.5.0
       with:
+        website: oracle.com
         release: ${{ env.GRADLE_JAVA_VERSION }}
 
     - name: 'Check default Java version'


### PR DESCRIPTION
**1. Status Quo**

The current workflow from `test.yml` cannot obtain a JDK version because that version is no longer available on [jdk.java.net](https://jdk.java.net). Also, some workflow versions are outdated and warnings get raised when the CI pipeline runs them.

**2. Problem**

The current workflow from `test.yml` fails locally and whenever raising a PR. (see #304).

**3. Fix**

This PR consists of :
* Adds `oracle.com` as website value for the workflow in order to download the requested JDK version. 
* Upgrades versions of GH actions to the newest available.

These changes ran successfully here https://github.com/ammbra/jextract/actions/runs/27826134565 and show no warning.

- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Change must be properly reviewed (no review required)

### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/305/head:pull/305` \
`$ git checkout pull/305`

Update a local copy of the PR: \
`$ git checkout pull/305` \
`$ git pull https://git.openjdk.org/jextract.git pull/305/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 305`

View PR using the GUI difftool: \
`$ git pr show -t 305`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/305.diff">https://git.openjdk.org/jextract/pull/305.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/305#issuecomment-4752062943)
</details>
