### PR TITLE
Address comments about instructions clarity and fix variable name typo.

### DIFF
--- a/samples/onnx/OnnxGenerator.java
+++ b/samples/onnx/OnnxGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, 2026, Oracle and/or its affiliates. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/samples/onnx/README.md
+++ b/samples/onnx/README.md
@@ -1,7 +1,7 @@
 To run Generative AI models with ONNX runtime, make sure to have downloaded a native [`libonnxruntime`](https://github.com/microsoft/onnxruntime/release) and [`libonnxruntime-genai`](https://github.com/microsoft/onnxruntime-genai/releases).
 Each release is distributed as an archive, so extract their contents.
 
-1. The [`libonnxruntime-genai`](https://github.com/microsoft/onnxruntime-genai/releases) binary needs the one from [`libonnxruntime`](https://github.com/microsoft/onnxruntime/release), so you have to set `ORT_LIB_PATH` to the `libonnxruntime` library file inside the downloaded [`libonnxruntime`](https://github.com/microsoft/onnxruntime/release), then the ONNX_GENAI_HOME to [`libonnxruntime-genai`](https://github.com/microsoft/onnxruntime-genai/releases) folder. 
+1. The [`libonnxruntime-genai`](https://github.com/microsoft/onnxruntime-genai/releases) library needs the one from [`libonnxruntime`](https://github.com/microsoft/onnxruntime/release), so you have to set `ORT_LIB_PATH` to the `libonnxruntime` library file inside the downloaded [`libonnxruntime`](https://github.com/microsoft/onnxruntime/release), then the ONNX_GENAI_HOME to [`libonnxruntime-genai`](https://github.com/microsoft/onnxruntime-genai/releases) folder. 
 The native library extension (`.dylib` or `.so` or `.dll`) is platform specific.
 
     ```bash

--- a/samples/onnx/README.md
+++ b/samples/onnx/README.md
@@ -1,6 +1,7 @@
 To run Generative AI models with ONNX runtime, make sure to have downloaded a native [`libonnxruntime`](https://github.com/microsoft/onnxruntime/release) and [`libonnxruntime-genai`](https://github.com/microsoft/onnxruntime-genai/releases).
+Each release is distributed as an archive, so extract their contents.
 
-1. The [`libonnxruntime-genai`](https://github.com/microsoft/onnxruntime-genai/releases) binary needs the statically built binaries from [`libonnxruntime`](https://github.com/microsoft/onnxruntime/release), so you have to set `ORT_LIB_PATH` to the directory containing the downloaded [`libonnxruntime`](https://github.com/microsoft/onnxruntime/release), then the ONNX_GEN_AI_HOME to [`libonnxruntime-genai`](https://github.com/microsoft/onnxruntime-genai/releases). 
+1. The [`libonnxruntime-genai`](https://github.com/microsoft/onnxruntime-genai/releases) binary needs the one from [`libonnxruntime`](https://github.com/microsoft/onnxruntime/release), so you have to set `ORT_LIB_PATH` to the `libonnxruntime` library file inside the downloaded [`libonnxruntime`](https://github.com/microsoft/onnxruntime/release), then the ONNX_GENAI_HOME to [`libonnxruntime-genai`](https://github.com/microsoft/onnxruntime-genai/releases) folder. 
 The native library extension (`.dylib` or `.so` or `.dll`) is platform specific.
 
     ```bash


### PR DESCRIPTION
This PR addresses @nizarbenalla comments from #304, already integrated.

- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Change must be properly reviewed (no review required)

### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**) ⚠️ Review applies to [3964f756](https://git.openjdk.org/jextract/pull/306/files/3964f756bacf0c5aa8aeb292b50dd1cc04d9e51e)
 * [Nizar Benalla](https://openjdk.org/census#nbenalla) (@nizarbenalla - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/306/head:pull/306` \
`$ git checkout pull/306`

Update a local copy of the PR: \
`$ git checkout pull/306` \
`$ git pull https://git.openjdk.org/jextract.git pull/306/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 306`

View PR using the GUI difftool: \
`$ git pr show -t 306`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/306.diff">https://git.openjdk.org/jextract/pull/306.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/306#issuecomment-4874639249)
</details>
