### PR TITLE
Normalize path output for --dump-includes

### DIFF
--- a/src/main/java/org/openjdk/jextract/impl/IncludeHelper.java
+++ b/src/main/java/org/openjdk/jextract/impl/IncludeHelper.java
@@ -134,7 +134,7 @@ public class IncludeHelper {
     public void dumpIncludes() {
         try (var writer = Files.newBufferedWriter(Path.of(dumpIncludesFile), StandardOpenOption.CREATE)) {
             Map<Path, Set<Declaration>> declsByPath = usedDeclarations.stream()
-                    .collect(Collectors.groupingBy(d -> d.pos().path(),
+                    .collect(Collectors.groupingBy(d -> d.pos().path().normalize(),
                             () -> new TreeMap<>(Path::compareTo),
                             Collectors.toCollection(() -> new TreeSet<>(Comparator.comparing(Declaration::name)))));
             String lineSep = "";

--- a/test/testng/org/openjdk/jextract/test/toolprovider/dumpIncludes/TestNormalizedPathOutput.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/dumpIncludes/TestNormalizedPathOutput.java
@@ -1,0 +1,34 @@
+package org.openjdk.jextract.test.toolprovider.dumpIncludes;
+
+import testlib.TestUtils;
+import org.testng.annotations.Test;
+import testlib.JextractToolRunner;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.testng.Assert.*;
+
+public class TestNormalizedPathOutput extends JextractToolRunner {
+    @Test
+    public void testNormalizedPathOutput() throws IOException {
+        Path filterOutput = getOutputFilePath("TestNormalizedPathOutput_output");
+        try {
+            Files.createDirectory(filterOutput);
+            Path includes = filterOutput.resolve("test.conf");
+            Path filterH = getInputFilePath("test.h");
+            runNoOuput("--dump-includes", includes.toString(), filterH.toString()).checkSuccess();
+            List<String> includeLines = Files.readAllLines(includes);
+            List<String> heading = includeLines.stream().filter(line -> line.startsWith("#### Extracted from")).toList();
+            assertEquals(heading.size(), 1);
+            assertTrue(heading.getFirst().endsWith("/dumpIncludes/header.h"));
+            List<String> filter = includeLines.stream().filter(line -> line.startsWith("--include-constant")).toList();
+            assertEquals(filter.size(), 1);
+            assertTrue(filter.getFirst().endsWith("/dumpIncludes/header.h"));
+        } finally {
+            TestUtils.deleteDir(filterOutput);
+        }
+    }
+}

--- a/test/testng/org/openjdk/jextract/test/toolprovider/dumpIncludes/TestNormalizedPathOutput.java
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/dumpIncludes/TestNormalizedPathOutput.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
 package org.openjdk.jextract.test.toolprovider.dumpIncludes;
 
 import testlib.TestUtils;

--- a/test/testng/org/openjdk/jextract/test/toolprovider/dumpIncludes/dir/dir.h
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/dumpIncludes/dir/dir.h
@@ -1,0 +1,1 @@
+#include "../header.h"

--- a/test/testng/org/openjdk/jextract/test/toolprovider/dumpIncludes/dir/dir.h
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/dumpIncludes/dir/dir.h
@@ -1,1 +1,24 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
 #include "../header.h"

--- a/test/testng/org/openjdk/jextract/test/toolprovider/dumpIncludes/header.h
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/dumpIncludes/header.h
@@ -1,1 +1,24 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
 #define CONSTANT 1

--- a/test/testng/org/openjdk/jextract/test/toolprovider/dumpIncludes/header.h
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/dumpIncludes/header.h
@@ -1,0 +1,1 @@
+#define CONSTANT 1

--- a/test/testng/org/openjdk/jextract/test/toolprovider/dumpIncludes/test.h
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/dumpIncludes/test.h
@@ -1,1 +1,24 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
 #include "dir/dir.h"

--- a/test/testng/org/openjdk/jextract/test/toolprovider/dumpIncludes/test.h
+++ b/test/testng/org/openjdk/jextract/test/toolprovider/dumpIncludes/test.h
@@ -1,0 +1,1 @@
+#include "dir/dir.h"


### PR DESCRIPTION
This PR normalizes the path output for `--dump-includes`.

1. Currently, when using jextract with multiple header files, the path outputs for `--dump-includes` may not be normalized. For example, the output could be:
   ```
   #### Extracted from: [...]/mylib/dir/../header.h

   --include-constant CONSTANT # header: [...]/mylib/dir/../header.h
   ```
2. This is problematic because one may wish to use tools like `grep` to filter based on known paths to header files.
3. To resolve this, I simply added a `normalize()` call in `IncludeHelper.java`.

I didn't test the PR locally using jtreg, but the [tests on GitHub Actions](https://github.com/xpple/jextract/actions/runs/30163537940) ran successfully. I did also confirm that the new output correctly normalizes each path:

```
#### Extracted from: [...]/mylib/header.h

--include-constant CONSTANT # header: [...]/mylib/header.h
```

- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Change must be properly reviewed (no review required)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jextract.git pull/307/head:pull/307` \
`$ git checkout pull/307`

Update a local copy of the PR: \
`$ git checkout pull/307` \
`$ git pull https://git.openjdk.org/jextract.git pull/307/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 307`

View PR using the GUI difftool: \
`$ git pr show -t 307`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jextract/pull/307.diff">https://git.openjdk.org/jextract/pull/307.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jextract/pull/307#issuecomment-5122523213)
</details>
